### PR TITLE
Add okcomputer for initial status check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'bootsnap', require: false
 # Additional gems
 gem 'config'
 gem 'honeybadger'
+gem 'okcomputer'
 gem 'view_component'
 
 # DLSS/domain-specific dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,11 +141,7 @@ GEM
       super_diff
       thor
       zeitwerk (~> 2.1)
-    commonmarker (1.1.5)
-      rb_sys (~> 0.9)
-    commonmarker (1.1.5-aarch64-linux)
     commonmarker (1.1.5-arm64-darwin)
-    commonmarker (1.1.5-x86_64-darwin)
     commonmarker (1.1.5-x86_64-linux)
     concurrent-ruby (1.3.4)
     config (5.5.2)
@@ -242,10 +238,6 @@ GEM
       net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)
-    ffi (1.17.0-aarch64-linux-gnu)
-    ffi (1.17.0-aarch64-linux-musl)
-    ffi (1.17.0-arm-linux-gnu)
-    ffi (1.17.0-arm-linux-musl)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     fugit (1.11.1)
@@ -314,6 +306,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    okcomputer (1.18.5)
     openapi3_parser (0.10.0)
       commonmarker (>= 1.0)
     openapi_parser (1.0.0)
@@ -381,7 +374,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rb_sys (0.9.102)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -516,7 +508,7 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
-  arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
@@ -538,6 +530,7 @@ DEPENDENCIES
   honeybadger
   importmap-rails
   jbuilder
+  okcomputer
   overmind
   pg
   propshaft


### PR DESCRIPTION
This add the `/status` and `/status/all` paths that we use in most projects. Currently this only checks the application database, a follow up PR will add checks for the `solid_*` db checks.