### PR TITLE
Add solargraph & -rails to development deps for Ruby IDE purposes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,8 @@ end
 
 group :development do
   gem 'overmind'
+  gem 'solargraph' # For Ruby IDE purposes
+  gem 'solargraph-rails'
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     attr_extras (7.1.0)
+    backport (1.2.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
@@ -213,6 +214,7 @@ GEM
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
+    e2mmap (0.1.0)
     ed25519 (1.3.0)
     edtf (0.0.3)
     equivalent-xml (0.6.0)
@@ -261,12 +263,17 @@ GEM
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jaro_winkler (1.6.0)
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.8.2)
     jsonpath (1.1.5)
       multi_json
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -376,11 +383,14 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rbs (2.8.4)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
     reline (0.5.11)
       io-console (~> 0.5)
+    reverse_markdown (2.1.1)
+      nokogiri
     rexml (3.3.9)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
@@ -447,6 +457,25 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
+    solargraph (0.50.0)
+      backport (~> 1.2)
+      benchmark
+      bundler (~> 2.0)
+      diff-lcs (~> 1.4)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      parser (~> 3.0)
+      rbs (~> 2.0)
+      reverse_markdown (~> 2.0)
+      rubocop (~> 1.38)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
+    solargraph-rails (1.1.0)
+      activesupport
+      solargraph
     solid_cable (3.0.2)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -477,6 +506,7 @@ GEM
       diff-lcs
       patience_diff
     thor (1.3.2)
+    tilt (2.4.0)
     timeout (0.4.2)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
@@ -508,6 +538,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.37)
     zeitwerk (2.7.1)
 
 PLATFORMS
@@ -552,6 +583,8 @@ DEPENDENCIES
   rubocop-rspec_rails
   selenium-webdriver
   simplecov
+  solargraph
+  solargraph-rails
   solid_cable
   solid_cache
   solid_queue


### PR DESCRIPTION
Maybe it only affects / helps emacs/vim users, but hopefully it is not in the way for anyone else.
