### PR TITLE
[DRAFT] Setup the collection machinery for depositing and managing collections

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -31,7 +31,6 @@ class CollectionsController < ApplicationController
     render :form
   end
 
-  # # rubocop:disable Metrics/AbcSize
   def create
     # TODO: Verify any user should be able to create a collection.
     skip_verify_authorized!
@@ -41,14 +40,15 @@ class CollectionsController < ApplicationController
     if @collection_form.valid?(deposit: deposit?)
       # Setting the deposit_job_started_at to the current time to indicate that the deposit job has started and user
       # should be "waiting".
-      collection = Collection.create!(title: @collection_form.title, user: current_user, deposit_job_started_at: Time.zone.now)
+      collection = Collection.create!(title: @collection_form.title,
+                                      user: current_user,
+                                      deposit_job_started_at: Time.zone.now)
       DepositCollectionJob.perform_later(collection:, collection_form: @collection_form, deposit: deposit?)
       redirect_to wait_collections_path(collection.id)
     else
       render :form, status: :unprocessable_entity
     end
   end
-  # # rubocop:enable Metrics/AbcSize
 
   def update
     authorize! @collection
@@ -100,6 +100,7 @@ class CollectionsController < ApplicationController
   def editable?
     return false unless @status.open? || @status.openable?
 
-    ToCollectionForm::RoundtripValidator.roundtrippable?(collection_form: @collection_form, cocina_object: @cocina_object)
+    ToCollectionForm::RoundtripValidator.roundtrippable?(collection_form: @collection_form,
+                                                         cocina_object: @cocina_object)
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# Controller for a Collection
+class CollectionsController < ApplicationController
+  before_action :set_collection, only: %i[show edit update]
+  before_action :check_deposit_job_started, only: %i[show edit]
+  before_action :set_collection_form_from_cocina, only: %i[show edit]
+  before_action :set_status, only: %i[show edit]
+
+  def show
+    authorize! @collection
+    @status_presenter = StatusPresenter.new(status: @status)
+  end
+
+  def new
+    # TODO: Verify any user should be able to create a collection.
+    skip_verify_authorized!
+
+    @collection_form = CollectionForm.new
+
+    render :form
+  end
+
+  def edit
+    authorize! @collection
+
+    unless editable?
+      flash[:danger] = I18n.t('works.edit.errors.cannot_be_edited')
+      return redirect_to work_path(druid: params[:druid])
+    end
+    render :form
+  end
+
+  # # rubocop:disable Metrics/AbcSize
+  def create
+    # TODO: Verify any user should be able to create a collection.
+    skip_verify_authorized!
+
+    @collection_form = CollectionForm.new(collection_params)
+    # The deposit param determines whether extra validations for deposits are applied.
+    if @collection_form.valid?(deposit: deposit?)
+      # Setting the deposit_job_started_at to the current time to indicate that the deposit job has started and user
+      # should be "waiting".
+      collection = Collection.create!(title: @collection_form.title, user: current_user, deposit_job_started_at: Time.zone.now)
+      DepositCollectionJob.perform_later(collection:, collection_form: @collection_form, deposit: deposit?)
+      redirect_to wait_collections_path(collection.id)
+    else
+      render :form, status: :unprocessable_entity
+    end
+  end
+  # # rubocop:enable Metrics/AbcSize
+
+  def update
+    authorize! @collection
+
+    @collection_form = CollectionForm.new(collection_params.merge(druid: params[:druid]))
+    # The deposit param determines whether extra validations for deposits are applied.
+    if @collection_form.valid?(deposit: deposit?)
+      DepositCollectionJob.perform_later(collection: @collection, collection_form: @collection_form, deposit: deposit?)
+      redirect_to wait_collections_path(@collection.id)
+    else
+      render :form, status: :unprocessable_entity
+    end
+  end
+
+  def wait
+    collection = Collection.find(params[:id])
+    authorize! collection
+
+    redirect_to collection_path(druid: collection.druid) if collection.deposit_job_finished?
+  end
+
+  private
+
+  def collection_params
+    params.expect(collection: CollectionForm.user_editable_attributes + [CollectionForm.nested_attributes_hash])
+  end
+
+  def deposit?
+    params[:commit] == 'Deposit'
+  end
+
+  def set_collection
+    @collection = Collection.find_by!(druid: params[:druid])
+  end
+
+  def check_deposit_job_started
+    redirect_to wait_collections_path(@collection.id) if @collection.deposit_job_started?
+  end
+
+  def set_collection_form_from_cocina
+    @cocina_object = Sdr::Repository.find(druid: params[:druid])
+    @collection_form = ToCollectionForm::Mapper.call(cocina_object: @cocina_object)
+  end
+
+  def set_status
+    @status = Sdr::Repository.status(druid: params[:druid])
+  end
+
+  def editable?
+    return false unless @status.open? || @status.openable?
+
+    ToCollectionForm::RoundtripValidator.roundtrippable?(collection_form: @collection_form, cocina_object: @cocina_object)
+  end
+end

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Form for a Collection
+class CollectionForm < ApplicationForm
+  accepts_nested_attributes_for :related_links
+
+  def self.immutable_attributes
+    ['druid']
+  end
+
+  attribute :druid, :string
+  alias id druid
+
+  def persisted?
+    druid.present?
+  end
+
+  attribute :lock, :string
+
+  attribute :version, :integer, default: 1
+
+  attribute :title, :string
+  validates :title, presence: true
+
+  attribute :abstract, :string
+  validates :abstract, presence: true, if: :deposit?
+end

--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Performs a deposit (without SDR API).
+class DepositCollectionJob < ApplicationJob
+  # @param [CollectionForm] collection_form
+  # @param [Collection] collection
+  # @param [Boolean] deposit if true, deposit the collection; otherwise, leave as draft
+  def perform(collection_form:, collection:, deposit:)
+    cocina_object = ToCocina::CollectionMapper.call(collection_form:, source_id: "h3:collection-#{collection.id}")
+    new_cocina_object = if collection_form.persisted?
+                          Sdr::Repository.open_if_needed(cocina_object:)
+                                         .then { |cocina_object| Sdr::Repository.update(cocina_object:) }
+                        else
+                          Sdr::Repository.register(cocina_object:)
+                        end
+    druid = new_cocina_object.externalIdentifier
+    Sdr::Repository.accession(druid:) if deposit
+
+    # Refresh the wait page. Since the deposit job is finished, this will redirect to the show page.
+    collection.update!(deposit_job_started_at: nil, druid:)
+    # Just to be aware for future troubleshooting: There is a possible race condition between the websocket
+    # connecting and the following broadcast being sent.
+    sleep 0.5 if Rails.env.test? # Avoids race condition in tests
+    Turbo::StreamsChannel.broadcast_refresh_to 'wait', collection.id
+  end
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,4 +5,14 @@
 class Collection < ApplicationRecord
   belongs_to :user
   has_many :works, dependent: :destroy
+
+  # deposit_job_started_at indicates that the job is queued or running.
+  # User should be "waiting" until the job is completed.
+  def deposit_job_started?
+    deposit_job_started_at.present?
+  end
+
+  def deposit_job_finished?
+    deposit_job_started_at.nil?
+  end
 end

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CollectionPolicy < ApplicationPolicy
+  alias_rule :show?, :update?, :edit?, :wait?, to: :manage?
+
+  def manage?
+    record.user_id == user.id
+  end
+end

--- a/app/serializers/collection_form_serializer.rb
+++ b/app/serializers/collection_form_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Serializer for CollectionForm
+class CollectionFormSerializer < ActiveJob::Serializers::ObjectSerializer
+  # Checks if an argument should be serialized by this serializer.
+  def serialize?(argument)
+    argument.is_a?(CollectionForm)
+  end
+
+  def serialize(model)
+    super(model.serializable_hash(include: model.class.nested_attributes_hash))
+  end
+
+  def deserialize(hash)
+    CollectionForm.new(hash.except('_aj_serialized'))
+  end
+end

--- a/app/services/to_cocina/collection_mapper.rb
+++ b/app/services/to_cocina/collection_mapper.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module ToCocina
+  # Maps CollectionForm to Cocina Collection
+  class CollectionMapper
+    def self.call(...)
+      new(...).call
+    end
+
+    # @param [CollectionForm] collection_form
+    # @param [source_id] source_id
+    def initialize(collection_form:, source_id:)
+      @collection_form = collection_form
+      @content = content
+      @source_id = source_id
+    end
+
+    # @return [Cocina::Models::Collection]
+    def call
+      if collection_form.persisted?
+        Cocina::Models.with_metadata(Cocina::Models.build(params), collection_form.lock)
+      else
+        Cocina::Models.build_request(params)
+      end
+    end
+
+    private
+
+    attr_reader :collection_form, :source_id, :content
+
+    def params
+      {
+        externalIdentifier: collection_form.druid,
+        type: Cocina::Models::ObjectType.collection,
+        label: collection_form.title,
+        description: ToCocina::DescriptionMapper.call(form: collection_form),
+        version: collection_form.version,
+        access: { view: 'world' },
+        identification: { sourceId: source_id },
+        administrative: { hasAdminPolicy: Settings.apo }
+      }.compact
+    end
+  end
+end

--- a/app/services/to_cocina/description_mapper.rb
+++ b/app/services/to_cocina/description_mapper.rb
@@ -7,14 +7,14 @@ module ToCocina
       new(...).call
     end
 
-    # @param [WorkForm] work_form
-    def initialize(work_form:)
-      @work_form = work_form
+    # @param [WorkForm] form
+    def initialize(form:)
+      @form = form
     end
 
     # @return [Cocina::Models::Description, Cocina::Models::RequestDescription]
     def call
-      if work_form.persisted?
+      if form.persisted?
         Cocina::Models::Description.new(params)
       else
         Cocina::Models::RequestDescription.new(params)
@@ -23,21 +23,21 @@ module ToCocina
 
     private
 
-    attr_reader :work_form
+    attr_reader :form
 
     def params
       {
-        title: CocinaDescriptionSupport.title(title: work_form.title),
+        title: CocinaDescriptionSupport.title(title: form.title),
         # contributor: contributors_params.presence,
         note: note_params,
         # subject: subject_params.presence,
-        purl: Sdr::Purl.from_druid(druid: work_form.druid),
-        relatedResource: CocinaDescriptionSupport.related_links(related_links: work_form.related_links)
+        purl: Sdr::Purl.from_druid(druid: form.druid),
+        relatedResource: CocinaDescriptionSupport.related_links(related_links: form.related_links)
       }.compact
     end
 
     # def contributors_params
-    #   work_form.authors.map do |contributor|
+    #   form.authors.map do |contributor|
     #     CocinaDescriptionSupport.person_contributor(
     #       forename: contributor.first_name,
     #       surname: contributor.last_name
@@ -47,9 +47,9 @@ module ToCocina
 
     def note_params
       [].tap do |params|
-        if work_form.abstract.present?
+        if form.abstract.present?
           params << CocinaDescriptionSupport.note(type: 'abstract',
-                                                  value: work_form.abstract)
+                                                  value: form.abstract)
         end
       end.presence
     end

--- a/app/services/to_cocina/mapper.rb
+++ b/app/services/to_cocina/mapper.rb
@@ -33,7 +33,7 @@ module ToCocina
         externalIdentifier: work_form.druid,
         type: Cocina::Models::ObjectType.object,
         label: work_form.title,
-        description: ToCocina::DescriptionMapper.call(work_form:),
+        description: ToCocina::DescriptionMapper.call(form: work_form),
         version: work_form.version,
         access: { view: 'world', download: 'world' },
         identification: { sourceId: source_id },

--- a/app/services/to_collection_form/mapper.rb
+++ b/app/services/to_collection_form/mapper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ToCollectionForm
+  # Maps Cocina Collection to CollectionForm
+  class Mapper
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(cocina_object:)
+      @cocina_object = cocina_object
+    end
+
+    def call
+      CollectionForm.new(params)
+    end
+
+    private
+
+    attr_reader :cocina_object
+
+    def params
+      {
+        druid: cocina_object.externalIdentifier,
+        lock: cocina_object.lock,
+        title: CocinaSupport.title_for(cocina_object:),
+        abstract:,
+        related_links: CocinaSupport.related_links_for(cocina_object:),
+        version: cocina_object.version
+      }
+    end
+
+    def abstract
+      cocina_object.description.note.find { |note| note.type == 'abstract' }&.value
+    end
+  end
+end

--- a/app/services/to_collection_form/roundtrip_validator.rb
+++ b/app/services/to_collection_form/roundtrip_validator.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module ToCollectionForm
+  # Validates that a cocina object can be converted to a work form and then back without loss.
+  class RoundtripValidator
+    def self.roundtrippable?(...)
+      new(...).call
+    end
+
+    # @param [CollectionForm] collection_form
+    # @param [Cocina::Models::Collection] cocina_object
+    def initialize(collection_form:, cocina_object:)
+      @collection_form = collection_form
+      @original_cocina_object = cocina_object
+    end
+
+    # @return [Boolean] true if the collection form can be converted to a cocina object and back without loss
+    def call
+      if roundtripped_cocina_object == normalized_original_cocina_object
+        true
+      else
+        pretty_original = CocinaSupport.pretty(cocina_object: normalized_original_cocina_object)
+        pretty_roundtripped = CocinaSupport.pretty(cocina_object: roundtripped_cocina_object)
+        Honeybadger.notify('Roundtrip failed',
+                           context: { original: pretty_original, roundtripped: pretty_roundtripped })
+        Rails.logger.info("Roundtrip failed. Original: #{pretty_original}")
+        Rails.logger.info("Roundtripped: #{pretty_roundtripped}")
+        false
+      end
+    end
+
+    private
+
+    attr_reader :collection_form, :content
+
+    def roundtripped_cocina_object
+      ToCocina::CollectionMapper.call(collection_form:,
+                                      source_id: normalized_original_cocina_object.identification&.sourceId)
+    end
+
+    def normalized_original_cocina_object
+      @normalized_original_cocina_object ||= begin
+        # Remove created_at and updated_at from the original cocina object
+        lock = @original_cocina_object&.lock
+        original_cocina_object_without_metadata = Cocina::Models.without_metadata(@original_cocina_object)
+        Cocina::Models.with_metadata(original_cocina_object_without_metadata, lock)
+      end
+    end
+  end
+end

--- a/app/views/collections/form.html.erb
+++ b/app/views/collections/form.html.erb
@@ -1,0 +1,32 @@
+  <%= render Elements::HeaderComponent.new(level: :h1, variant: :h2, text: @collection_form.title || 'Untitled deposit', classes: 'mb-3') %>
+  <%= render Elements::AlertComponent.new(variant: :danger, value: I18n.t('works.edit.errors.validation')) if @collection_form.errors.present? %>
+  <div class="d-flex tabbable-panes" data-controller="tab-error">
+    <div class="nav nav-pills flex-column px-2 py-1 me-5 col-3" role="tablist" aria-orientation="vertical">
+      <%= render Works::Edit::TabComponent.new(label: I18n.t('works.edit.panes.title.tab_label'), tab_name: :title, selected: true) %>
+      <%= render Works::Edit::TabComponent.new(label: I18n.t('works.edit.panes.abstract.tab_label'), tab_name: :abstract) %>
+      <%= render Works::Edit::TabComponent.new(label: I18n.t('works.edit.panes.related_content.tab_label'), tab_name: :related_content) %>
+      <%= render Works::Edit::TabComponent.new(label: I18n.t('works.edit.panes.deposit.tab_label'), tab_name: :deposit) %>
+    </div>
+    <%= form_with model: @collection_form, class: 'w-100' do |form| %>
+      <%= form.hidden_field :lock %>
+      <%= form.hidden_field :version %>
+      <div class="tab-content h-100">
+        <%= render Works::Edit::PaneComponent.new(tab_name: :title, label: I18n.t('works.edit.panes.title.label'), form:, selected: true) do %>
+          <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :title, required: true, label: I18n.t('works.edit.fields.title.label'),
+                                                             help_text: I18n.t('works.edit.fields.title.help_text')) %>
+        <% end %>
+        <%= render Works::Edit::PaneComponent.new(tab_name: :abstract, label: I18n.t('works.edit.panes.abstract.label'), form:) do %>
+          <p><%= t('works.edit.fields.abstract.help_text') %></p>
+          <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :abstract, label: I18n.t('works.edit.fields.abstract.label')) %>
+        <% end %>
+        <%= render Works::Edit::PaneComponent.new(tab_name: :related_content, label: I18n.t('works.edit.panes.related_content.label'), form:) do %>
+          <%= render Elements::Forms::NestedComponent.new(form:, model_class: RelatedLinkForm, field_name: :related_links, form_component: RelatedLinks::EditComponent) %>
+        <% end %>
+        <%= render Works::Edit::PaneComponent.new(tab_name: :deposit, form:, label: I18n.t('works.edit.panes.deposit.label'), render_footer: false) do %>
+          <p><%= t('works.edit.panes.deposit.help_text') %></p>
+          <%= link_to 'Cancel', works_path %>
+          <%= render Elements::Forms::SubmitComponent.new(form:, label: 'Deposit', classes: 'mt-2 ms-2') %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,0 +1,9 @@
+<%= render Elements::HeaderComponent.new(level: :h1, text: @collection_form.title, classes: 'mb-4 d-inline-block') %>
+<span class="ms-4 fst-italic status"><%= @status_presenter.status_message %></span>
+<%= render Elements::ButtonLinkComponent.new(link: edit_collection_path(@collection_form.druid), label: 'Edit or deposit', classes: 'float-end', variant: :'outline-primary') if @status_presenter.editable? %>
+<%= render Elements::Tables::TableComponent.new(id: 'title-table', classes: 'table-collection mb-5', label: 'Title') do |component| %>
+  <% component.with_row(label: 'Title', values: [@collection_form.title]) %>
+<% end %>
+<%= render Elements::Tables::TableComponent.new(id: 'description-table', classes: 'table-collection mb-5', label: 'Description') do |component| %>
+  <% component.with_row(label: 'Abstract', values: [@collection_form.abstract]) %>
+<% end %>

--- a/app/views/collections/wait.html.erb
+++ b/app/views/collections/wait.html.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream_from 'wait', params[:id] %>
+<%= render Elements::SpinnerComponent.new(message: 'Processing...', variant: :info, classes: 'my-2') %>

--- a/config/initializers/custom_serializers.rb
+++ b/config/initializers/custom_serializers.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 Rails.application.config.active_job.custom_serializers << WorkFormSerializer
+Rails.application.config.active_job.custom_serializers << CollectionFormSerializer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,5 +21,12 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :collections, only: [:new, :create, :show, :edit, :update], param: :druid do
+    resources :works, only: [:index]
+    collection do
+      get 'wait/:id', to: 'collections#wait', as: 'wait'
+    end
+  end
+
   root to: 'dashboard#show'
 end

--- a/db/migrate/20241121040349_add_deposit_job_started_to_collections.rb
+++ b/db/migrate/20241121040349_add_deposit_job_started_to_collections.rb
@@ -1,0 +1,6 @@
+class AddDepositJobStartedToCollections < ActiveRecord::Migration[8.0]
+  def change
+    add_column :collections, :deposit_job_started_at, :datetime
+    change_column_null :collections, :druid, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -31,11 +31,12 @@ CREATE TABLE public.ar_internal_metadata (
 
 CREATE TABLE public.collections (
     id bigint NOT NULL,
-    druid character varying NOT NULL,
+    druid character varying,
     title character varying NOT NULL,
     user_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    deposit_job_started_at timestamp(6) without time zone
 );
 
 
@@ -269,6 +270,7 @@ ALTER TABLE ONLY public.collections
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241121040349'),
 ('20241115001146'),
 ('20241115001126'),
 ('20241111223829'),

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     sequence(:title) { |n| "Collection #{n}" }
     druid { 'druid:cc234dd5678' }
     user
+
+    trait :deposit_job_started do
+      deposit_job_started_at { Time.zone.now }
+    end
   end
 end

--- a/spec/jobs/deposit_collection_job_spec.rb
+++ b/spec/jobs/deposit_collection_job_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DepositCollectionJob do
+  let(:druid) { 'druid:cc234dd5678' }
+  let(:cocina_object) { instance_double(Cocina::Models::CollectionWithMetadata, externalIdentifier: druid) }
+
+  before do
+    allow(ToCocina::CollectionMapper).to receive(:call).and_call_original
+    allow(Sdr::Repository).to receive(:accession)
+    allow(Turbo::StreamsChannel).to receive(:broadcast_refresh_to)
+  end
+
+  context 'when a new collection' do
+    let(:collection_form) { CollectionForm.new(title: collection.title) }
+    let(:collection) { create(:collection, :deposit_job_started) }
+
+    before do
+      allow(Sdr::Repository).to receive(:register).and_return(cocina_object)
+    end
+
+    it 'registers a new work' do
+      described_class.perform_now(collection_form:, collection:, deposit: true)
+      expect(ToCocina::CollectionMapper).to have_received(:call).with(collection_form: collection_form,
+                                                                      source_id: "h3:collection-#{collection.id}")
+      expect(Sdr::Repository).to have_received(:register)
+        .with(cocina_object: an_instance_of(Cocina::Models::RequestCollection))
+      expect(Sdr::Repository).to have_received(:accession).with(druid:)
+
+      expect(collection.reload.deposit_job_finished?).to be true
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_refresh_to).with('wait', collection.id)
+    end
+  end
+
+  context 'when an existing collection' do
+    let(:collection_form) { CollectionForm.new(title: collection.title, druid:, lock: 'abc123') }
+    let(:collection) { create(:collection, :deposit_job_started, druid:) }
+
+    before do
+      allow(Sdr::Repository).to receive_messages(open_if_needed: cocina_object, update: cocina_object)
+    end
+
+    it 'updates an existing collection' do
+      described_class.perform_now(collection_form: collection_form, collection: collection, deposit: false)
+      expect(ToCocina::CollectionMapper).to have_received(:call).with(collection_form: collection_form,
+                                                                      source_id: "h3:collection-#{collection.id}")
+      expect(Sdr::Repository).to have_received(:open_if_needed)
+        .with(cocina_object: an_instance_of(Cocina::Models::CollectionWithMetadata))
+      expect(Sdr::Repository).to have_received(:update).with(cocina_object: cocina_object)
+      expect(Sdr::Repository).not_to have_received(:accession)
+
+      expect(collection.reload.deposit_job_finished?).to be true
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_refresh_to).with('wait', collection.id)
+    end
+  end
+end

--- a/spec/services/to_cocina/collection_mapper_spec.rb
+++ b/spec/services/to_cocina/collection_mapper_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ToCocina::CollectionMapper, type: :mapping do
+  subject(:cocina_object) { described_class.call(collection_form:, source_id: collection_source_id_fixture) }
+
+  context 'with a new collection' do
+    let(:collection_form) { new_collection_form_fixture }
+
+    it 'maps to cocina' do
+      expect(cocina_object).to equal_cocina(request_collection_fixture)
+    end
+  end
+
+  context 'with a collection' do
+    let(:collection_form) { collection_form_fixture }
+
+    it 'maps to cocina' do
+      expect(cocina_object).to equal_cocina(collection_with_metadata_fixture)
+    end
+  end
+end

--- a/spec/services/to_collection_form/mapper_spec.rb
+++ b/spec/services/to_collection_form/mapper_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ToCollectionForm::Mapper, type: :mapping do
+  subject(:collection_form) { described_class.call(cocina_object: collection_with_metadata_fixture) }
+
+  it 'maps to cocina' do
+    expect(collection_form).to equal_form(collection_form_fixture)
+  end
+end

--- a/spec/services/to_collection_form/roundtrip_validator_spec.rb
+++ b/spec/services/to_collection_form/roundtrip_validator_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ToCollectionForm::RoundtripValidator, type: :mapping do
+  subject(:roundtrippable?) { described_class.roundtrippable?(collection_form:, cocina_object:) }
+
+  context 'when roundtrippable' do
+    let(:collection_form) { collection_form_fixture }
+
+    let(:cocina_object) { collection_with_metadata_fixture }
+
+    it 'returns true' do
+      expect(roundtrippable?).to be true
+    end
+  end
+
+  context 'when not roundtrippable' do
+    let(:collection_form) { collection_form_fixture }
+
+    let(:cocina_object) { collection_with_metadata_fixture.new(type: Cocina::Models::ObjectType.curated_collection) }
+
+    it 'returns false' do
+      expect(roundtrippable?).to be false
+    end
+  end
+end

--- a/spec/support/collection_fixtures.rb
+++ b/spec/support/collection_fixtures.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+def collection_druid_fixture
+  'druid:cc234dd5678'
+end
+
+def collection_title_fixture
+  'My Collection'
+end
+
+def collection_source_id_fixture
+  'h3:collection-1'
+end
+
+def collection_abstract_fixture
+  'My first collection for testing'
+end

--- a/spec/support/collection_mapping_fixtures.rb
+++ b/spec/support/collection_mapping_fixtures.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Fixtures for collection mappings.
+# Not using FactoryBot because we want these fixtures to be consistent across tests.
+module CollectionMappingFixtures
+  def new_collection_form_fixture
+    CollectionForm.new(
+      title: collection_title_fixture,
+      abstract: collection_abstract_fixture
+    )
+  end
+
+  def collection_form_fixture
+    new_collection_form_fixture.tap do |form|
+      form.druid = collection_druid_fixture
+      form.version = 2
+      form.lock = lock_fixture
+    end
+  end
+
+  def request_collection_fixture
+    Cocina::Models.build_request(
+      {
+        type: Cocina::Models::ObjectType.collection,
+        label: collection_title_fixture,
+        description: {
+          title: CocinaDescriptionSupport.title(title: collection_title_fixture),
+          note: [CocinaDescriptionSupport.note(type: 'abstract', value: collection_abstract_fixture)]
+        },
+        version: 1,
+        identification: { sourceId: collection_source_id_fixture },
+        administrative: { hasAdminPolicy: Settings.apo },
+        access: { view: 'world' }
+      }
+    )
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def collection_fixture
+    Cocina::Models.build(
+      {
+        externalIdentifier: collection_druid_fixture,
+        type: Cocina::Models::ObjectType.collection,
+        label: collection_title_fixture,
+        description: {
+          title: CocinaDescriptionSupport.title(title: collection_title_fixture),
+          note: [CocinaDescriptionSupport.note(type: 'abstract', value: collection_abstract_fixture)],
+          purl: Sdr::Purl.from_druid(druid: collection_druid_fixture)
+        },
+        version: 2,
+        identification: { sourceId: collection_source_id_fixture },
+        administrative: { hasAdminPolicy: Settings.apo },
+        access: { view: 'world' }
+      }
+    )
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  def collection_with_metadata_fixture
+    Cocina::Models.with_metadata(collection_fixture, lock_fixture)
+  end
+
+  RSpec.configure do |config|
+    config.include CollectionMappingFixtures, type: :mapping
+  end
+end

--- a/spec/support/collection_mapping_fixtures.rb
+++ b/spec/support/collection_mapping_fixtures.rb
@@ -35,7 +35,6 @@ module CollectionMappingFixtures
     )
   end
 
-  # rubocop:disable Metrics/MethodLength
   def collection_fixture
     Cocina::Models.build(
       {
@@ -54,7 +53,6 @@ module CollectionMappingFixtures
       }
     )
   end
-  # rubocop:enable Metrics/MethodLength
 
   def collection_with_metadata_fixture
     Cocina::Models.with_metadata(collection_fixture, lock_fixture)

--- a/spec/support/mapping_fixtures.rb
+++ b/spec/support/mapping_fixtures.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Fixtures for mappings.
+# Fixtures for work mappings.
 # Not using FactoryBot because we want these fixtures to be consistent across tests.
 module MappingFixtures
   def new_work_form_fixture


### PR DESCRIPTION
Fixes #128
Fixes #146

This is mostly a copy of the work machinery to collection machinery. The purpose of separating Work and Collection machinery is avoid the extra complexity of determining type in the to and from cocina mapping.

This also removes the `null` requirement on the Collection ActiveRecord druid field is to allow the record to be created and wait for the deposit to complete and set the druid. This has been manually tested locally.

I will undraft after adding more testing for the new classes and system tests for the new forms.

Note: This branch is based on #144 and will be rebased after it is merged and before undrafting.