### PR TITLE
Fix editing of nested models

### DIFF
--- a/app/components/elements/forms/nested_component.html.erb
+++ b/app/components/elements/forms/nested_component.html.erb
@@ -2,15 +2,17 @@
   <div class="card-header">
     <%= header_label %>
   </div>
-  <%= tag.div(class: 'card-body', id: body_id) do %>
-    <ul class="list-group list-group-flush">
-      <%= form.fields_for field_name, model_class.new do |nested_form| %>
-        <li class="list-group-item">
-          <%= tag.div do %>
-            <%= render form_component.new(form: nested_form) %>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
+  <% nested_models.each do |nested_model| %>
+    <%= tag.div(class: 'card-body', id: body_id) do %>
+      <ul class="list-group list-group-flush">
+        <%= form.fields_for field_name, nested_model do |nested_form| %>
+          <li class="list-group-item">
+            <%= tag.div do %>
+              <%= render form_component.new(form: nested_form) %>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   <% end %>
 </div>

--- a/app/components/elements/forms/nested_component.rb
+++ b/app/components/elements/forms/nested_component.rb
@@ -14,6 +14,12 @@ module Elements
 
       attr_reader :form, :model_class, :form_component
 
+      def nested_models
+        return [model_class.new] if (existing_models = form.object.public_send(@field_name)).empty?
+
+        existing_models
+      end
+
       def body_id
         "card-body-#{@field_name}"
       end

--- a/app/components/related_links/edit_component.html.erb
+++ b/app/components/related_links/edit_component.html.erb
@@ -1,2 +1,2 @@
-<%= render Elements::Forms::TextFieldComponent.new(field_name: :text, label: 'Link text', form:) %>
-<%= render Elements::Forms::TextFieldComponent.new(field_name: :url, label: 'URL', form:) %>
+<%= render Elements::Forms::TextFieldComponent.new(field_name: :text, label: I18n.t('works.edit.fields.related_links.text.label'), form:) %>
+<%= render Elements::Forms::TextFieldComponent.new(field_name: :url, label: I18n.t('works.edit.fields.related_links.url.label'), form:) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,11 @@ en:
             A detailed statement may improve the discovery of your work in web searches.
         related_content:
           label: 'Related content'
+        related_links:
+          url:
+            label: 'URL'
+          text:
+            label: 'Link text'
         title:
           label: 'Title of deposit'
           help_text: >


### PR DESCRIPTION
Includes:

- **Generate nested fields from existing models so e.g. related links can be edited**
- **Add missing i18n texts for related link field labels** (opportunistic)

I suspect we missed this because the edit work system spec is busted (see https://github.com/sul-dlss/hungry-hungry-hippo/issues/138). I believe that issue will add the needed test coverage for this change as well.
