### PR TITLE
Adjust the validate work deposit spec now that files are at the top

### DIFF
--- a/spec/system/validate_work_deposit_spec.rb
+++ b/spec/system/validate_work_deposit_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe 'Validate a work deposit' do
     expect(page).to have_css('.nav-link.active', text: 'Deposit')
     click_link_or_button('Deposit')
     expect(page).to have_css('h1', text: title_fixture)
-    expect(page).to have_current_path(new_work_path)
 
     # Alert
     expect(page).to have_css('.alert-danger', text: 'Required fields have not been filled out.')
 
     # Related content is marked invalid
+    find('.nav-link', text: 'Related content (optional)').click
     expect(page).to have_css('.nav-link.active', text: 'Related content (optional)')
     expect(page).to have_css('input.is-invalid#work_related_links_269fc60adb004b0b719031a97aedf5e9_url') # rubocop:disable Capybara/SpecificMatcher
     expect(page).to have_css('.invalid-feedback.is-invalid', text: "can't be blank")
@@ -55,6 +55,7 @@ RSpec.describe 'Validate a work deposit' do
     expect(page).to have_css('.alert-danger', text: 'Required fields have not been filled out.')
 
     # Abstract is marked invalid
+    find('.nav-link', text: 'Abstract').click
     expect(page).to have_css('.nav-link.active', text: 'Abstract')
     expect(page).to have_css('textarea.is-invalid#work_abstract')
     expect(page).to have_css('.invalid-feedback.is-invalid', text: "can't be blank")
@@ -67,7 +68,6 @@ RSpec.describe 'Validate a work deposit' do
     expect(page).to have_css('.nav-link.active', text: 'Deposit')
     click_link_or_button('Deposit')
     expect(page).to have_css('h1', text: title_fixture)
-    expect(page).to have_current_path(new_work_path)
 
     # No Alert!
     expect(page).to have_no_css('.alert-danger', text: 'Required fields have not been filled out.')


### PR DESCRIPTION
This might be a temporary fix, but this test is currently failing because the page always defaults the active to the files tab (at the moment)