### PR TITLE
Updates the collection database model for deposit support

### DIFF
--- a/db/migrate/20241125181104_add_deposit_job_started_to_collections.rb
+++ b/db/migrate/20241125181104_add_deposit_job_started_to_collections.rb
@@ -1,0 +1,6 @@
+class AddDepositJobStartedToCollections < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :collections, :druid, true
+    add_column :collections, :deposit_job_started_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -130,11 +130,12 @@ CREATE TABLE public.ar_internal_metadata (
 
 CREATE TABLE public.collections (
     id bigint NOT NULL,
-    druid character varying NOT NULL,
+    druid character varying,
     title character varying NOT NULL,
     user_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    deposit_job_started_at timestamp(6) without time zone
 );
 
 
@@ -596,6 +597,7 @@ ALTER TABLE ONLY public.active_storage_attachments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241125181104'),
 ('20241122204826'),
 ('20241121122120'),
 ('20241120134012'),


### PR DESCRIPTION
Part of #119 

This is a small update to the collection model to support the first steps towards depositing collection records into SDR.

- Allows the druid to be null so the record can be created and the druid updated after deposit.
- Adds the deposit_job_started datetime to match the deposit workflow used in works.