### PR TITLE
Add collection form, mappers, and roundtrip validation

### DIFF
--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Form for a Collection
+class CollectionForm < ApplicationForm
+  accepts_nested_attributes_for :related_links
+
+  def self.immutable_attributes
+    ['druid']
+  end
+
+  attribute :druid, :string
+  alias id druid
+
+  def persisted?
+    druid.present?
+  end
+
+  attribute :lock, :string
+
+  attribute :version, :integer, default: 1
+
+  attribute :title, :string
+  validates :title, presence: true
+
+  # The Collection description maps to the cocina abstract
+  attribute :description, :string
+  validates :description, presence: true, if: :deposit?
+end

--- a/app/services/cocina_support.rb
+++ b/app/services/cocina_support.rb
@@ -16,6 +16,10 @@ class CocinaSupport
     end.presence
   end
 
+  def self.abstract_for(cocina_object:)
+    cocina_object.description.note.find { |note| note.type == 'abstract' }&.value
+  end
+
   def self.pretty(cocina_object:)
     JSON.pretty_generate(clean(cocina_object.to_h))
   end

--- a/app/services/to_cocina/collection/description_mapper.rb
+++ b/app/services/to_cocina/collection/description_mapper.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module ToCocina
+  module Collection
+    # Maps a CollectionForm to a Cocina description
+    class DescriptionMapper
+      def self.call(...)
+        new(...).call
+      end
+
+      # @param [CollectionForm] collection_form
+      def initialize(collection_form:)
+        @collection_form = collection_form
+      end
+
+      # @return [Cocina::Models::Description, Cocina::Models::RequestDescription]
+      def call
+        if collection_form.persisted?
+          Cocina::Models::Description.new(params)
+        else
+          Cocina::Models::RequestDescription.new(params)
+        end
+      end
+
+      private
+
+      attr_reader :collection_form
+
+      def params
+        {
+          title: CocinaDescriptionSupport.title(title: collection_form.title),
+          note: note_params,
+          purl: Sdr::Purl.from_druid(druid: collection_form.druid),
+          relatedResource: CocinaDescriptionSupport.related_links(related_links: collection_form.related_links)
+        }.compact
+      end
+
+      def note_params
+        [].tap do |params|
+          if collection_form.description.present?
+            params << CocinaDescriptionSupport.note(type: 'abstract',
+                                                    value: collection_form.description)
+          end
+        end.presence
+      end
+    end
+  end
+end

--- a/app/services/to_cocina/collection/mapper.rb
+++ b/app/services/to_cocina/collection/mapper.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module ToCocina
+  module Collection
+    # Maps CollectionForm to Cocina Collection
+    class Mapper
+      def self.call(...)
+        new(...).call
+      end
+
+      # @param [CollectionForm] collection_form
+      # @param [source_id] source_id
+      def initialize(collection_form:, source_id:)
+        @collection_form = collection_form
+        @source_id = source_id
+      end
+
+      # @return [Cocina::Models::CollectionWithMetadata, Cocina::Models::RequestCollection]
+      def call
+        if collection_form.persisted?
+          Cocina::Models.with_metadata(Cocina::Models.build(params), collection_form.lock)
+        else
+          Cocina::Models.build_request(params)
+        end
+      end
+
+      private
+
+      attr_reader :collection_form, :source_id
+
+      def params
+        {
+          externalIdentifier: collection_form.druid,
+          type: Cocina::Models::ObjectType.collection,
+          label: collection_form.title,
+          description: ToCocina::Collection::DescriptionMapper.call(collection_form:),
+          version: collection_form.version,
+          access: { view: 'world' },
+          identification: { sourceId: source_id },
+          administrative: { hasAdminPolicy: Settings.apo }
+        }.compact
+      end
+    end
+  end
+end

--- a/app/services/to_collection_form/mapper.rb
+++ b/app/services/to_collection_form/mapper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module ToWorkForm
-  # Maps Cocina DRO to WorkForm
+module ToCollectionForm
+  # Maps Cocina Collection to CollectionForm
   class Mapper
     def self.call(...)
       new(...).call
@@ -12,7 +12,7 @@ module ToWorkForm
     end
 
     def call
-      WorkForm.new(params)
+      CollectionForm.new(params)
     end
 
     private
@@ -24,7 +24,7 @@ module ToWorkForm
         druid: cocina_object.externalIdentifier,
         lock: cocina_object.lock,
         title: CocinaSupport.title_for(cocina_object:),
-        abstract: CocinaSupport.abstract_for(cocina_object:),
+        description: CocinaSupport.abstract_for(cocina_object:), # Cocina abstract maps to Collection description
         related_links: CocinaSupport.related_links_for(cocina_object:),
         version: cocina_object.version
       }

--- a/app/services/to_collection_form/roundtrip_validator.rb
+++ b/app/services/to_collection_form/roundtrip_validator.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module ToCollectionForm
+  # Validates that a cocina object can be converted to a collection form and then back without loss.
+  class RoundtripValidator
+    def self.roundtrippable?(...)
+      new(...).call
+    end
+
+    # @param [CollectoinForm] collection_form
+    # @param [Cocina::Models::Collection] cocina_object
+    def initialize(collection_form:, cocina_object:)
+      @collection_form = collection_form
+      @original_cocina_object = cocina_object
+    end
+
+    # @return [Boolean] true if the work form can be converted to a cocina object and back without loss
+    def call
+      if roundtripped_cocina_object == normalized_original_cocina_object
+        true
+      else
+        pretty_original = CocinaSupport.pretty(cocina_object: normalized_original_cocina_object)
+        pretty_roundtripped = CocinaSupport.pretty(cocina_object: roundtripped_cocina_object)
+        Honeybadger.notify('Roundtrip failed',
+                           context: { original: pretty_original, roundtripped: pretty_roundtripped })
+        Rails.logger.info("Roundtrip failed. Original: #{pretty_original}")
+        Rails.logger.info("Roundtripped: #{pretty_roundtripped}")
+        false
+      end
+    end
+
+    private
+
+    attr_reader :collection_form, :content
+
+    def roundtripped_cocina_object
+      ToCocina::Collection::Mapper.call(collection_form:,
+                                        source_id: normalized_original_cocina_object.identification&.sourceId)
+    end
+
+    def normalized_original_cocina_object
+      @normalized_original_cocina_object ||= begin
+        # Remove created_at and updated_at from the original cocina object
+        lock = @original_cocina_object&.lock
+        original_cocina_object_without_metadata = Cocina::Models.without_metadata(@original_cocina_object)
+        Cocina::Models.with_metadata(original_cocina_object_without_metadata, lock)
+      end
+    end
+  end
+end

--- a/spec/services/cocina_support_spec.rb
+++ b/spec/services/cocina_support_spec.rb
@@ -47,4 +47,30 @@ RSpec.describe CocinaSupport do
       end
     end
   end
+
+  describe '#abstract_for' do
+    let(:cocina_object) do
+      # NOTE: the :dro factory in the cocina-models gem does not have a seam
+      #       for injecting abstract, so we do it manually here
+      build(:dro, title: title_fixture).then do |object|
+        object.new(
+          object
+          .to_h
+          .tap do |obj|
+            obj[:description][:note] =
+              [
+                {
+                  type: 'abstract',
+                  value: abstract_fixture
+                }
+              ]
+          end
+        )
+      end
+    end
+
+    it 'returns the abstract' do
+      expect(described_class.abstract_for(cocina_object:)).to eq abstract_fixture
+    end
+  end
 end

--- a/spec/services/to_cocina/collection/mapper_spec.rb
+++ b/spec/services/to_cocina/collection/mapper_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ToCocina::Collection::Mapper, type: :mapping do
+  subject(:cocina_object) { described_class.call(collection_form:, source_id: collection_source_id_fixture) }
+
+  let(:collection_form) { collection_form_fixture }
+
+  context 'with a new collection' do
+    let(:collection_form) { new_collection_form_fixture }
+
+    it 'maps to cocina' do
+      expect(cocina_object).to equal_cocina(request_collection_fixture)
+    end
+  end
+
+  context 'with a collection' do
+    it 'maps to cocina' do
+      expect(cocina_object).to equal_cocina(collection_with_metadata_fixture)
+    end
+  end
+end

--- a/spec/services/to_collection_form/mapper_spec.rb
+++ b/spec/services/to_collection_form/mapper_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ToCollectionForm::Mapper, type: :mapping do
+  subject(:collection_form) { described_class.call(cocina_object: collection_with_metadata_fixture) }
+
+  it 'maps to cocina' do
+    expect(collection_form).to equal_form(collection_form_fixture)
+  end
+end

--- a/spec/services/to_collection_form/roundtrip_validator_spec.rb
+++ b/spec/services/to_collection_form/roundtrip_validator_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ToCollectionForm::RoundtripValidator, type: :mapping do
+  subject(:roundtrippable?) do
+    described_class.roundtrippable?(collection_form: collection_form_fixture, cocina_object:)
+  end
+
+  context 'when roundtrippable' do
+    let(:cocina_object) { collection_with_metadata_fixture }
+
+    it 'returns true' do
+      expect(roundtrippable?).to be true
+    end
+  end
+
+  context 'when not roundtrippable' do
+    let(:cocina_object) { collection_with_metadata_fixture.new(type: Cocina::Models::ObjectType.curated_collection) }
+
+    it 'returns false' do
+      expect(roundtrippable?).to be false
+    end
+  end
+end

--- a/spec/support/collection_fixtures.rb
+++ b/spec/support/collection_fixtures.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+def collection_druid_fixture
+  'druid:cc234dd5678'
+end
+
+def collection_title_fixture
+  'My Collection'
+end
+
+def collection_source_id_fixture
+  'hydrus:collection-1'
+end
+
+def collection_description_fixture
+  'My first collection for testing'
+end

--- a/spec/support/collection_mapping_fixtures.rb
+++ b/spec/support/collection_mapping_fixtures.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Fixtures for collection mappings.
+# Not using FactoryBot because we want these fixtures to be consistent across tests.
+module CollectionMappingFixtures
+  def new_collection_form_fixture
+    CollectionForm.new(
+      title: collection_title_fixture,
+      description: collection_description_fixture
+    )
+  end
+
+  def collection_form_fixture
+    new_collection_form_fixture.tap do |form|
+      form.druid = collection_druid_fixture
+      form.version = 2
+      form.lock = lock_fixture
+    end
+  end
+
+  def request_collection_fixture
+    Cocina::Models.build_request(
+      {
+        type: Cocina::Models::ObjectType.collection,
+        label: collection_title_fixture,
+        description: {
+          title: CocinaDescriptionSupport.title(title: collection_title_fixture),
+          note: [CocinaDescriptionSupport.note(type: 'abstract', value: collection_description_fixture)]
+        },
+        version: 1,
+        identification: { sourceId: collection_source_id_fixture },
+        administrative: { hasAdminPolicy: Settings.apo },
+        access: { view: 'world' }
+      }
+    )
+  end
+
+  def collection_fixture
+    Cocina::Models.build(
+      {
+        externalIdentifier: collection_druid_fixture,
+        type: Cocina::Models::ObjectType.collection,
+        label: collection_title_fixture,
+        description: {
+          title: CocinaDescriptionSupport.title(title: collection_title_fixture),
+          note: [CocinaDescriptionSupport.note(type: 'abstract', value: collection_description_fixture)],
+          purl: Sdr::Purl.from_druid(druid: collection_druid_fixture)
+        },
+        version: 2,
+        identification: { sourceId: collection_source_id_fixture },
+        administrative: { hasAdminPolicy: Settings.apo },
+        access: { view: 'world' }
+      }
+    )
+  end
+
+  def collection_with_metadata_fixture
+    Cocina::Models.with_metadata(collection_fixture, lock_fixture)
+  end
+
+  RSpec.configure do |config|
+    config.include CollectionMappingFixtures, type: :mapping
+  end
+end


### PR DESCRIPTION
Closes #133 

This implements the collection form, mappers (to and from cocina), and roundtrip validation.

This is the last chunk of work extracting from #144 - I will start basing #147 on main once this is merged in order to setup the actual UI forms and links from works, etc.