### PR TITLE
Add and configure mission-control for viewing jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'bcrypt', '~> 3.1.7'
 gem 'tzinfo-data', platforms: %i[windows jruby]
 
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
+gem 'mission_control-jobs' # Rails-based frontend to Active Job adapters that support SolidQueue
 gem 'solid_cable'
 gem 'solid_cache'
 gem 'solid_queue'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,8 +286,6 @@ GEM
     kaminari-core (1.2.2)
     kramdown (2.4.0)
       rexml
-    kramdown (2.5.1)
-      rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
@@ -308,6 +306,16 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.2)
+    mission_control-jobs (0.6.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
     msgpack (1.7.5)
     multi_json (1.15.0)
     net-http (0.5.0)
@@ -586,6 +594,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kaminari
+  mission_control-jobs
   okcomputer
   overmind
   pg

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -4,6 +4,7 @@
 class AuthenticationController < ApplicationController
   allow_unauthenticated_access only: %i[login]
   skip_verify_authorized only: %i[login logout]
+  skip_after_action :verify_authorized, if: :mission_control?
 
   # See Authentication concern for the methods used below.
 
@@ -16,5 +17,9 @@ class AuthenticationController < ApplicationController
     terminate_session
 
     redirect_to SHIBBOLETH_LOGOUT_PATH
+  end
+
+  def mission_control?
+    is_a?(::MissionControl::Jobs::ApplicationController)
   end
 end

--- a/config/initializers/mission_control.rb
+++ b/config/initializers/mission_control.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  MissionControl::Jobs.base_controller_class = 'AuthenticationController'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,4 +26,6 @@ Rails.application.routes.draw do
   resources :content_files, only: [:edit, :update, :destroy, :show]
 
   root to: 'dashboard#show'
+
+  mount MissionControl::Jobs::Engine, at: "/jobs"
 end


### PR DESCRIPTION
This implements mission_control-jobs so we have a dashboard for viewing the active jobs.

![Screenshot 2024-11-26 at 10 04 34 AM](https://github.com/user-attachments/assets/b7ffa441-6bcf-4c13-82af-cfd33bce4198)

Closes #167 