### PR TITLE
Extract Current.groups from request headers

### DIFF
--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -5,4 +5,5 @@
 # They can be accessed with Current.user, etc.
 class Current < ActiveSupport::CurrentAttributes
   attribute :user
+  attribute :groups
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -2,17 +2,9 @@
 
 # Base class for application policies
 class ApplicationPolicy < ActionPolicy::Base
-  # Configure additional authorization contexts here
-  # (`user` is added by default).
-  #
-  #   authorize :account, optional: true
-  #
-  # Read more about authorization context: https://actionpolicy.evilmartians.io/#/authorization_context
+  pre_check :allow_admins
 
-  # Define shared methods useful for most policies.
-  # For example:
-  #
-  #  def owner?
-  #    record.user_id == user.id
-  #  end
+  def allow_admins
+    allow! if Current.groups.include?(Settings.authorization_workgroup_names.administrators)
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,3 +12,8 @@ purl:
   url: "https://sul-purl-stage.stanford.edu"
 
 staging_location: '/dor/workspace'
+
+# mappings from authorization role to workgroup name
+authorization_workgroup_names:
+  administrators: 'dlss:hydrus-app-administrators'
+  collection_creators: 'dlss:hydrus-app-collection-creators'

--- a/lib/test_shibboleth_headers.rb
+++ b/lib/test_shibboleth_headers.rb
@@ -19,7 +19,7 @@ class TestShibbolethHeaders
       env[mangle(Authentication::NAME_HEADER)] = user.name
       env[mangle(Authentication::FIRST_NAME_HEADER)] = user.first_name
     end
-    env[Authentication::GROUPS_HEADER] = Array(groups).join(';') if groups
+    env[mangle(Authentication::GROUPS_HEADER)] = Array(groups).join(';') if groups
     @app.call(env)
   end
   # rubocop:enable Metrics/AbcSize

--- a/spec/requests/show_work_spec.rb
+++ b/spec/requests/show_work_spec.rb
@@ -23,6 +23,29 @@ RSpec.describe 'Show work' do
     end
   end
 
+  context 'when the user is an administrator' do
+    let(:admin_user) { create(:user) }
+    let(:groups) { ['dlss:hydrus-app-administrators'] }
+
+    before do
+      create(:work, druid:)
+      allow(Sdr::Repository).to receive(:find).with(druid:).and_return(dro_with_metadata_fixture)
+      allow(Sdr::Repository).to receive(:status)
+        .with(druid:).and_return(
+          instance_double(Dor::Services::Client::ObjectVersion::VersionStatus, open?: true, version: 1,
+                                                                               openable?: false)
+        )
+
+      sign_in(admin_user, groups:)
+    end
+
+    it 'display the work show page' do
+      get "/works/#{druid}"
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   context 'when the deposit job started' do
     let!(:work) { create(:work, :deposit_job_started, druid:, user:) }
     let(:user) { create(:user) }

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -2,11 +2,12 @@
 
 # Helpers to assist with authentication.
 module AuthenticationHelpers
-  def authentication_headers_for(user)
+  def authentication_headers_for(user, groups: [])
     {
       Authentication::REMOTE_USER_HEADER => user.email_address,
       Authentication::NAME_HEADER => user.name,
-      Authentication::FIRST_NAME_HEADER => user.first_name
+      Authentication::FIRST_NAME_HEADER => user.first_name,
+      Authentication::GROUPS_HEADER => groups.join(';')
     }
   end
 


### PR DESCRIPTION
Fixes #215 

Brings the `UserWithGroups` authorization logic from H2 into `Current.groups` in our new approach to authentication.

Manually tested this on stage where admin users (@lwrubel and @amyehodge) were able to view my works, while `main` blocks their access.