### PR TITLE
Add merge_classes to NestedComponent to allow stayling differences pe…

### DIFF
--- a/app/components/elements/forms/repeatable_nested_component.html.erb
+++ b/app/components/elements/forms/repeatable_nested_component.html.erb
@@ -1,12 +1,12 @@
 <fieldset class="my-3" data-controller="nested-form" data-nested-form-selector-value=".row">
   <legend class="h5">
-    <%= header_label %>
+    <%= render Elements::Forms::LabelComponent.new(form:, field_name:, label_text:, hidden_label:) %>
   </legend>
   <%= tag.div(class: 'mb-3 container', data: { nested_form_target: 'container' }) do %>
     <template data-nested-form-target="template">
       <%= form.fields_for field_name, model_class.new, child_index: 'NEW_RECORD' do |nested_form| %>
         <%# Note that this div is duplicated below. If making a change here, also make the change below. %>
-        <%= tag.div(class: 'mb-3 p-3 border border-3 border-light-subtle border-opacity-75 row', data: { index: nested_form.options[:child_index], nested_form_target: 'instance' }) do %>
+        <%= tag.div(class: classes, data: { index: nested_form.options[:child_index], nested_form_target: 'instance' }) do %>
           <div class="col">
             <%= render form_component.new(form: nested_form) %>
           </div>
@@ -20,7 +20,7 @@
     </template>
     <%= form.fields_for field_name do |nested_form| %>
       <%# Note that this div is duplicated above. If making a change here, also make the change above. %>
-      <%= tag.div(class: 'mb-3 p-3 border border-3 border-light-subtle border-opacity-75 row', data: { index: nested_form.options[:child_index], nested_form_target: 'instance' }) do %>
+      <%= tag.div(class: classes, data: { index: nested_form.options[:child_index], nested_form_target: 'instance' }) do %>
         <div class="col">
           <%= render form_component.new(form: nested_form) %>
         </div>

--- a/app/components/elements/forms/repeatable_nested_component.rb
+++ b/app/components/elements/forms/repeatable_nested_component.rb
@@ -5,13 +5,13 @@ module Elements
     # Encapsulates a repeatable nested form, including adding and removing nested models.
     # NOTE: Use the `NestedComponentPresenter` to invoke this component; do not directly instantiate it.
     class RepeatableNestedComponent < ApplicationComponent
-      def initialize(form:, model_class:, field_name:, form_component:)
+      def initialize(form:, model_class:, field_name:, form_component:, hidden_label: false, bordered: true) # rubocop:disable Metrics/ParameterLists
         @form = form
         @model_class = model_class
         @field_name = field_name
         @form_component = form_component
-        @hidden_label = hide_label
-        @classes = classes
+        @hidden_label = hidden_label
+        @bordered = bordered
         super()
       end
 
@@ -22,7 +22,13 @@ module Elements
       end
 
       def classes
-        merge_classes(@classes)
+        merge_classes(%w[mb-3 p-3 row], bordered_classes)
+      end
+
+      def bordered_classes
+        return [] unless @bordered
+
+        %w[border border-3 border-light-subtle border-opacity-75]
       end
 
       def label_text

--- a/app/components/elements/forms/repeatable_nested_component.rb
+++ b/app/components/elements/forms/repeatable_nested_component.rb
@@ -10,16 +10,22 @@ module Elements
         @model_class = model_class
         @field_name = field_name
         @form_component = form_component
+        @hidden_label = hide_label
+        @classes = classes
         super()
       end
 
-      attr_reader :form, :model_class, :field_name, :form_component
+      attr_reader :form, :model_class, :field_name, :form_component, :hidden_label
 
       def add_button_label
         "+ Add another #{model_class.model_name.singular.humanize(capitalize: false)}"
       end
 
-      def header_label
+      def classes
+        merge_classes(@classes)
+      end
+
+      def label_text
         model_class.model_name.plural.humanize
       end
     end

--- a/spec/components/elements/forms/repeatable_nested_component_spec.rb
+++ b/spec/components/elements/forms/repeatable_nested_component_spec.rb
@@ -5,16 +5,43 @@ require 'rails_helper'
 RSpec.describe Elements::Forms::RepeatableNestedComponent, type: :component do
   subject(:component) do
     described_class.new(form:, field_name: :related_links, model_class: RelatedLinkForm,
-                        form_component: RelatedLinks::EditComponent)
+                        form_component: RelatedLinks::EditComponent, hidden_label:, bordered:)
   end
 
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, vc_test_controller.view_context, {}) }
   let(:work_form) { WorkForm.new }
 
-  it 'renders the nested component' do
-    render_inline(component)
-    expect(page).to have_text('Related links')
-    expect(page).to have_field('Link text')
-    expect(page).to have_field('URL')
+  context 'when rendering the default component' do
+    let(:hidden_label) { false }
+    let(:bordered) { true }
+
+    it 'renders the nested component' do
+      render_inline(component)
+      expect(page).to have_text('Related links')
+      expect(page).to have_field('Link text')
+      expect(page).to have_field('URL')
+      expect(page).to have_no_css('label.visually-hidden')
+      expect(page).to have_css('div.border-3')
+    end
+  end
+
+  context 'when hiding the label for the component' do
+    let(:hidden_label) { true }
+    let(:bordered) { true }
+
+    it 'does not render the label' do
+      render_inline(component)
+      expect(page).to have_css('label.visually-hidden')
+    end
+  end
+
+  context 'when rendering the component borderless' do
+    let(:hidden_label) { true }
+    let(:bordered) { false }
+
+    it 'does not include the border classes' do
+      render_inline(component)
+      expect(page).to have_no_css('div.border-3')
+    end
   end
 end


### PR DESCRIPTION
…r design

The figma designs show that while the contact email (on the title pane) is nested, it does not have the box styling included the same way as the related works content does. This add `hide_label` and `merge_classes` to allow broader reuse of the component.