### PR TITLE
Add nested contact emails to the work form title tab

### DIFF
--- a/app/components/contact_emails/edit_component.html.erb
+++ b/app/components/contact_emails/edit_component.html.erb
@@ -1,0 +1,1 @@
+<%= render Elements::Forms::TextFieldComponent.new(field_name: :email, label: helpers.t('contact_email.edit.fields.email.label'), form:) %>

--- a/app/components/contact_emails/edit_component.rb
+++ b/app/components/contact_emails/edit_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ContactEmails
+  # Component for editing contact emails
+  class EditComponent < ApplicationComponent
+    def initialize(form:)
+      @form = form
+      super()
+    end
+
+    attr_reader :form
+  end
+end

--- a/app/forms/contact_email_form.rb
+++ b/app/forms/contact_email_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Form for contact emails
+class ContactEmailForm < ApplicationForm
+  attribute :email, :string
+  validates :email, presence: true, format: {
+    with: /\A[^@]+@([a-z0-9-]+\.)+[a-z]{2,4}\z/
+  }
+end

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -2,7 +2,7 @@
 
 # Form for a Work
 class WorkForm < ApplicationForm
-  accepts_nested_attributes_for :related_links, :related_works, :publication_date
+  accepts_nested_attributes_for :related_links, :related_works, :publication_date, :contact_emails
 
   def self.immutable_attributes
     ['druid']

--- a/app/services/cocina_description_support.rb
+++ b/app/services/cocina_description_support.rb
@@ -27,6 +27,21 @@ class CocinaDescriptionSupport
     [{ value: title }]
   end
 
+  def self.contact_emails(contact_emails:)
+    contact_emails.map do |contact_email|
+      # Since contact_email is either a Hash or an instance of ContactEmailForm,
+      # we need to make it a hash of the attributes if it's a ContactEmailForm
+      contact_email = contact_email.attributes if contact_email.respond_to?(:attributes)
+      next if contact_email['email'].blank?
+
+      {
+        value: contact_email['email'],
+        type: 'email',
+        displayLabel: 'Contact'
+      }
+    end.compact_blank
+  end
+
   def self.related_links(related_links:)
     related_links.map do |related_link|
       # NOTE: Sometimes this is an array of hashes and sometimes it's an array of RelatedLinkForm instances

--- a/app/services/cocina_support.rb
+++ b/app/services/cocina_support.rb
@@ -6,6 +6,20 @@ class CocinaSupport
     cocina_object.description.title.first.value
   end
 
+  # Maps the value from the accessContact field in the Cocina::DescriptiveAccessMetadata object.
+  # to the email value for a contact_email in the WorkForm
+  # @param [Cocina::Models::DRO] cocina_object
+  # @return [Array<Hash>, Nil] with keys for email
+  def self.contact_emails_for(cocina_object:)
+    return nil if cocina_object.description.access.blank?
+
+    cocina_object.description.access.accessContact.filter_map do |access_contact|
+      next if access_contact.value.blank?
+
+      { 'email' => access_contact[:value] }
+    end.presence
+  end
+
   def self.related_links_for(cocina_object:) # rubocop:disable Metrics/AbcSize
     return nil if cocina_object.description.relatedResource.blank?
 

--- a/app/services/to_cocina/work/description_mapper.rb
+++ b/app/services/to_cocina/work/description_mapper.rb
@@ -26,6 +26,7 @@ module ToCocina
 
       attr_reader :work_form
 
+      # rubocop:disable Metrics/AbcSize
       def params
         {
           title: CocinaDescriptionSupport.title(title: work_form.title),
@@ -35,9 +36,13 @@ module ToCocina
           # subject: subject_params.presence,
           purl: Sdr::Purl.from_druid(druid: work_form.druid),
           relatedResource: CocinaDescriptionSupport.related_works(related_works: work_form.related_works_attributes) +
-            CocinaDescriptionSupport.related_links(related_links: work_form.related_links_attributes)
+            CocinaDescriptionSupport.related_links(related_links: work_form.related_links_attributes),
+          access: {
+            accessContact: CocinaDescriptionSupport.contact_emails(contact_emails: work_form.contact_emails_attributes)
+          }
         }.compact
       end
+      # rubocop:enable Metrics/AbcSize
 
       # def contributors_params
       #   work_form.authors.map do |contributor|

--- a/app/services/to_work_form/mapper.rb
+++ b/app/services/to_work_form/mapper.rb
@@ -26,6 +26,7 @@ module ToWorkForm
         lock: cocina_object.lock,
         title: CocinaSupport.title_for(cocina_object:),
         abstract: CocinaSupport.abstract_for(cocina_object:),
+        contact_emails_attributes: CocinaSupport.contact_emails_for(cocina_object:),
         related_works_attributes: CocinaSupport.related_works_for(cocina_object:),
         related_links_attributes: CocinaSupport.related_links_for(cocina_object:),
         license:,

--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -29,6 +29,7 @@
     <% component.with_pane(tab_name: :title, label: t('works.edit.panes.title.label'), form:) do %>
       <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :title, label: t('works.edit.fields.title.label'),
                                                          help_text: t('works.edit.fields.title.help_text')) %>
+      <%= render NestedComponentPresenter.for(form:, field_name: :contact_emails, model_class: ContactEmailForm, form_component: ContactEmails::EditComponent, hidden_label: true, bordered: false) %>
     <% end %>
 
     <% component.with_pane(tab_name: :abstract, label: t('works.edit.panes.abstract.label'), form:) do %>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -6,8 +6,9 @@
   <%= render Elements::SpinnerComponent.new %>
 <% end %>
 
-<%= render Elements::Tables::TableComponent.new(id: 'title-table', classes: 'table-show mb-5', label: 'Title') do |component| %>
+<%= render Elements::Tables::TableComponent.new(id: 'title-table', classes: 'table-show mb-5', label: 'Title and contact') do |component| %>
   <% component.with_row(label: 'Title', values: [@work_form.title]) %>
+  <% component.with_row(label: 'Contact emails', values: [@work_form.contact_emails_attributes.map(&:email).join(', ')]) %>
 <% end %>
 
 <%= render Elements::Tables::TableComponent.new(id: 'dates-table', classes: 'table-show mb-5', label: 'Dates') do |component| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,10 @@ en:
           attributes:
             relationship:
               inclusion: '%{value} is not a valid relationship for related works'
+        contact_email:
+          attributes:
+            email:
+              format: '%{value} is not a valid email address'
   errors:
     not_authorized: 'You are not authorized to perform the requested action.'
   publication_date:
@@ -47,6 +51,11 @@ en:
           label: 'Month'
         day:
           label: 'Day'
+  contact_email:
+    edit:
+      fields:
+        email:
+          label: 'Contact email'
   related_links:
     edit:
       fields:
@@ -128,7 +137,7 @@ en:
           tab_label: 'Related content (optional)'
           label: 'Related content'
         title:
-          tab_label: 'Title'
+          tab_label: 'Title & contact'
           label: 'Title of deposit'
   collections:
     edit:

--- a/spec/serializers/work_form_serializer_spec.rb
+++ b/spec/serializers/work_form_serializer_spec.rb
@@ -17,13 +17,15 @@ RSpec.describe WorkFormSerializer do
       'related_works_attributes' => related_works_fixture,
       'license' => license_fixture,
       'publication_date_attributes' => publication_date_fixture,
+      'contact_emails_attributes' => contact_email_fixture,
       'content_id' => 5
     }
   end
   let(:work_form) do
     WorkForm.new(title: title_fixture, druid:, collection_druid: collection_druid_fixture, abstract: abstract_fixture,
                  related_links_attributes: related_links_fixture, related_works_attributes: related_works_fixture,
-                 license: license_fixture, publication_date_attributes: publication_date_fixture, content_id: 5)
+                 license: license_fixture, publication_date_attributes: publication_date_fixture,
+                 contact_emails_attributes: contact_email_fixture, content_id: 5)
   end
 
   describe '.serialize?' do

--- a/spec/support/work_fixtures.rb
+++ b/spec/support/work_fixtures.rb
@@ -46,6 +46,17 @@ def related_works_fixture
   ]
 end
 
+def contact_email_fixture
+  [
+    {
+      'email' => 'aperson@example.com'
+    },
+    {
+      'email' => 'anotherperson@example.com'
+    }
+  ]
+end
+
 def license_fixture
   'https://creativecommons.org/licenses/by/4.0/legalcode'
 end

--- a/spec/support/work_mapping_fixtures.rb
+++ b/spec/support/work_mapping_fixtures.rb
@@ -12,7 +12,8 @@ module WorkMappingFixtures
       related_works_attributes: related_works_fixture,
       license: license_fixture,
       collection_druid: collection_druid_fixture,
-      publication_date_attributes: { year: '2024', month: '12' }
+      publication_date_attributes: { year: '2024', month: '12' },
+      contact_emails_attributes: contact_email_fixture
     )
   end
 
@@ -69,7 +70,8 @@ module WorkMappingFixtures
           event: [CocinaDescriptionSupport.event_date(type: 'publication', date: '2024-12', primary: true)],
           note: [CocinaDescriptionSupport.note(type: 'abstract', value: abstract_fixture)],
           relatedResource: CocinaDescriptionSupport.related_works(related_works: related_works_fixture) +
-                           CocinaDescriptionSupport.related_links(related_links: related_links_fixture)
+                           CocinaDescriptionSupport.related_links(related_links: related_links_fixture),
+          access: { accessContact: CocinaDescriptionSupport.contact_emails(contact_emails: contact_email_fixture) }
         },
         version: 1,
         identification: { sourceId: source_id_fixture },
@@ -140,6 +142,7 @@ module WorkMappingFixtures
           note: [CocinaDescriptionSupport.note(type: 'abstract', value: abstract_fixture)],
           relatedResource: CocinaDescriptionSupport.related_works(related_works: related_works_fixture) +
                            CocinaDescriptionSupport.related_links(related_links: related_links_fixture),
+          access: { accessContact: CocinaDescriptionSupport.contact_emails(contact_emails: contact_email_fixture) },
           purl: Sdr::Purl.from_druid(druid: druid_fixture)
         },
         version: 2,

--- a/spec/system/create_work_deposit_spec.rb
+++ b/spec/system/create_work_deposit_spec.rb
@@ -54,8 +54,9 @@ RSpec.describe 'Create a work deposit' do
     expect(page).to have_css('table#content-table td', text: 'hippo.png')
 
     # Filling in title
-    find('.nav-link', text: 'Title').click
+    find('.nav-link', text: 'Title & contact').click
     fill_in('work_title', with: title_fixture)
+    fill_in('Contact email', with: contact_email_fixture.first['email'])
 
     # Click Next to go to abstract tab
     click_link_or_button('Next')

--- a/spec/system/create_work_draft_spec.rb
+++ b/spec/system/create_work_draft_spec.rb
@@ -39,15 +39,17 @@ RSpec.describe 'Create a work draft' do
     expect(page).to have_css('h1', text: 'Untitled deposit')
 
     # Title is required.
-    find('.nav-link', text: 'Title').click
+    find('.nav-link', text: 'Title & contact').click
     click_link_or_button('Save as draft')
 
     # Validation fails for title.
     expect(page).to have_css('.alert-danger', text: 'Required fields have not been filled out.')
     expect(page).to have_css('input.is-invalid#work_title') # rubocop:disable Capybara/SpecificMatcher
+    expect(page).to have_css('input.is-invalid#work_contact_emails_attributes_0_email') # rubocop:disable Capybara/SpecificMatcher
 
     # Filling in title
     fill_in('work_title', with: title_fixture)
+    fill_in('Contact email', with: contact_email_fixture.first['email'])
 
     # This should work now.
     click_link_or_button('Save as draft')

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -145,9 +145,11 @@ RSpec.describe 'Show a work' do
 
     # Title table
     within('table#title-table') do
-      expect(page).to have_css('caption', text: 'Title')
+      expect(page).to have_css('caption', text: 'Title and contact')
       expect(page).to have_css('tr', text: 'Title')
       expect(page).to have_css('td', text: work.title)
+      expect(page).to have_css('tr', text: 'Contact emails')
+      expect(page).to have_css('td', text: contact_email_fixture.pluck(:email).join(', '))
     end
 
     # Description table

--- a/spec/system/validate_work_deposit_spec.rb
+++ b/spec/system/validate_work_deposit_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe 'Validate a work deposit' do
     expect(page).to have_css('h1', text: 'Untitled deposit')
 
     # Filling in title
-    find('.nav-link', text: 'Title').click
+    find('.nav-link', text: 'Title & contact').click
     fill_in('work_title', with: title_fixture)
+    fill_in('Contact email', with: contact_email_fixture.first['email'])
 
     # Abstract is required for deposit, but skipping.
 


### PR DESCRIPTION
Closes #112 

Note - this can be merged as is (pending review) but a styling update should happen after #224 to remove the border to more closely match the design.

Nested form:

<img width="1390" alt="Screenshot 2024-12-03 at 7 59 32 PM" src="https://github.com/user-attachments/assets/ff776999-2104-4238-a939-dde28cf7351d">

Show page:

<img width="1382" alt="Screenshot 2024-12-03 at 8 04 00 PM" src="https://github.com/user-attachments/assets/a6823cc3-f075-4fa3-82ff-e687473043fd">
