### PR TITLE
Changes to refresh for waiting for deposit.

### DIFF
--- a/app/javascript/controllers/refresh_controller.js
+++ b/app/javascript/controllers/refresh_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  connect () {
+    setTimeout(() => {
+      window.location.reload()
+    }, 750)
+  }
+}

--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -14,12 +14,8 @@ class DepositCollectionJob < ApplicationJob
 
     Sdr::Repository.accession(druid:) if deposit
 
-    # Refresh the wait page. Since the deposit job is finished, this will redirect to the show page.
+    # The wait page will refresh until deposit_job_started_at is nil.
     collection.update!(deposit_job_started_at: nil, druid:)
-    # Just to be aware for future troubleshooting: There is a possible race condition between the websocket
-    # connecting and the following broadcast being sent.
-    sleep 0.5 if Rails.env.test? # Avoids race condition in tests
-    Turbo::StreamsChannel.broadcast_refresh_to 'collection/wait', collection.id
   end
 
   private

--- a/app/jobs/deposit_work_job.rb
+++ b/app/jobs/deposit_work_job.rb
@@ -20,12 +20,8 @@ class DepositWorkJob < ApplicationJob
 
     ModelSync::Work.call(work:, cocina_object: new_cocina_object)
 
-    # Refresh the wait page. Since the deposit job is finished, this will redirect to the show page.
+    # The wait page will refresh until deposit_job_started_at is nil.
     work.update!(deposit_job_started_at: nil, druid:)
-    # Just to be aware for future troubleshooting: There is a possible race condition between the websocket
-    # connecting and the following broadcast being sent.
-    sleep 0.5 if Rails.env.test? # Avoids race condition in tests
-    Turbo::StreamsChannel.broadcast_refresh_to 'wait', work.id
 
     # Content isn't needed anymore
     content.destroy!

--- a/app/views/collections/wait.html.erb
+++ b/app/views/collections/wait.html.erb
@@ -1,2 +1,6 @@
-<%= turbo_stream_from 'wait', params[:id] %>
-<%= render Elements::SpinnerComponent.new(message: 'Processing...', variant: :info, classes: 'my-2') %>
+<%# Setting the turbo_refresh_method will make the refresh smooth. %>
+<% content_for(:turbo_refresh_method, 'refresh') %>
+
+<%= tag.div data: { controller: 'refresh' } do %>
+    <%= render Elements::SpinnerComponent.new(message: 'Processing...', variant: :info, classes: 'my-2') %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,9 @@
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
     <%#= tag.link rel: 'manifest', href: pwa_manifest_path(format: :json) %>
 
+    <%# To morph a page: <% content_for(:turbo_refresh_method, 'refresh') %> %>
+    <%= tag.meta name: 'turbo-refresh-method', content: content_for(:turbo_refresh_method) || 'replace' %>
+
     <link rel='icon' href='/icon.png' type='image/png'>
     <link rel='icon' href='/icon.svg' type='image/svg+xml'>
     <link rel='apple-touch-icon' href='/icon.png'>

--- a/app/views/works/wait.html.erb
+++ b/app/views/works/wait.html.erb
@@ -1,2 +1,6 @@
-<%= turbo_stream_from 'wait', params[:id] %>
-<%= render Elements::SpinnerComponent.new(message: 'Processing...', variant: :info, classes: 'my-2') %>
+<%# Setting the turbo_refresh_method will make the refresh smooth. %>
+<% content_for(:turbo_refresh_method, 'refresh') %>
+
+<%= tag.div data: { controller: 'refresh' } do %>
+    <%= render Elements::SpinnerComponent.new(message: 'Processing...', variant: :info, classes: 'my-2') %>
+<% end %>

--- a/spec/jobs/deposit_collection_job_spec.rb
+++ b/spec/jobs/deposit_collection_job_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe DepositCollectionJob do
   before do
     allow(ToCocina::Collection::Mapper).to receive(:call).and_call_original
     allow(Sdr::Repository).to receive(:accession)
-    allow(Turbo::StreamsChannel).to receive(:broadcast_refresh_to)
   end
 
   context 'when a new collection' do
@@ -29,7 +28,6 @@ RSpec.describe DepositCollectionJob do
       expect(Sdr::Repository).to have_received(:accession).with(druid:)
 
       expect(collection.reload.deposit_job_finished?).to be true
-      expect(Turbo::StreamsChannel).to have_received(:broadcast_refresh_to).with('collection/wait', collection.id)
     end
   end
 
@@ -51,7 +49,6 @@ RSpec.describe DepositCollectionJob do
       expect(Sdr::Repository).not_to have_received(:accession)
 
       expect(collection.reload.deposit_job_finished?).to be true
-      expect(Turbo::StreamsChannel).to have_received(:broadcast_refresh_to).with('collection/wait', collection.id)
     end
   end
 end

--- a/spec/jobs/deposit_work_job_spec.rb
+++ b/spec/jobs/deposit_work_job_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe DepositWorkJob do
     allow(ToCocina::Work::Mapper).to receive(:call).and_call_original
     allow(Contents::Stager).to receive(:call)
     allow(Sdr::Repository).to receive(:accession)
-    allow(Turbo::StreamsChannel).to receive(:broadcast_refresh_to)
   end
 
   context 'when a new work' do
@@ -37,7 +36,6 @@ RSpec.describe DepositWorkJob do
       expect(Sdr::Repository).to have_received(:accession).with(druid:)
 
       expect(work.reload.deposit_job_finished?).to be true
-      expect(Turbo::StreamsChannel).to have_received(:broadcast_refresh_to).with('wait', work.id)
     end
   end
 
@@ -68,7 +66,6 @@ RSpec.describe DepositWorkJob do
       expect(work.reload.title).to eq(title_fixture)
 
       expect(work.deposit_job_finished?).to be true
-      expect(Turbo::StreamsChannel).to have_received(:broadcast_refresh_to).with('wait', work.id)
     end
   end
 end


### PR DESCRIPTION
Why? To avoid this race condition:
1. Deposit job is started.
2. User is redirected to waiting page.
3. Deposit completes and sends broadcast.
4. Waiting page connects web socket.

In this case, the waiting page never gets the broadcast about the deposit being complete.