### PR TITLE
Get rid of extra ERB tags

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
     <%#= tag.link rel: 'manifest', href: pwa_manifest_path(format: :json) %>
 
-    <%# To morph a page: <% content_for(:turbo_refresh_method, 'refresh') %> %>
+    <%# To morph a page: content_for(:turbo_refresh_method, 'refresh') %>
     <%= tag.meta name: 'turbo-refresh-method', content: content_for(:turbo_refresh_method) || 'replace' %>
 
     <link rel='icon' href='/icon.png' type='image/png'>


### PR DESCRIPTION
Otherwise a literal `%>` shows up on the page.