### PR TITLE
Allow nil object_updated_at

### DIFF
--- a/app/components/dashboard/show/works_list_component.rb
+++ b/app/components/dashboard/show/works_list_component.rb
@@ -27,7 +27,7 @@ module Dashboard
           link_to(work.title, link_for(work)),
           @status_map[work.id].status_message,
           work.user.name,
-          I18n.l(work.object_updated_at, format: '%b %d, %Y'),
+          work.object_updated_at ? I18n.l(work.object_updated_at, format: '%b %d, %Y') : nil,
           work.druid ? link_to(nil, Sdr::Purl.from_druid(druid: work.druid)) : nil
         ]
       end


### PR DESCRIPTION
I don't think this would happen in a non-dev environment, but just in case. (It is an issue for me locally.)