### PR TITLE
Only include padding on nested element when bordered

### DIFF
--- a/app/components/elements/forms/repeatable_nested_component.rb
+++ b/app/components/elements/forms/repeatable_nested_component.rb
@@ -22,13 +22,13 @@ module Elements
       end
 
       def classes
-        merge_classes(%w[mb-3 p-3 row], bordered_classes)
+        merge_classes(%w[mb-3 row], bordered_classes)
       end
 
       def bordered_classes
         return [] unless @bordered
 
-        %w[border border-3 border-light-subtle border-opacity-75]
+        %w[p-3 border border-3 border-light-subtle border-opacity-75]
       end
 
       def label_text


### PR DESCRIPTION
This slightly improves the padding around nested elements when not bordered.

![Screenshot 2024-12-05 at 1 24 21 PM](https://github.com/user-attachments/assets/0c141317-da34-4f08-b14c-8dcdfe906de7)

![Screenshot 2024-12-05 at 1 24 48 PM](https://github.com/user-attachments/assets/d65b13dd-a381-4724-9af2-fa39f235aa21)
