### PR TITLE
Use URI::MailTo::EMAIL_REGEX instead of bespoke regex

### DIFF
--- a/app/forms/contact_email_form.rb
+++ b/app/forms/contact_email_form.rb
@@ -4,6 +4,6 @@
 class ContactEmailForm < ApplicationForm
   attribute :email, :string
   validates :email, presence: true, format: {
-    with: /\A[^@]+@([a-z0-9-]+\.)+[a-z]{2,4}\z/
+    with: URI::MailTo::EMAIL_REGEXP
   }
 end


### PR DESCRIPTION
I didn't initially see any helpers like this on the initial PR, but found this used in [H2](https://github.com/sul-dlss/happy-heron/blob/main/app/models/user.rb#L17C15-L17C46) for email validation. We should probably avoid bespoke regex in cases like this.