### PR TITLE
Limit solargraph to Linux installs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,11 @@ end
 
 group :development do
   gem 'overmind'
+  # For Ruby IDE purposes on Linux platforms
+  if RUBY_PLATFORM.match?('x86_64-linux')
+    gem 'solargraph'
+    gem 'solargraph-rails'
+  end
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -74,8 +74,6 @@ end
 
 group :development do
   gem 'overmind'
-  gem 'solargraph' # For Ruby IDE purposes
-  gem 'solargraph-rails'
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,6 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     attr_extras (7.1.0)
-    backport (1.2.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
@@ -216,7 +215,6 @@ GEM
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
-    e2mmap (0.1.0)
     ed25519 (1.3.0)
     edtf (3.2.0)
       activesupport (>= 3.0, < 9.0)
@@ -266,7 +264,6 @@ GEM
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jaro_winkler (1.6.0)
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -285,10 +282,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kramdown (2.5.1)
-      rexml (>= 3.3.9)
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -409,14 +402,11 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (2.8.4)
     rdoc (6.8.1)
       psych (>= 4.0.0)
     regexp_parser (2.9.3)
     reline (0.5.12)
       io-console (~> 0.5)
-    reverse_markdown (2.1.1)
-      nokogiri
     rexml (3.3.9)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
@@ -483,25 +473,6 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
-    solargraph (0.50.0)
-      backport (~> 1.2)
-      benchmark
-      bundler (~> 2.0)
-      diff-lcs (~> 1.4)
-      e2mmap
-      jaro_winkler (~> 1.5)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.1)
-      parser (~> 3.0)
-      rbs (~> 2.0)
-      reverse_markdown (~> 2.0)
-      rubocop (~> 1.38)
-      thor (~> 1.0)
-      tilt (~> 2.0)
-      yard (~> 0.9, >= 0.9.24)
-    solargraph-rails (1.1.0)
-      activesupport
-      solargraph
     solid_cable (3.0.2)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -532,7 +503,6 @@ GEM
       diff-lcs
       patience_diff
     thor (1.3.2)
-    tilt (2.4.0)
     timeout (0.4.2)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
@@ -568,7 +538,6 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.37)
     zeitwerk (2.7.1)
 
 PLATFORMS
@@ -617,8 +586,6 @@ DEPENDENCIES
   rubocop-rspec_rails
   selenium-webdriver
   simplecov
-  solargraph
-  solargraph-rails
   solid_cable
   solid_cache
   solid_queue

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     attr_extras (7.1.0)
+    backport (1.2.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
@@ -215,6 +216,7 @@ GEM
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
+    e2mmap (0.1.0)
     ed25519 (1.3.0)
     edtf (3.2.0)
       activesupport (>= 3.0, < 9.0)
@@ -264,6 +266,7 @@ GEM
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jaro_winkler (1.6.0)
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -282,6 +285,10 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -402,11 +409,14 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rbs (2.8.4)
     rdoc (6.8.1)
       psych (>= 4.0.0)
     regexp_parser (2.9.3)
     reline (0.5.12)
       io-console (~> 0.5)
+    reverse_markdown (2.1.1)
+      nokogiri
     rexml (3.3.9)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
@@ -473,6 +483,25 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
+    solargraph (0.50.0)
+      backport (~> 1.2)
+      benchmark
+      bundler (~> 2.0)
+      diff-lcs (~> 1.4)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      parser (~> 3.0)
+      rbs (~> 2.0)
+      reverse_markdown (~> 2.0)
+      rubocop (~> 1.38)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
+    solargraph-rails (1.1.0)
+      activesupport
+      solargraph
     solid_cable (3.0.2)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -503,6 +532,7 @@ GEM
       diff-lcs
       patience_diff
     thor (1.3.2)
+    tilt (2.4.0)
     timeout (0.4.2)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
@@ -538,6 +568,7 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.37)
     zeitwerk (2.7.1)
 
 PLATFORMS
@@ -586,6 +617,8 @@ DEPENDENCIES
   rubocop-rspec_rails
   selenium-webdriver
   simplecov
+  solargraph
+  solargraph-rails
   solid_cable
   solid_cache
   solid_queue


### PR DESCRIPTION
Erb formatting has been broken in VSCode for weeks, which has been driving me crazy. Finally tracked it down: https://github.com/Shopify/ruby-lsp/issues/2282