### PR TITLE
Small labeling updates to match the designs

### DIFF
--- a/app/views/collections/form.html.erb
+++ b/app/views/collections/form.html.erb
@@ -1,25 +1,19 @@
 <%= render Elements::HeaderComponent.new(level: :h1, variant: :h2, text: @collection_form.title || 'Untitled collection', classes: 'mb-3') %>
 <%= render Elements::AlertComponent.new(variant: :danger, value: I18n.t('collections.edit.errors.validation')) if @collection_form.errors.present? %>
 <%= render Elements::TabForm::TabListComponent.new(model: @collection_form, hidden_fields: %i[lock version]) do |component| %>
-  <% component.with_tab(label: I18n.t('collections.edit.panes.title.tab_label'), tab_name: :title, selected: true) %>
-  <% component.with_tab(label: I18n.t('collections.edit.panes.description.tab_label'), tab_name: :description) %>
-  <% component.with_tab(label: I18n.t('collections.edit.panes.related_content.tab_label'), tab_name: :related_content) %>
+  <% component.with_tab(label: I18n.t('collections.edit.panes.details.tab_label'), tab_name: :details, selected: true) %>
+  <% component.with_tab(label: I18n.t('collections.edit.panes.related_links.tab_label'), tab_name: :related_links) %>
   <% component.with_tab(label: I18n.t('collections.edit.panes.deposit.tab_label'), tab_name: :deposit) %>
   <%# The panes below need a form in order to render their contents. This provides a "fake" form to use for that purpose. %>
   <%# TabListComponent will render the actual form. %>
   <% form_with(model: @collection_form) do |form| %>
-    <% component.with_pane(tab_name: :title, label: I18n.t('collections.edit.panes.title.label'), selected: true, form:) do %>
-      <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :title, label: I18n.t('collections.edit.fields.title.label'),
-                                                         help_text: I18n.t('collections.edit.fields.title.help_text')) %>
-    <% end %>
-
-    <% component.with_pane(tab_name: :description, label: I18n.t('collections.edit.panes.description.label'), form:) do %>
-      <p><%= t('collections.edit.fields.description.help_text') %></p>
+    <% component.with_pane(tab_name: :details, label: I18n.t('collections.edit.panes.details.label'), selected: true, form:) do %>
+      <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :title, label: I18n.t('collections.edit.fields.title.label')) %>
       <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :description, label: I18n.t('collections.edit.fields.description.label')) %>
     <% end %>
 
-    <% component.with_pane(tab_name: :related_content, label: I18n.t('collections.edit.panes.related_content.label'), form:) do %>
-      <%= render NestedComponentPresenter.for(form:, field_name: :related_links, model_class: RelatedLinkForm, form_component: RelatedLinks::EditComponent) %>
+    <% component.with_pane(tab_name: :related_links, label: I18n.t('collections.edit.panes.related_links.label'), form:) do %>
+      <%= render NestedComponentPresenter.for(form:, field_name: :related_links, model_class: RelatedLinkForm, form_component: RelatedLinks::EditComponent, hidden_label: true) %>
     <% end %>
 
     <% component.with_pane(tab_name: :deposit, label: I18n.t('collections.edit.panes.deposit.label'), form:, render_footer: false) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,9 +148,9 @@ en:
             Enter a summary statement (max 600 words) describing the collection that you are creating.
             A detailed statement may improve the discovery of your collection in web searches.
         title:
-          label: 'Title of collection'
+          label: 'Collection name'
           help_text: >
-            A unique, descriptive title may improve discovery of your collection in web searches.
+            A unique, descriptive name may improve discovery of your collection in web searches.
         license:
           label: 'License'
           help_text: Assigning a default license may improve discovery of your collection in web searches.
@@ -178,9 +178,9 @@ en:
           label: 'License'
           help_text: >
             More text here.
-        related_content:
-          tab_label: 'Related content (optional)'
-          label: 'Related content'
-        title:
-          tab_label: 'Title'
-          label: 'Title of collection'
+        related_links:
+          tab_label: 'Related links'
+          label: 'Links to related content (optional)'
+        details:
+          tab_label: 'Details'
+          label: 'Collection details'

--- a/spec/system/create_collection_deposit_spec.rb
+++ b/spec/system/create_collection_deposit_spec.rb
@@ -40,28 +40,20 @@ RSpec.describe 'Create a collection deposit' do
     expect(page).to have_css('h1', text: 'Untitled collection')
 
     # Testing tabs
-    expect(page).to have_css('.nav-link.active', text: 'Title')
-    expect(page).to have_css('.nav-link:not(.active)', text: 'Description')
+    expect(page).to have_css('.nav-link.active', text: 'Details')
+    expect(page).to have_css('.nav-link:not(.active)', text: 'Related links')
     # Manage files pane with form field is visible, abstract is not
-    expect(page).to have_css('div.h4', text: 'Title')
-    expect(page).to have_no_text('Describe your collection')
+    expect(page).to have_css('div.h4', text: 'Collection details')
 
-    # Filling in title
-    find('.nav-link', text: 'Title').click
+    # Filling in title and description
+    find('.nav-link', text: 'Details').click
     fill_in('collection_title', with: collection_title_fixture)
-
-    # Click Next to go to abstract tab
-    click_link_or_button('Next')
-    expect(page).to have_css('.nav-link.active', text: 'Description')
-    expect(page).to have_text('Describe your collection')
-
-    # Filling in abstract
     fill_in('collection_description', with: collection_description_fixture)
 
     # Clicking on Next to go to related content tab
     click_link_or_button('Next')
-    expect(page).to have_css('.nav-link.active', text: 'Related content (optional)')
-    expect(page).to have_text('Related links')
+    expect(page).to have_css('.nav-link.active', text: 'Related links')
+    expect(page).to have_text('Links to related content (optional)')
 
     # Filling in related links
     fill_in('Link text', with: related_links_fixture.first['text'])

--- a/spec/system/create_collection_draft_spec.rb
+++ b/spec/system/create_collection_draft_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Create a collection draft' do
     expect(page).to have_css('h1', text: 'Untitled collection')
 
     # Title is required.
-    find('.nav-link', text: 'Title').click
+    find('.nav-link', text: 'Details').click
     click_link_or_button('Save as draft')
 
     # Validation fails for title.

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -56,13 +56,13 @@ RSpec.describe 'Edit a collection' do
 
     expect(page).to have_css('h1', text: collection_title_fixture)
 
-    find('.nav-link', text: 'Title').click
-    expect(page).to have_field('Title of collection', with: collection_title_fixture)
+    find('.nav-link', text: 'Details').click
+    expect(page).to have_field('Collection name', with: collection_title_fixture)
 
-    fill_in('Title of collection', with: updated_title)
+    fill_in('Collection name', with: updated_title)
 
     # Testing validation
-    find('.nav-link', text: 'Description').click
+    find('.nav-link', text: 'Details').click
     fill_in('collection_description', with: '')
     find('.nav-link', text: 'Deposit').click
     click_link_or_button('Deposit')
@@ -72,7 +72,7 @@ RSpec.describe 'Edit a collection' do
     fill_in('collection_description', with: updated_description)
 
     # Filling in related content
-    find('.nav-link', text: 'Related content (optional)').click
+    find('.nav-link', text: 'Related links').click
     fill_in('Link text', with: 'delete')
     fill_in('URL', with: 'me')
     # Test adding a new nested field

--- a/spec/system/validate_collection_deposit_spec.rb
+++ b/spec/system/validate_collection_deposit_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe 'Validate a collection deposit' do
     expect(page).to have_css('h1', text: 'Untitled collection')
 
     # Filling in title
-    find('.nav-link', text: 'Title').click
+    find('.nav-link', text: 'Details').click
     fill_in('collection_title', with: collection_title_fixture)
 
     # Description is required for deposit, but skipping.
 
     # Clicking on related content tab & filling in related link text and *not* URL (which is required for deposit)
-    find('.nav-link', text: 'Related content (optional)').click
-    expect(page).to have_css('.nav-link.active', text: 'Related content (optional)')
+    find('.nav-link', text: 'Related links').click
+    expect(page).to have_css('.nav-link.active', text: 'Related links')
     fill_in('Link text', with: related_links_fixture.first['text'])
 
     # Depositing the work
@@ -38,7 +38,7 @@ RSpec.describe 'Validate a collection deposit' do
     expect(page).to have_css('.alert-danger', text: 'Required fields have not been filled out.')
 
     # Description is marked invalid
-    expect(page).to have_css('.nav-link.active', text: 'Description')
+    expect(page).to have_css('.nav-link.active', text: 'Details')
     expect(page).to have_css('textarea.is-invalid#collection_description')
     expect(page).to have_css('.invalid-feedback.is-invalid', text: "can't be blank")
 
@@ -46,8 +46,8 @@ RSpec.describe 'Validate a collection deposit' do
     fill_in('Description', with: collection_description_fixture)
 
     # Related content is marked invalid
-    expect(page).to have_css('.nav-link', text: 'Related content (optional)')
-    find('.nav-link', text: 'Related content (optional)').click
+    expect(page).to have_css('.nav-link', text: 'Related links')
+    find('.nav-link', text: 'Related links').click
     expect(page).to have_field('collection_related_links_attributes_0_url', class: 'is-invalid')
     expect(page).to have_css('.invalid-feedback.is-invalid', text: "can't be blank")
 


### PR DESCRIPTION
Fixes #270 
Fixes #271 

Small update to the labels on the collection form to match the figma designs.

![Screenshot 2024-12-06 at 1 58 03 PM](https://github.com/user-attachments/assets/0d122cc6-2180-4d3c-93cc-60b91ef28a3d)
