### PR TITLE
Do not return () when related works are empty

### DIFF
--- a/app/forms/related_work_form.rb
+++ b/app/forms/related_work_form.rb
@@ -28,6 +28,8 @@ class RelatedWorkForm < ApplicationForm
   end
 
   def to_s
+    return if relationship.blank? # otherwise it will return " ()"
+
     "#{identifier.presence || citation} (#{relationship})"
   end
 end


### PR DESCRIPTION
Fixes #266 

The relationship was always added in the `to_s` method even when blank resulting in the "()" display if there were no related works.

This clears that up and still presents properly when a related work is included.

When blank:
![Screenshot 2024-12-06 at 2 59 57 PM](https://github.com/user-attachments/assets/aa363095-d63f-45cd-8973-bdccd3cce7eb)

When populated:
![Screenshot 2024-12-06 at 2 58 51 PM](https://github.com/user-attachments/assets/5af27bd9-6d15-49c7-885a-9db6786a6305)
