### PR TITLE
Add keywords to the work form

### DIFF
--- a/app/components/elements/forms/repeatable_nested_component.html.erb
+++ b/app/components/elements/forms/repeatable_nested_component.html.erb
@@ -2,11 +2,11 @@
   <legend class="h5">
     <%= render Elements::Forms::LabelComponent.new(form:, field_name:, label_text:, hidden_label:) %>
   </legend>
-  <%= tag.div(class: 'mb-3 container', data: { nested_form_target: 'container' }) do %>
+  <%= tag.div(class: container_classes, data: { nested_form_target: 'container' }) do %>
     <template data-nested-form-target="template">
       <%= form.fields_for field_name, model_class.new, child_index: 'NEW_RECORD' do |nested_form| %>
         <%# Note that this div is duplicated below. If making a change here, also make the change below. %>
-        <%= tag.div(class: classes, data: { index: nested_form.options[:child_index], nested_form_target: 'instance' }) do %>
+        <%= tag.div(class: row_classes, data: { index: nested_form.options[:child_index], nested_form_target: 'instance' }) do %>
           <div class="col">
             <%= render form_component.new(form: nested_form) %>
           </div>
@@ -20,7 +20,7 @@
     </template>
     <%= form.fields_for field_name do |nested_form| %>
       <%# Note that this div is duplicated above. If making a change here, also make the change above. %>
-      <%= tag.div(class: classes, data: { index: nested_form.options[:child_index], nested_form_target: 'instance' }) do %>
+      <%= tag.div(class: row_classes, data: { index: nested_form.options[:child_index], nested_form_target: 'instance' }) do %>
         <div class="col">
           <%= render form_component.new(form: nested_form) %>
         </div>

--- a/app/components/elements/forms/repeatable_nested_component.rb
+++ b/app/components/elements/forms/repeatable_nested_component.rb
@@ -15,20 +15,18 @@ module Elements
         super()
       end
 
-      attr_reader :form, :model_class, :field_name, :form_component, :hidden_label
+      attr_reader :form, :model_class, :field_name, :form_component, :hidden_label, :bordered
 
       def add_button_label
         "+ Add another #{model_class.model_name.singular.humanize(capitalize: false)}"
       end
 
-      def classes
-        merge_classes(%w[mb-3 row], bordered_classes)
+      def container_classes
+        merge_classes(%w[mb-3 container], bordered ? [] : %w[p-0])
       end
 
-      def bordered_classes
-        return [] unless @bordered
-
-        %w[p-3 border border-3 border-light-subtle border-opacity-75]
+      def row_classes
+        merge_classes(%w[row], bordered ? %w[p-3 border border-3 border-light-subtle border-opacity-75 mb-3] : [])
       end
 
       def label_text

--- a/app/components/keywords/edit_component.html.erb
+++ b/app/components/keywords/edit_component.html.erb
@@ -1,0 +1,1 @@
+<%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :text, label: helpers.t('keyword.edit.fields.text.label')) %>

--- a/app/components/keywords/edit_component.rb
+++ b/app/components/keywords/edit_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Keywords
+  # Component for editing keywords
+  class EditComponent < ApplicationComponent
+    def initialize(form:)
+      @form = form
+      super()
+    end
+
+    attr_reader :form
+  end
+end

--- a/app/forms/keyword_form.rb
+++ b/app/forms/keyword_form.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Form for keywords
+class KeywordForm < ApplicationForm
+  attribute :text, :string
+  validates :text, presence: true, if: :deposit?
+end

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -2,7 +2,7 @@
 
 # Form for a Work
 class WorkForm < ApplicationForm
-  accepts_nested_attributes_for :related_links, :related_works, :publication_date, :contact_emails
+  accepts_nested_attributes_for :related_links, :related_works, :publication_date, :contact_emails, :keywords
 
   def self.immutable_attributes
     ['druid']

--- a/app/services/cocina_description_support.rb
+++ b/app/services/cocina_description_support.rb
@@ -42,6 +42,17 @@ class CocinaDescriptionSupport
     end.compact_blank
   end
 
+  def self.keywords(keywords:)
+    keywords.map do |keyword|
+      # Since keyword is either a Hash or an instance of KeywordForm,
+      # we need to make it a hash of the attributes if it's a KeywordForm
+      keyword = keyword.attributes if keyword.respond_to?(:attributes)
+      next if keyword['text'].blank?
+
+      { value: keyword['text'] }
+    end.compact_blank
+  end
+
   def self.related_links(related_links:)
     related_links.map do |related_link|
       # NOTE: Sometimes this is an array of hashes and sometimes it's an array of RelatedLinkForm instances

--- a/app/services/cocina_support.rb
+++ b/app/services/cocina_support.rb
@@ -20,6 +20,16 @@ class CocinaSupport
     end.presence
   end
 
+  def self.keywords_for(cocina_object:)
+    return nil if cocina_object.description.subject.blank?
+
+    cocina_object.description.subject.filter_map do |subject|
+      next if subject.value.blank?
+
+      { 'text' => subject.value }
+    end.presence
+  end
+
   def self.related_links_for(cocina_object:) # rubocop:disable Metrics/AbcSize
     return nil if cocina_object.description.relatedResource.blank?
 

--- a/app/services/to_cocina/work/description_mapper.rb
+++ b/app/services/to_cocina/work/description_mapper.rb
@@ -33,7 +33,7 @@ module ToCocina
           # contributor: contributors_params.presence,
           note: note_params,
           event: event_params,
-          # subject: subject_params.presence,
+          subject: CocinaDescriptionSupport.keywords(keywords: work_form.keywords_attributes),
           purl: Sdr::Purl.from_druid(druid: work_form.druid),
           relatedResource: CocinaDescriptionSupport.related_works(related_works: work_form.related_works_attributes) +
             CocinaDescriptionSupport.related_links(related_links: work_form.related_links_attributes),

--- a/app/services/to_cocina/work/mapper.rb
+++ b/app/services/to_cocina/work/mapper.rb
@@ -35,12 +35,12 @@ module ToCocina
           externalIdentifier: work_form.druid,
           type: Cocina::Models::ObjectType.object,
           label: work_form.title,
-          description: ToCocina::Work::DescriptionMapper.call(work_form:),
+          description: DescriptionMapper.call(work_form:),
           version: work_form.version,
           access:,
           identification: { sourceId: source_id },
           administrative: { hasAdminPolicy: Settings.apo },
-          structural: ToCocina::Work::StructuralMapper.call(work_form:, content:)
+          structural: StructuralMapper.call(work_form:, content:)
         }.compact
       end
 

--- a/app/services/to_work_form/mapper.rb
+++ b/app/services/to_work_form/mapper.rb
@@ -28,6 +28,7 @@ module ToWorkForm
         contact_emails_attributes: CocinaSupport.contact_emails_for(cocina_object:),
         related_works_attributes: CocinaSupport.related_works_for(cocina_object:),
         related_links_attributes: CocinaSupport.related_links_for(cocina_object:),
+        keywords_attributes: CocinaSupport.keywords_for(cocina_object:),
         license: cocina_object.access.license,
         version: cocina_object.version,
         collection_druid: CocinaSupport.collection_druid_for(cocina_object:),

--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -35,6 +35,7 @@
     <% component.with_pane(tab_name: :abstract, label: t('works.edit.panes.abstract.label'), form:) do %>
       <p><%= t('works.edit.fields.abstract.help_text') %></p>
       <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :abstract, label: t('works.edit.fields.abstract.label')) %>
+      <%= render NestedComponentPresenter.for(form:, field_name: :keywords, model_class: KeywordForm, form_component: Keywords::EditComponent, hidden_label: false, bordered: false) %>
     <% end %>
 
     <% component.with_pane(tab_name: :dates, label: t('works.edit.panes.dates.label'), form:) do %>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -15,8 +15,9 @@
   <% component.with_row(label: 'Publication date', values: [@work_form.publication_date.to_s]) %>
 <% end %>
 
-<%= render Elements::Tables::TableComponent.new(id: 'description-table', classes: 'table-show mb-5', label: 'Description') do |component| %>
+<%= render Elements::Tables::TableComponent.new(id: 'description-table', classes: 'table-show mb-5', label: 'Abstract and keywords') do |component| %>
   <% component.with_row(label: 'Abstract', values: [@work_form.abstract]) %>
+  <% component.with_row(label: 'Keywords', values: [@work_form.keywords_attributes.map(&:text).join(', ')]) %>
 <% end %>
 
 <%= render Elements::Tables::TableComponent.new(id: 'related-content-table', classes: 'table-show mb-5', label: 'Related content') do |component| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,11 @@ en:
       fields:
         email:
           label: 'Contact email'
+  keyword:
+    edit:
+      fields:
+        text:
+          label: 'Keywords (one per box)'
   related_links:
     edit:
       fields:
@@ -118,8 +123,8 @@ en:
           the left to correct the error(s) and then try depositing again.
       panes:
         abstract:
-          tab_label: 'Abstract'
-          label: 'Describe your deposit'
+          tab_label: 'Abstract & keywords'
+          label: 'Abstract'
         dates:
           tab_label: 'Dates (optional)'
           label: 'Enter dates related to your deposit'

--- a/spec/serializers/work_form_serializer_spec.rb
+++ b/spec/serializers/work_form_serializer_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe WorkFormSerializer do
       'related_works_attributes' => related_works_fixture,
       'license' => license_fixture,
       'publication_date_attributes' => publication_date_fixture,
-      'contact_emails_attributes' => contact_email_fixture,
+      'contact_emails_attributes' => contact_emails_fixture,
+      'keywords_attributes' => keywords_fixture,
       'content_id' => 5
     }
   end
@@ -25,7 +26,8 @@ RSpec.describe WorkFormSerializer do
     WorkForm.new(title: title_fixture, druid:, collection_druid: collection_druid_fixture, abstract: abstract_fixture,
                  related_links_attributes: related_links_fixture, related_works_attributes: related_works_fixture,
                  license: license_fixture, publication_date_attributes: publication_date_fixture,
-                 contact_emails_attributes: contact_email_fixture, content_id: 5)
+                 contact_emails_attributes: contact_emails_fixture, keywords_attributes: keywords_fixture,
+                 content_id: 5)
   end
 
   describe '.serialize?' do

--- a/spec/support/work_fixtures.rb
+++ b/spec/support/work_fixtures.rb
@@ -46,13 +46,24 @@ def related_works_fixture
   ]
 end
 
-def contact_email_fixture
+def contact_emails_fixture
   [
     {
       'email' => 'aperson@example.com'
     },
     {
       'email' => 'anotherperson@example.com'
+    }
+  ]
+end
+
+def keywords_fixture
+  [
+    {
+      'text' => 'Biology'
+    },
+    {
+      'text' => 'Chemistry'
     }
   ]
 end

--- a/spec/support/work_mapping_fixtures.rb
+++ b/spec/support/work_mapping_fixtures.rb
@@ -12,7 +12,8 @@ module WorkMappingFixtures
       license: license_fixture,
       collection_druid: collection_druid_fixture,
       publication_date_attributes: { year: '2024', month: '12' },
-      contact_emails_attributes: contact_email_fixture
+      contact_emails_attributes: contact_emails_fixture,
+      keywords_attributes: keywords_fixture
     )
   end
 
@@ -65,11 +66,12 @@ module WorkMappingFixtures
         label: title_fixture,
         description: {
           title: CocinaDescriptionSupport.title(title: title_fixture),
+          subject: CocinaDescriptionSupport.keywords(keywords: keywords_fixture),
           event: [CocinaDescriptionSupport.event_date(type: 'publication', date: '2024-12', primary: true)],
           note: [CocinaDescriptionSupport.note(type: 'abstract', value: abstract_fixture)],
           relatedResource: CocinaDescriptionSupport.related_works(related_works: related_works_fixture) +
                            CocinaDescriptionSupport.related_links(related_links: related_links_fixture),
-          access: { accessContact: CocinaDescriptionSupport.contact_emails(contact_emails: contact_email_fixture) }
+          access: { accessContact: CocinaDescriptionSupport.contact_emails(contact_emails: contact_emails_fixture) }
         },
         version: 1,
         identification: { sourceId: source_id_fixture },
@@ -129,17 +131,17 @@ module WorkMappingFixtures
   def dro_fixture # rubocop:disable Metrics/AbcSize
     Cocina::Models.build(
       {
-
         externalIdentifier: druid_fixture,
         type: Cocina::Models::ObjectType.object,
         label: title_fixture,
         description: {
           title: CocinaDescriptionSupport.title(title: title_fixture),
+          subject: CocinaDescriptionSupport.keywords(keywords: keywords_fixture),
           event: [CocinaDescriptionSupport.event_date(type: 'publication', date: '2024-12', primary: true)],
           note: [CocinaDescriptionSupport.note(type: 'abstract', value: abstract_fixture)],
           relatedResource: CocinaDescriptionSupport.related_works(related_works: related_works_fixture) +
                            CocinaDescriptionSupport.related_links(related_links: related_links_fixture),
-          access: { accessContact: CocinaDescriptionSupport.contact_emails(contact_emails: contact_email_fixture) },
+          access: { accessContact: CocinaDescriptionSupport.contact_emails(contact_emails: contact_emails_fixture) },
           purl: Sdr::Purl.from_druid(druid: druid_fixture)
         },
         version: 2,

--- a/spec/system/create_work_deposit_spec.rb
+++ b/spec/system/create_work_deposit_spec.rb
@@ -56,15 +56,17 @@ RSpec.describe 'Create a work deposit' do
     # Filling in title
     find('.nav-link', text: 'Title & contact').click
     fill_in('work_title', with: title_fixture)
-    fill_in('Contact email', with: contact_email_fixture.first['email'])
+    fill_in('Contact email', with: contact_emails_fixture.first['email'])
 
     # Click Next to go to abstract tab
     click_link_or_button('Next')
     expect(page).to have_css('.nav-link.active', text: 'Abstract')
-    expect(page).to have_text('Describe your deposit')
+    expect(page).to have_text('Abstract')
 
-    # Filling in abstract
+    # Filling in abstract & keywords
     fill_in('work_abstract', with: abstract_fixture)
+    expect(page).to have_text('Keywords')
+    fill_in('Keywords (one per box)', with: keywords_fixture.first['text'])
 
     # Clicking on Next to go to dates tab
     click_link_or_button('Next')

--- a/spec/system/create_work_draft_spec.rb
+++ b/spec/system/create_work_draft_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Create a work draft' do
 
     # Filling in title
     fill_in('work_title', with: title_fixture)
-    fill_in('Contact email', with: contact_email_fixture.first['email'])
+    fill_in('Contact email', with: contact_emails_fixture.first['email'])
 
     # This should work now.
     click_link_or_button('Save as draft')

--- a/spec/system/edit_work_spec.rb
+++ b/spec/system/edit_work_spec.rb
@@ -8,18 +8,16 @@ RSpec.describe 'Edit a work' do
 
   let(:druid) { druid_fixture }
   let(:user) { create(:user) }
-
   let(:cocina_object) do
     dro_with_metadata_fixture
   end
-
   let(:version_status) do
     instance_double(Dor::Services::Client::ObjectVersion::VersionStatus, open?: true, openable?: false,
                                                                          version: cocina_object.version)
   end
-
   let(:updated_title) { 'My new title' }
   let(:updated_abstract) { 'This is what my work is really about.' }
+  let(:updated_keywords) { ['First Keyword'] }
   let(:updated_related_links) do
     [
       {
@@ -66,7 +64,7 @@ RSpec.describe 'Edit a work' do
     fill_in('Title of deposit', with: updated_title)
 
     # Testing validation
-    find('.nav-link', text: 'Abstract').click
+    find('.nav-link', text: 'Abstract & keywords').click
     fill_in('work_abstract', with: '')
     find('.nav-link', text: 'Deposit').click
     click_link_or_button('Deposit')
@@ -74,6 +72,7 @@ RSpec.describe 'Edit a work' do
 
     # Filling in abstract
     fill_in('work_abstract', with: updated_abstract)
+    fill_in('work_keywords_attributes_1_text', with: updated_keywords.first)
 
     # Filling in related content, first related links
     find('.nav-link', text: 'Related content (optional)').click
@@ -105,6 +104,7 @@ RSpec.describe 'Edit a work' do
     # On show page
     expect(page).to have_css('h1', text: updated_title)
     expect(page).to have_content(updated_abstract)
+    expect(page).to have_content(updated_keywords.first)
     expect(page).to have_link(updated_related_links.first['text'], href: updated_related_links.first['url'])
     expect(page).to have_content('https://purl.stanford.edu/fake (references)')
     expect(page).to have_css('.status', text: 'New version in draft')

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -149,14 +149,16 @@ RSpec.describe 'Show a work' do
       expect(page).to have_css('tr', text: 'Title')
       expect(page).to have_css('td', text: work.title)
       expect(page).to have_css('tr', text: 'Contact emails')
-      expect(page).to have_css('td', text: contact_email_fixture.pluck(:email).join(', '))
+      expect(page).to have_css('td', text: contact_emails_fixture.pluck(:email).join(', '))
     end
 
     # Description table
     within('table#description-table') do
-      expect(page).to have_css('caption', text: 'Description')
+      expect(page).to have_css('caption', text: 'Abstract and keywords')
       expect(page).to have_css('tr', text: 'Abstract')
       expect(page).to have_css('td', text: abstract_fixture)
+      expect(page).to have_css('tr', text: 'Keywords')
+      expect(page).to have_css('td', text: keywords_fixture.pluck(:text).join(', '))
     end
 
     # Related Content table

--- a/spec/system/validate_work_deposit_spec.rb
+++ b/spec/system/validate_work_deposit_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Validate a work deposit' do
     # Filling in title
     find('.nav-link', text: 'Title & contact').click
     fill_in('work_title', with: title_fixture)
-    fill_in('Contact email', with: contact_email_fixture.first['email'])
+    fill_in('Contact email', with: contact_emails_fixture.first['email'])
 
     # Abstract is required for deposit, but skipping.
 


### PR DESCRIPTION
NOTE: This is the first half of the keywords implementation to get most of the pieces in place for creating and editing keywords. To be added: FAST support.

Connects to #57

![Screenshot from 2024-12-09 14-49-53](https://github.com/user-attachments/assets/cee9a09d-77f2-4037-9cdd-e6b6e9cb4115)
