### PR TITLE
Add the work detail section to the work show page

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -11,6 +11,7 @@ class WorksController < ApplicationController
   def show
     authorize! @work
     @status_presenter = StatusPresenter.new(status: @status)
+    @purl_link_presenter = PurlLinkPresenter.new(druid: @work.druid)
 
     # This updates the Work with the latest metadata from the Cocina object.
     # Does not update the Work's collection if the collection cannot be found.

--- a/app/presenters/purl_link_presenter.rb
+++ b/app/presenters/purl_link_presenter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Presenter for the Purl (persistent) link to the provided druid.
+class PurlLinkPresenter
+  include ActionView::Helpers::UrlHelper
+
+  # @param [druid] The druid to link to
+  # @param [label] The label for the link, default to nil
+  def initialize(druid:, label: nil)
+    @druid = druid
+    @label = label
+  end
+
+  def link
+    link_to(@label, Sdr::Purl.from_druid(druid: @druid)) if @druid # No druid yet, so H3 is depositing.
+  end
+end

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -6,6 +6,15 @@
   <%= render Elements::SpinnerComponent.new %>
 <% end %>
 
+<%= render Elements::Tables::TableComponent.new(id: 'details-table', classes: 'table-show mb-5', label: 'Details') do |component| %>
+  <% component.with_row(label: 'Persistent Link', values: [@purl_link_presenter.link]) %>
+  <%# TODO: Add DOIs when support is implemented for them %>
+  <% component.with_row(label: 'Collection', values: [link_to(@work.collection.title, collection_path(@work.collection))]) %>
+  <% component.with_row(label: 'Depositor', values: [@work.user.name]) %>
+  <% component.with_row(label: 'Version details', values: [@work_form.version]) %>
+  <% component.with_row(label: 'Deposit created', values: [l(@work.created_at, format: :long)]) %>
+<% end %>
+
 <%= render Elements::Tables::TableComponent.new(id: 'title-table', classes: 'table-show mb-5', label: 'Title and contact') do |component| %>
   <% component.with_row(label: 'Title', values: [@work_form.title]) %>
   <% component.with_row(label: 'Contact emails', values: [@work_form.contact_emails_attributes.map(&:email).join(', ')]) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,9 @@ en:
           attributes:
             email:
               format: '%{value} is not a valid email address'
+  time:
+    formats:
+      long: '%B %d, %Y'
   errors:
     not_authorized: 'You are not authorized to perform the requested action.'
   publication_date:

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -143,6 +143,21 @@ RSpec.describe 'Show a work' do
       expect(page).to have_no_css('td', text: 'my_file1.txt')
     end
 
+    # Details table
+    within('table#details-table') do
+      expect(page).to have_css('caption', text: 'Details')
+      expect(page).to have_css('tr', text: 'Persistent Link')
+      expect(page).to have_css('td', text: Sdr::Purl.from_druid(druid:))
+      expect(page).to have_css('tr', text: 'Collection')
+      expect(page).to have_css('td', text: collection.title)
+      expect(page).to have_css('tr', text: 'Depositor')
+      expect(page).to have_css('td', text: user.name)
+      expect(page).to have_css('tr', text: 'Version details')
+      expect(page).to have_css('td', text: '1')
+      expect(page).to have_css('tr', text: 'Deposit created')
+      expect(page).to have_css('td', text: I18n.l(Time.zone.now, format: :long))
+    end
+
     # Title table
     within('table#title-table') do
       expect(page).to have_css('caption', text: 'Title and contact')


### PR DESCRIPTION
Fixes #267 

Adds the details section to the work show page per the figma designs.

<img width="1323" alt="Screenshot 2024-12-10 at 10 18 05 AM" src="https://github.com/user-attachments/assets/b4ce63fa-4254-48bd-ae14-d2b30dfc7dee">
