### PR TITLE
Refactor toggle

### DIFF
--- a/app/components/contributors/edit_component.html.erb
+++ b/app/components/contributors/edit_component.html.erb
@@ -1,8 +1,23 @@
 
 <div data-controller="contributors">
   <%= render Elements::Forms::ToggleComponent.new(form:, field_name: :role_type,
-                                                  label: t('works.edit.fields.contributors.role_type.label'),
-                                                  options: role_type_options) %>
+                                                  label: t('works.edit.fields.contributors.role_type.label')) do |component| %>
+    <% component.with_toggle_option(form:,
+                                    field_name: :role_type,
+                                    label: t('works.edit.fields.contributors.role_type.person.label'),
+                                    value: 'person',
+                                    data: { contributors_target: 'contributorTypePerson' },
+                                    label_data: { contributors_target: 'contributorTypePersonLabel',
+                                                  action: 'click->contributors#contributorTypePersonSelected' }) %>
+    <% component.with_toggle_option(form:,
+                                    field_name: :role_type,
+                                    label: t('works.edit.fields.contributors.role_type.organization.label'),
+                                    value: 'organization',
+                                    data: { contributors_target: 'contributorTypeOrganization' },
+                                    label_data: { contributors_target: 'contributorTypeOrganizationLabel',
+                                                  action: 'click->contributors#contributorTypeOrganizationSelected' }) %>
+  <% end %>
+
   <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :person_role,
                                                        options: PERSON_ROLES, label: t('works.edit.fields.contributors.role.label'),
                                                        data: { contributors_target: 'selectPersonRole' }) %>
@@ -21,7 +36,6 @@
     <div class="form-check">
       <%= form.radio_button :with_orcid, false, class: 'form-check-input', checked: true %>
       <%= form.label :with_orcid_false, 'Name', class: 'form-check-label' %>
-      <!-- author name fields -->
     </div>
     <%= render Elements::Forms::InvalidFeedbackComponent.new(form:, field_name: :with_orcid) %>
     <div class="row">

--- a/app/components/contributors/edit_component.rb
+++ b/app/components/contributors/edit_component.rb
@@ -10,19 +10,6 @@ module Contributors
 
     attr_reader :form
 
-    def role_type_options
-      [{ 'value' => 'person',
-         'label' => 'Individual',
-         'data' => { contributors_target: 'contributorTypePerson' },
-         'label_data' => { contributors_target: 'contributorTypePersonLabel',
-                           action: 'click->contributors#contributorTypePersonSelected' } },
-       { 'value' => 'organization',
-         'label' => 'Organization',
-         'data' => { contributors_target: 'contributorTypeOrganization' },
-         'label_data' => { contributors_target: 'contributorTypeOrganizationLabel',
-                           action: 'click->contributors#contributorTypeOrganizationSelected' } }]
-    end
-
     PERSON_ROLES = [
       ['Author', 'author'],
       ['Advisor', 'advisor'],

--- a/app/components/elements/forms/toggle_component.html.erb
+++ b/app/components/elements/forms/toggle_component.html.erb
@@ -1,11 +1,9 @@
 <div class="mb-4">
   <%= render Elements::Forms::LabelComponent.new(form:, field_name:, label_text: label) %><br>
   <div class="btn-group" role="group">
-      <% options.each do |option| %>
-        <%= form.radio_button field_name, option['value'], type: 'radio', class: 'btn-check', data: option['data'] %>
-        <%# Actions must be triggered by button label, which overlays radio %>
-        <%= form.label field_name, option['label'], value: option['value'], class: 'btn btn-outline-primary', data: option['label_data'] %>
+      <% toggle_options.each do |option| %>
+        <%= option %>
       <% end %>
-    </div>
+  </div>
   <%= render Elements::Forms::InvalidFeedbackComponent.new(form:, field_name:) %>
 </div>

--- a/app/components/elements/forms/toggle_component.rb
+++ b/app/components/elements/forms/toggle_component.rb
@@ -4,12 +4,7 @@ module Elements
   module Forms
     # Component for a toggle-like radio button group field
     class ToggleComponent < FieldComponent
-      def initialize(options:, **)
-        @options = options
-        super(**)
-      end
-
-      attr_reader :options
+      renders_many :toggle_options, Elements::Forms::ToggleOptionComponent
     end
   end
 end

--- a/app/components/elements/forms/toggle_option_component.html.erb
+++ b/app/components/elements/forms/toggle_option_component.html.erb
@@ -1,0 +1,3 @@
+<%= form.radio_button field_name, value, type: 'radio', class: 'btn-check', data: %>
+<%# Actions must be triggered by button label, which overlays radio %>
+<%= form.label field_name, label, value:, class: 'btn btn-outline-primary', data: label_data %>

--- a/app/components/elements/forms/toggle_option_component.rb
+++ b/app/components/elements/forms/toggle_option_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Elements
+  module Forms
+    # Component for a toggle option
+    class ToggleOptionComponent < ApplicationComponent
+      def initialize(form:, field_name:, label:, value:, data:, label_data:) # rubocop:disable Metrics/ParameterLists
+        @form = form
+        @field_name = field_name
+        @label = label
+        @value = value
+        @data = data
+        @label_data = label_data
+        super()
+      end
+
+      attr_reader :form, :field_name, :label, :value, :data, :label_data
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,10 @@ en:
             label: 'Role'
           role_type:
             label: 'Role type'
+            person:
+              label: 'Individual'
+            organization:
+              label: 'Organization'
           orcid_or_name:
             label: 'ORCID iD or Name'
           orcid:

--- a/spec/components/elements/forms/toggle_component_spec.rb
+++ b/spec/components/elements/forms/toggle_component_spec.rb
@@ -7,15 +7,17 @@ RSpec.describe Elements::Forms::ToggleComponent, type: :component do
   let(:author_form) { AuthorForm.new }
   let(:field_name) { 'role_type' }
   let(:label) { 'Role Type' }
-  let(:options) do
-    [{ 'label' => 'Type 1', 'value' => 'type1', 'data' => { test: 'test_data' },
-       'label_data' => { action: 'label_test_data1' } },
-     { 'label' => 'Type 2', 'value' => 'type2', 'data' => { test: 'more_test_data' },
-       'label_data' => { action: 'label_test_data2' } }]
+  let(:component) { described_class.new(form:, field_name:, label:) }
+
+  before do
+    component.with_toggle_option(form:, field_name:, label: 'Type 1', value: 'type1', data: { test: 'test_data' },
+                                 label_data: { action: 'label_test_data1' })
+    component.with_toggle_option(form:, field_name:, label: 'Type 2', value: 'type2', data: { test: 'more_test_data' },
+                                 label_data: { action: 'label_test_data2' })
   end
 
   it 'creates toggle field with label' do
-    render_inline(described_class.new(form: form, field_name:, options:, label:))
+    render_inline(component)
     expect(page).to have_css('label.form-label:not(.visually-hidden)', text: 'Role Type')
     expect(page).to have_css('input[type="radio"]:not(.is-invalid)')
     expect(page).to have_css('input[data-test="test_data"]')


### PR DESCRIPTION
Fixes #339 to use slots to render the options in the toggle, as a follow-up to #113.