### PR TITLE
No empty author row content

### DIFF
--- a/app/components/works/show/authors_show_component.html.erb
+++ b/app/components/works/show/authors_show_component.html.erb
@@ -1,4 +1,4 @@
-<%= render Elements::Tables::TableComponent.new(id: 'authors-table', classes: 'table-work mb-5', label: 'Authors') do |component| %>
+<%= render Elements::Tables::TableComponent.new(id: 'authors-table', classes: 'table-work mb-5', label: 'Author(s)') do |component| %>
   <% component.with_header(headers:) %>
   <% work_presenter.authors.each do |author| %>
     <% component.with_row(values: values_for(author)) %>

--- a/app/components/works/show/authors_show_component.rb
+++ b/app/components/works/show/authors_show_component.rb
@@ -12,15 +12,18 @@ module Works
       attr_reader :work_presenter
 
       def headers
-        %w[Authors ORCID Role]
+        %w[Author ORCID Role]
       end
 
       def values_for(author)
-        [
+        values = [
           author_name(author),
           orcid_link(author),
           author_role_label(author)
         ]
+        return [] unless values.any?
+
+        values
       end
 
       private

--- a/spec/system/create_work_draft_spec.rb
+++ b/spec/system/create_work_draft_spec.rb
@@ -59,5 +59,6 @@ RSpec.describe 'Create a work draft' do
     expect(page).to have_css('h1', text: title_fixture)
     expect(page).to have_css('.status', text: 'Draft - Not deposited')
     expect(page).to have_link('Edit or deposit', href: edit_work_path(druid))
+    expect(page).to have_no_css('#authors-table td')
   end
 end

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -165,6 +165,17 @@ RSpec.describe 'Show a work' do
       expect(page).to have_css('td', text: contact_emails_fixture.pluck(:email).join(', '))
     end
 
+    # Authors
+    within('table#authors-table') do
+      expect(page).to have_css('caption', text: 'Author(s)')
+      expect(page).to have_css('th', text: 'Author')
+      expect(page).to have_css('th', text: 'ORCID')
+      expect(page).to have_css('th', text: 'Role')
+      expect(page).to have_css('td', text: authors_fixture.first['first_name'])
+      expect(page).to have_css('td', text: authors_fixture.first['last_name'])
+      expect(page).to have_css('td', text: authors_fixture.first['orcid'])
+    end
+
     # Description table
     within('table#description-table') do
       expect(page).to have_css('caption', text: 'Abstract and keywords')


### PR DESCRIPTION
Resolves #352 and avoids this display:

![Screenshot 2024-12-13 at 2 30 24 PM](https://github.com/user-attachments/assets/53aa3edc-3226-4519-b869-c2959ffc5677)

Now displays as:
![Screenshot 2024-12-13 at 5 27 52 PM](https://github.com/user-attachments/assets/9acf1fee-7356-493b-9346-c91bc2a503c1)
