### PR TITLE
Inject orcid prefix value in contributor form

### DIFF
--- a/app/components/contributors/edit_component.rb
+++ b/app/components/contributors/edit_component.rb
@@ -31,11 +31,13 @@ module Contributors
     end
 
     def contributors_data
-      { controller: 'contributors' }.tap do |contributors_hash|
+      {
+        controller: 'contributors',
+        contributors_orcid_prefix_value: Settings.orcid.url
+      }.tap do |contributors_hash|
         next unless orcid?
 
         contributors_hash[:contributors_orcid_value] = orcid
-        contributors_hash[:contributors_orcid_prefix_value] = Settings.orcid.url
       end
     end
 


### PR DESCRIPTION
Do this always, not just when the orcid value is present so that users without Stanford-linked orcids benefit from normalization.
