### PR TITLE
[SPIKE] Make SelectFieldComponent inherit from FieldComponent

### DIFF
--- a/app/components/elements/forms/select_field_component.rb
+++ b/app/components/elements/forms/select_field_component.rb
@@ -3,32 +3,14 @@
 module Elements
   module Forms
     # Component for form select fields
-    class SelectFieldComponent < ApplicationComponent
-      def initialize(form:, field_name:, options:, required: false, hidden_label: false, # rubocop:disable Metrics/ParameterLists
-                     label: nil, help_text: nil, prompt: false, data: {})
-        @form = form
-        @field_name = field_name
+    class SelectFieldComponent < FieldComponent
+      def initialize(options:, prompt: false, **)
         @options = options
-        @required = required
-        @hidden_label = hidden_label
-        @label = label
-        @help_text = help_text
         @prompt = prompt
-        @data = data
-        super()
+        super(**)
       end
 
-      attr_reader :form, :field_name, :options, :required, :hidden_label, :label, :help_text, :prompt, :data
-
-      def help_text_id
-        @help_text_id ||= form.field_id(field_name, 'help')
-      end
-
-      def field_aria
-        return if @help_text.blank?
-
-        { describedby: help_text_id }
-      end
+      attr_reader :options, :prompt
     end
   end
 end


### PR DESCRIPTION
These classes were already very similar. The differences between these classes are:

1. `FieldComponent` has four kwargs not in the `SelectFieldComponent` (`disabled: false`, `hidden: false`, `placeholder: nil`, `width: nil`), but all of them are optional and have defaults that fit the `SelectFieldComponent`
2. `FieldComponent` defines an instance method that acts upon the optional `width` arg.
3. `SelectFieldComponent` has two kwargs not in the `FieldComponent` (`options:` & `prompt: false`), but subclasses can extend their parents, so that's no big deal.

This PR reduces the number of junk drawer components in the app. Why not?

