### PR TITLE
Broadcast file updates only when completed.

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -24,9 +24,11 @@ class ContentsController < ApplicationController
 
     update_files
 
-    # Broadcast the update to the content
-    Turbo::StreamsChannel.broadcast_update_later_to @content, target: 'content-files', partial: 'contents/show',
-                                                              locals: { content: @content }
+    # Broadcast the update to the content if completed
+    if params[:content][:completed] == 'true'
+      Turbo::StreamsChannel.broadcast_update_later_to @content, target: 'content-files', partial: 'contents/show',
+                                                                locals: { content: @content }
+    end
 
     head :ok
   end

--- a/app/javascript/controllers/dropzone_controller.js
+++ b/app/javascript/controllers/dropzone_controller.js
@@ -17,7 +17,7 @@ export default class extends Controller {
     this.dropzone.on('addedfiles', () => {
       this.progressTarget.classList.remove('d-none')
       // This shows the user that something is going on since there may be a paused before first progress.
-      this.updateProgress(2)
+      this.updateProgress(2, true)
     })
     this.dropzone.on('totaluploadprogress', (totalUploadProgress) => {
       const uploadProgress = Math.trunc(totalUploadProgress)
@@ -37,12 +37,13 @@ export default class extends Controller {
         const path = file.fullPath ? file.fullPath : file.name
         data.append(`content[paths][${i}]`, path)
       }
+      data.append('content[completed]', this.dropzone.getActiveFiles().length === files.length)
     })
   }
 
-  updateProgress (progress) {
+  updateProgress (progress, reset = false) {
     // For some reason progress bounces around a bit. This keeps the progress moving forward.
-    if (progress <= this.progress) return
+    if (progress <= this.progress && !reset) return
 
     this.progressTarget.setAttribute('aria-valuenow', progress)
     const barElement = this.progressTarget.querySelector('.progress-bar')


### PR DESCRIPTION
This makes things zippier when uploading large number of files.