### PR TITLE
Use name from ORCID in author/contributor form

### DIFF
--- a/app/components/contributors/edit_component.html.erb
+++ b/app/components/contributors/edit_component.html.erb
@@ -35,7 +35,7 @@
         <span class="input-group-text">
           <%= Settings.orcid.url %>
         </span>
-        <%= form.text_field :orcid, class: 'form-control', data: { contributors_target: 'orcidField', action: 'change->contributors#normalizeOrcid' } %>
+        <%= form.text_field :orcid, class: 'form-control', data: { contributors_target: 'orcidField', action: 'change->contributors#normalizeAndResolveOrcid' }, readonly: render_reset_orcid_button? %>
         <%= render Elements::ButtonComponent.new(label: t('works.edit.fields.contributors.use_orcid_button.label'), classes: 'btn btn-outline-primary',
                                                  data: { action: 'contributors#useOrcid', contributors_target: 'useOrcidButton' }, hidden: !render_use_orcid_button?) %>
         <%= render Elements::ButtonComponent.new(label: t('works.edit.fields.contributors.reset_orcid_button.label'), classes: 'btn btn-outline-primary',
@@ -48,10 +48,12 @@
       <%= form.label :with_orcid_false, 'Name', class: 'form-check-label visually-hidden' %>
       <div class="row">
         <div class="col">
-          <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :first_name, label: t('works.edit.fields.contributors.first_name.label'), container_classes: 'mb-4') %>
+          <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :first_name, label: t('works.edit.fields.contributors.first_name.label'), container_classes: 'mb-4',
+                                                             data: { contributors_target: 'firstNameField' }) %>
         </div>
         <div class="col">
-          <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :last_name, label: t('works.edit.fields.contributors.last_name.label'), container_classes: 'mb-4') %>
+          <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :last_name, label: t('works.edit.fields.contributors.last_name.label'), container_classes: 'mb-4',
+                                                             data: { contributors_target: 'lastNameField' }) %>
         </div>
       </div>
     </div>

--- a/app/components/contributors/edit_component.rb
+++ b/app/components/contributors/edit_component.rb
@@ -21,19 +21,20 @@ module Contributors
     # Render the button to use the user's orcid if and only if the user has an
     # orcid attr in Shibboleth and hasn't already entered it
     def render_use_orcid_button?
-      orcid? && form.object.orcid.blank?
+      orcid? && (form.object.orcid.blank? || !orcid.match?(form.object.orcid))
     end
 
     # Render the button to reset the user's orcid if and only if the user has an
-    # orcid attr in Shibboleth and *has* already entered it
+    # orcid attr in Shibboleth and *has* already entered it and it matches
     def render_reset_orcid_button?
-      orcid? && form.object.orcid.present?
+      orcid? && form.object.orcid.present? && orcid.match?(form.object.orcid)
     end
 
     def contributors_data
       {
         controller: 'contributors',
-        contributors_orcid_prefix_value: Settings.orcid.url
+        contributors_orcid_prefix_value: Settings.orcid.url,
+        contributors_orcid_resolver_path_value: orcid_path(id: '')
       }.tap do |contributors_hash|
         next unless orcid?
 

--- a/app/controllers/orcid_controller.rb
+++ b/app/controllers/orcid_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Lookup a contributor in ORCID and return their name information
+class OrcidController < ApplicationController
+  skip_verify_authorized only: %i[search]
+
+  def search
+    result = OrcidResolver.call(orcid_id: params[:id])
+
+    if result.success?
+      render json: { orcid: params[:id], first_name: result.value![0], last_name: result.value![1] }
+    else
+      head result.failure
+    end
+  end
+end

--- a/app/javascript/controllers/contributors_controller.js
+++ b/app/javascript/controllers/contributors_controller.js
@@ -4,12 +4,14 @@ export default class extends Controller {
   static targets = [
     'contributorTypePerson', 'contributorTypeOrganization', 'contributorTypePersonLabel',
     'contributorTypeOrganizationLabel', 'selectPersonRole', 'selectOrganizationRole', 'personName',
-    'organizationName', 'orcidField', 'useOrcidButton', 'resetOrcidButton'
+    'organizationName', 'orcidField', 'useOrcidButton', 'resetOrcidButton', 'firstNameField',
+    'lastNameField'
   ]
 
   static values = {
     orcid: String,
-    orcidPrefix: String
+    orcidPrefix: String,
+    orcidResolverPath: String
   }
 
   connect () {
@@ -22,7 +24,7 @@ export default class extends Controller {
 
   useOrcid () {
     this.orcidFieldTarget.value = this.orcidValue
-    this.normalizeOrcid()
+    this.normalizeAndResolveOrcid()
     this.orcidFieldTarget.readOnly = true
     this.useOrcidButtonTarget.hidden = true
     this.resetOrcidButtonTarget.hidden = false
@@ -35,8 +37,19 @@ export default class extends Controller {
     this.useOrcidButtonTarget.hidden = false
   }
 
-  normalizeOrcid () {
+  normalizeAndResolveOrcid () {
     this.orcidFieldTarget.value = this.orcidFieldTarget.value.replace(this.orcidPrefixValue, '')
+
+    fetch(`${this.orcidResolverPathValue}${this.orcidFieldTarget.value}`)
+      .then(response => {
+        if (!response.ok) throw new Error(response.status)
+        return response.json()
+      })
+      .then(data => {
+        if (this.firstNameFieldTarget.value === '') this.firstNameFieldTarget.value = data.first_name
+        if (this.lastNameFieldTarget.value === '') this.lastNameFieldTarget.value = data.last_name
+      })
+      .catch(error => console.dir(error))
   }
 
   // Role type toggle Individual selection

--- a/app/services/orcid_resolver.rb
+++ b/app/services/orcid_resolver.rb
@@ -16,7 +16,7 @@ class OrcidResolver
   def call
     return orcid_result if orcid_result.failure?
 
-    response = Faraday.new.get(url, {}, headers)
+    response = Faraday.get(url, {}, headers)
     return Failure.new(response.status) unless response.success?
 
     response_hash = JSON.parse(response.body)

--- a/app/services/orcid_resolver.rb
+++ b/app/services/orcid_resolver.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# This resolves an ORCID ID to an ORCID entity from ORCID.org
+class OrcidResolver
+  include Dry::Monads[:result]
+
+  # @see OrcidResolver#initialize, OrcidResolver#call
+  def self.call(...)
+    new(...).call
+  end
+
+  def initialize(orcid_id:)
+    @orcid_id = orcid_id
+  end
+
+  def call
+    return orcid_result if orcid_result.failure?
+
+    response = Faraday.new.get(url, {}, headers)
+    return Failure.new(response.status) unless response.success?
+
+    response_hash = JSON.parse(response.body)
+    Success.new([response_hash.dig('name', 'given-names', 'value'), response_hash.dig('name', 'family-name', 'value')])
+  end
+
+  private
+
+  attr_reader :orcid_id
+
+  def orcid_result
+    @orcid_result ||= begin
+      match = /[0-9xX]{4}-[0-9xX]{4}-[0-9xX]{4}-[0-9xX]{4}/.match(orcid_id)
+      match ? Success.new(match[0]&.upcase) : Failure.new(400)
+    end
+  end
+
+  def url
+    "#{Settings.orcid.public_api_base_url}#{orcid_result.value!}/personal-details"
+  end
+
+  def headers
+    {
+      'Accept' => 'application/json',
+      'User-Agent' => 'Stanford Self-Deposit (Happy Heron)'
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get 'up' => 'rails/health#show', as: :rails_health_check
 
   get 'fast', to: 'fast#show', defaults: { format: 'html' }
+  get 'orcid', to: 'orcid#search'
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,7 @@ autocomplete_lookup:
 
 orcid:
   url: 'https://orcid.org/'
+  public_api_base_url: 'https://pub.orcid.org/v3.0/'
 
 http_headers:
   user_groups: 'X-Groups'

--- a/spec/requests/orcid_spec.rb
+++ b/spec/requests/orcid_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Orcid' do
+  before { sign_in(create(:user)) }
+
+  describe 'GET /search' do
+    context 'when search successful' do
+      before do
+        allow(OrcidResolver).to receive(:call).and_return(Dry::Monads::Result::Success.new(%w[Wilford Brimley]))
+      end
+
+      it 'returns the data' do
+        get '/orcid?id=0000-0003-1527-0030'
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq('{"orcid":"0000-0003-1527-0030","first_name":"Wilford","last_name":"Brimley"}')
+        expect(OrcidResolver).to have_received(:call).with(orcid_id: '0000-0003-1527-0030')
+      end
+    end
+
+    context 'when search unsuccessful' do
+      before do
+        allow(OrcidResolver).to receive(:call).and_return(Dry::Monads::Result::Failure.new(404))
+      end
+
+      it 'returns status' do
+        get '/orcid?id=0000-0003-1527-0030'
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/services/orcid_resolver_spec.rb
+++ b/spec/services/orcid_resolver_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OrcidResolver do
+  include Dry::Monads[:result]
+
+  subject(:response) { described_class.call(orcid_id:) }
+
+  let(:body) do
+    {
+      'last-modified-date' => { 'value' => 1_460_763_728_406 },
+      'name' => {
+        'created-date' => { 'value' => 1_460_763_728_406 },
+        'last-modified-date' => { 'value' => 1_460_763_728_406 },
+        'given-names' => { 'value' => 'Justin' },
+        'family-name' => { 'value' => 'Littman' },
+        'credit-name' => nil,
+        'source' => nil,
+        'visibility' => 'public',
+        'path' => '0000-0003-1527-0030'
+      },
+      'other-names' => {
+        'last-modified-date' => nil,
+        'other-name' => [],
+        'path' => '/0000-0003-1527-0030/other-names'
+      },
+      'biography' => nil,
+      'path' => '/0000-0003-1527-0030/personal-details'
+    }.to_json
+  end
+
+  context 'when bad orcid id' do
+    let(:orcid_id) { 'abcd-efgh-ijkl-mnop' }
+
+    it { is_expected.to eq(Failure(400)) }
+  end
+
+  context 'when an orcid id' do
+    let(:orcid_id) { '0000-0003-1527-0030' }
+
+    before do
+      stub_request(:get, "#{Settings.orcid.public_api_base_url}0000-0003-1527-0030/personal-details")
+        .with(
+          headers: {
+            'Accept' => 'application/json',
+            'User-Agent' => 'Stanford Self-Deposit (Happy Heron)'
+          }
+        )
+        .to_return(status: 200, body:, headers: {})
+    end
+
+    it { is_expected.to eq(Success(%w[Justin Littman])) }
+  end
+
+  context 'when an orcid id that requires normalizing' do
+    let(:orcid_id) { 'https://orcid.org/0000-0003-1527-003x' }
+
+    before do
+      stub_request(:get, "#{Settings.orcid.public_api_base_url}0000-0003-1527-003X/personal-details")
+        .to_return(status: 200, body:, headers: {})
+    end
+
+    it { is_expected.to eq(Success(%w[Justin Littman])) }
+  end
+
+  context 'when ORCID API returns an error' do
+    let(:orcid_id) { 'https://orcid.org/0000-0003-1527-0030' }
+
+    before do
+      stub_request(:get, "#{Settings.orcid.public_api_base_url}0000-0003-1527-0030/personal-details")
+        .to_return(status: 404, body: '', headers: {})
+    end
+
+    it { is_expected.to eq(Failure(404)) }
+  end
+end


### PR DESCRIPTION
Fixes #136 

- **Add resolver to pull names from ORCID API**
- **Enter user names in author/contributor form as registered in orcid**


![Peek 2024-12-16 13-52](https://github.com/user-attachments/assets/35a87fe6-8605-4d0f-90d4-6ce98b376d1b)
