### PR TITLE
When editing works / collections, wait before going to show.

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -58,6 +58,9 @@ class CollectionsController < ApplicationController
     @collection_form = CollectionForm.new(**update_collection_params)
     # The deposit param determines whether extra validations for deposits are applied.
     if @collection_form.valid?(deposit: deposit?)
+      # Setting the deposit_job_started_at to the current time to indicate that the deposit job has started and user
+      # should be "waiting".
+      @collection.update!(deposit_job_started_at: Time.zone.now)
       DepositCollectionJob.perform_later(collection: @collection, collection_form: @collection_form, deposit: deposit?)
       redirect_to wait_collections_path(@collection.id)
     else

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -67,6 +67,9 @@ class WorksController < ApplicationController
     @work_form = WorkForm.new(**update_work_params)
     # The deposit param determines whether extra validations for deposits are applied.
     if @work_form.valid?(deposit: deposit?)
+      # Setting the deposit_job_started_at to the current time to indicate that the deposit job has started and user
+      # should be "waiting".
+      @work.update!(deposit_job_started_at: Time.zone.now)
       DepositWorkJob.perform_later(work: @work, work_form: @work_form, deposit: deposit?)
       redirect_to wait_works_path(@work.id)
     else


### PR DESCRIPTION
Previously, it would redirect to wait page and then immediately to show page (without waiting for deposit job).