### PR TITLE
Stop generating cocina with blank orcids.

### DIFF
--- a/app/services/cocina_generators/description/person_contributor.rb
+++ b/app/services/cocina_generators/description/person_contributor.rb
@@ -52,7 +52,7 @@ module CocinaGenerators
       end
 
       def identifier_params
-        return if orcid.nil?
+        return if orcid.blank?
 
         [
           {

--- a/spec/services/cocina_generators/description/person_contributor_spec.rb
+++ b/spec/services/cocina_generators/description/person_contributor_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CocinaGenerators::Description::PersonContributor do
+  subject(:contributor_params) { described_class.call(forename: 'Leland', surname: 'Stanford', role: 'funder', orcid:) }
+
+  context 'when orcid is blank' do
+    let(:orcid) { '' }
+
+    it 'does not include identifier' do
+      expect(contributor_params[:identifier]).to be_nil
+    end
+  end
+
+  context 'when orcid is nil' do
+    let(:orcid) { nil }
+
+    it 'does not include identifier' do
+      expect(contributor_params[:identifier]).to be_nil
+    end
+  end
+
+  context 'when orcid' do
+    let(:orcid) { '0000-0000-0000-0000' }
+
+    it 'does not include identifier' do
+      expect(contributor_params[:identifier]).to eq [{ value: '0000-0000-0000-0000', type: 'ORCID',
+                                                       source: { uri: 'https://orcid.org/' } }]
+    end
+  end
+end


### PR DESCRIPTION
Before this cocina was getting created with blank orcids. In addition to being wrong, it was breaking roundtripping.