### PR TITLE
Remove bogus aliases in collection policy

### DIFF
--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CollectionPolicy < ApplicationPolicy
-  alias_rule :new?, :create?, :show?, :update?, :edit?, :wait?, :destroy?, to: :manage?
+  alias_rule :show?, :update?, :edit?, :wait?, :destroy?, to: :manage?
 
   def manage?
     record.user_id == user.id


### PR DESCRIPTION
I don't think we want to `alias_rule` *and* `def` the same policies.