### PR TITLE
Remove duplicate `license` from path to license label field in i18n

### DIFF
--- a/app/components/works/edit/license_component.rb
+++ b/app/components/works/edit/license_component.rb
@@ -16,7 +16,7 @@ module Works
       end
 
       def label
-        helpers.t('license.edit.fields.license.label')
+        helpers.t('license.edit.fields.label')
       end
 
       def help_text

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,8 +76,7 @@ en:
   license:
     edit:
       fields:
-        license:
-          label: 'License'
+        label: 'License'
       license_terms_of_use: In addition to the license, the following Terms of Use will also be displayed on your PURL page.
       terms_of_use: >
         User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or


### PR DESCRIPTION
Follows #425
