### PR TITLE
Use :on instead of :if for validations to separate data concerns from context concerns

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,4 +21,15 @@ class ApplicationController < ActionController::Base
     flash[:warning] = helpers.t('errors.not_authorized')
     redirect_to main_app.root_path
   end
+
+  def deposit?
+    params[:commit] == 'Deposit'
+  end
+
+  # NOTE: a `nil` validation context runs all validations without an explicit context
+  def validation_context
+    return :deposit if deposit?
+
+    nil
+  end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -39,8 +39,8 @@ class CollectionsController < ApplicationController
   def create
     authorize! Collection
     @collection_form = CollectionForm.new(**collection_params)
-    # The deposit param determines whether extra validations for deposits are applied.
-    if @collection_form.valid?(deposit: deposit?)
+    # The validation_context param determines whether extra validations are applied, e.g., for deposits.
+    if @collection_form.valid?(validation_context)
       # Setting the deposit_job_started_at to the current time to indicate that the deposit job has started and user
       # should be "waiting".
       collection = Collection.create!(title: @collection_form.title,
@@ -57,8 +57,8 @@ class CollectionsController < ApplicationController
     authorize! @collection
 
     @collection_form = CollectionForm.new(**update_collection_params)
-    # The deposit param determines whether extra validations for deposits are applied.
-    if @collection_form.valid?(deposit: deposit?)
+    # The validation_context param determines whether extra validations are applied, e.g., for deposits.
+    if @collection_form.valid?(validation_context)
       # Setting the deposit_job_started_at to the current time to indicate that the deposit job has started and user
       # should be "waiting".
       @collection.update!(deposit_job_started_at: Time.zone.now)
@@ -98,10 +98,6 @@ class CollectionsController < ApplicationController
 
   def update_collection_params
     collection_params.merge(druid: params[:druid])
-  end
-
-  def deposit?
-    params[:commit] == 'Deposit'
   end
 
   def set_collection

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -50,8 +50,8 @@ class WorksController < ApplicationController
     @collection_title = collection.title
     authorize! collection, with: WorkPolicy
 
-    # The deposit param determines whether extra validations for deposits are applied.
-    if @work_form.valid?(deposit: deposit?)
+    # The validation_context param determines whether extra validations are applied, e.g., for deposits.
+    if @work_form.valid?(validation_context)
       # Setting the deposit_job_started_at to the current time to indicate that the deposit job has started and user
       # should be "waiting".
       work = Work.create!(title: @work_form.title, user: current_user, deposit_job_started_at: Time.zone.now,
@@ -68,8 +68,8 @@ class WorksController < ApplicationController
     authorize! @work
 
     @work_form = WorkForm.new(**update_work_params)
-    # The deposit param determines whether extra validations for deposits are applied.
-    if @work_form.valid?(deposit: deposit?)
+    # The validation_context param determines whether extra validations are applied, e.g., for deposits.
+    if @work_form.valid?(validation_context)
       # Setting the deposit_job_started_at to the current time to indicate that the deposit job has started and user
       # should be "waiting".
       @work.update!(deposit_job_started_at: Time.zone.now)
@@ -111,10 +111,6 @@ class WorksController < ApplicationController
 
   def update_work_params
     work_params.merge(druid: params[:druid])
-  end
-
-  def deposit?
-    params[:commit] == 'Deposit'
   end
 
   def set_work

--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -19,16 +19,4 @@ class ApplicationForm
   def self.immutable_attributes
     []
   end
-
-  # @param deposit [Boolean] whether the form is being used for a deposit
-  def valid?(deposit: false)
-    @deposit = deposit
-    super
-  end
-
-  # This can be used to control validations specific to deposits.
-  # For example: validates :authors, presence: { message: 'requires at least one author' }, if: :deposit?
-  def deposit?
-    @deposit
-  end
 end

--- a/app/forms/author_form.rb
+++ b/app/forms/author_form.rb
@@ -3,15 +3,15 @@
 # Form for an author
 class AuthorForm < ApplicationForm
   attribute :first_name, :string
-  validates :first_name, presence: true, if: -> { person? && deposit? }
+  validates :first_name, presence: true, on: :deposit, if: -> { person? }
 
   attribute :last_name, :string
-  validates :last_name, presence: true, if: -> { person? && deposit? }
+  validates :last_name, presence: true, on: :deposit, if: -> { person? }
 
   validate :name_must_be_complete, if: :person?
 
   attribute :organization_name, :string
-  validates :organization_name, presence: true, if: -> { organization? && deposit? }
+  validates :organization_name, presence: true, on: :deposit, if: -> { organization? }
 
   attribute :person_role, :string
   validates :person_role, presence: true, if: :person?

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -24,5 +24,5 @@ class CollectionForm < ApplicationForm
 
   # The Collection description maps to the cocina abstract
   attribute :description, :string
-  validates :description, presence: true, if: :deposit?
+  validates :description, presence: true, on: :deposit
 end

--- a/app/forms/contact_email_form.rb
+++ b/app/forms/contact_email_form.rb
@@ -3,7 +3,7 @@
 # Form for contact emails
 class ContactEmailForm < ApplicationForm
   attribute :email, :string
-  validates :email, presence: true, if: :deposit?
+  validates :email, presence: true, on: :deposit
   validates :email, format: {
     with: URI::MailTo::EMAIL_REGEXP,
     allow_blank: true

--- a/app/forms/keyword_form.rb
+++ b/app/forms/keyword_form.rb
@@ -3,7 +3,7 @@
 # Form for keywords
 class KeywordForm < ApplicationForm
   attribute :text, :string
-  validates :text, presence: true, if: :deposit?
+  validates :text, presence: true, on: :deposit
   # NOTE: These two attributes are parsed from the keyword resolution service
   #       response and injected into the form, and are entirely optional. If
   #       the resolution service fails or the user wants a keyword that cannot

--- a/app/forms/related_link_form.rb
+++ b/app/forms/related_link_form.rb
@@ -4,5 +4,5 @@
 class RelatedLinkForm < ApplicationForm
   attribute :text, :string
   attribute :url, :string
-  validates :url, presence: true, if: :deposit?, unless: ->(link) { link.text.blank? }
+  validates :url, presence: true, on: :deposit, unless: ->(link) { link.text.blank? }
 end

--- a/app/forms/related_work_form.rb
+++ b/app/forms/related_work_form.rb
@@ -25,7 +25,7 @@ class RelatedWorkForm < ApplicationForm
   validates :relationship, inclusion: { in: RELATIONSHIP_TYPES }, allow_blank: true
   attribute :use_citation, :boolean
 
-  with_options(if: :deposit?) do |deposit|
+  with_options(on: :deposit) do |deposit|
     deposit.validates :citation, absence: true, if: ->(related_work) { related_work.identifier.present? }
     deposit.validates :identifier, absence: true, if: ->(related_work) { related_work.citation.present? }
     deposit.validates :relationship, presence: true, if: (lambda do |related_work|

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -4,7 +4,7 @@
 class WorkForm < ApplicationForm
   accepts_nested_attributes_for :related_links, :related_works, :publication_date, :contact_emails, :authors, :keywords
 
-  validate :content_file_presence, if: :deposit?
+  validate :content_file_presence, on: :deposit
 
   def self.immutable_attributes
     ['druid']
@@ -32,17 +32,17 @@ class WorkForm < ApplicationForm
   validates :title, presence: true
 
   attribute :abstract, :string
-  validates :abstract, presence: true, if: :deposit?
+  validates :abstract, presence: true, on: :deposit
 
   attribute :citation, :string
   attribute :auto_generate_citation, :boolean
   validates :citation, presence: true, if: -> { auto_generate_citation == false }
 
   attribute :license, :string
-  validates :license, presence: true, if: :deposit?
+  validates :license, presence: true, on: :deposit
 
   attribute :work_type, :string
-  validates :work_type, presence: true, if: :deposit?
+  validates :work_type, presence: true, on: :deposit
 
   attribute :work_subtypes, array: true, default: -> { [] }
   # Music and mixed materials have a minimum number of subtypes required

--- a/spec/forms/author_form_spec.rb
+++ b/spec/forms/author_form_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe AuthorForm do
       let(:organization_name) { '' }
 
       it 'is not valid' do
-        expect(form.valid?(deposit: true)).not_to be true
+        expect(form.valid?(:deposit)).not_to be true
       end
     end
 
@@ -104,7 +104,7 @@ RSpec.describe AuthorForm do
       let(:last_name) { '' }
 
       it 'is not valid' do
-        expect(form.valid?(deposit: true)).to be false
+        expect(form.valid?(:deposit)).to be false
       end
     end
   end

--- a/spec/forms/contact_email_form_spec.rb
+++ b/spec/forms/contact_email_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ContactEmailForm do
 
     context 'when nil and depositing' do
       it 'is not valid' do
-        expect(form.valid?(deposit: true)).to be false
+        expect(form.valid?(:deposit)).to be false
       end
     end
 

--- a/spec/forms/keyword_form_spec.rb
+++ b/spec/forms/keyword_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe KeywordForm do
   end
 
   it 'is valid when depositing' do
-    expect(form.valid?(deposit: true)).to be true
+    expect(form.valid?(:deposit)).to be true
   end
 
   context 'with blank text' do
@@ -24,7 +24,7 @@ RSpec.describe KeywordForm do
 
     context 'when depositing' do
       it 'is not valid' do
-        expect(form.valid?(deposit: true)).to be false
+        expect(form.valid?(:deposit)).to be false
       end
     end
   end

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe WorkForm do
 
     context 'when depositing with blank work type' do
       it 'is invalid' do
-        expect(form.valid?(deposit: true)).to be false
+        expect(form.valid?(:deposit)).to be false
         expect(form.errors[:work_type]).to include("can't be blank")
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe WorkForm do
       let(:work_type) { 'Other' }
 
       it 'is invalid' do
-        expect(form.valid?(deposit: true)).to be false
+        expect(form.valid?(:deposit)).to be false
         expect(form.errors[:other_work_subtype]).to include("can't be blank")
       end
     end


### PR DESCRIPTION
I stumbled on https://guides.rubyonrails.org/active_record_validations.html#on over the winter break and thought we might be able to dump some custom validation code in H3 to be more Rails-y.
