### PR TITLE
Align delete icon with input field in some forms

### DIFF
--- a/app/components/elements/forms/repeatable_nested_component.html.erb
+++ b/app/components/elements/forms/repeatable_nested_component.html.erb
@@ -10,13 +10,13 @@
           <div class="col">
             <%= render form_component.new(form: nested_form) %>
           </div>
-          <div class="col-md-auto d-flex flex-column">
+          <%= tag.div(class: nested_buttons_classes) do %>
             <%= render Elements::DeleteButtonComponent.new(data: { action: 'click->nested-form#delete' }) %>
             <% if reorderable? %>
               <%= render Elements::MoveUpButtonComponent.new(classes: 'd-none', data: { action: 'click->nested-form-reorder#moveUp' }) %>
               <%= render Elements::MoveDownButtonComponent.new(classes: 'd-none', data: { action: 'click->nested-form-reorder#moveDown' }) %>
             <% end %>
-          </div>
+          <% end %>
         <% end %>
       <% end %>
     </template>
@@ -26,13 +26,13 @@
         <div class="col">
           <%= render form_component.new(form: nested_form) %>
         </div>
-        <div class="col-md-auto d-flex flex-column">
+        <%= tag.div(class: nested_buttons_classes) do %>
           <%= render Elements::DeleteButtonComponent.new(data: { action: 'click->nested-form#delete' }) %>
           <% if reorderable? %>
             <%= render Elements::MoveUpButtonComponent.new(classes: 'd-none', data: { action: 'click->nested-form-reorder#moveUp' }) %>
             <%= render Elements::MoveDownButtonComponent.new(classes: 'd-none', data: { action: 'click->nested-form-reorder#moveDown' }) %>
           <% end %>
-        </div>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/elements/forms/repeatable_nested_component.rb
+++ b/app/components/elements/forms/repeatable_nested_component.rb
@@ -6,7 +6,7 @@ module Elements
     # NOTE: Use the `NestedComponentPresenter` to invoke this component; do not directly instantiate it.
     class RepeatableNestedComponent < ApplicationComponent
       def initialize(form:, model_class:, field_name:, form_component:, hidden_label: false, bordered: true, # rubocop:disable Metrics/ParameterLists
-                     reorderable: false, label: nil)
+                     reorderable: false, single_field: false, label: nil)
         @form = form
         @model_class = model_class
         @field_name = field_name
@@ -14,6 +14,7 @@ module Elements
         @hidden_label = hidden_label
         @bordered = bordered
         @reorderable = reorderable
+        @single_field = single_field
         @label = label
         super()
       end
@@ -37,6 +38,11 @@ module Elements
                       bordered? ? %w[p-3 border border-3 border-light-subtle border-opacity-75 mb-3] : [])
       end
 
+      def nested_buttons_classes
+        merge_classes(%w[col-md-auto d-flex],
+                      single_field? ? %w[align-items-stretch] : %w[flex-column])
+      end
+
       def add_button_classes
         bordered? ? 'my-4' : 'mb-4 mt-0'
       end
@@ -54,6 +60,11 @@ module Elements
           controller: ['nested-form', reorderable? ? 'nested-form-reorder' : nil].compact.join(' '),
           nested_form_selector_value: '.form-instance'
         }
+      end
+
+      def single_field?
+        # whether there is a single visible field in the form, to determine button placement
+        @single_field
       end
     end
   end

--- a/app/views/collections/form.html.erb
+++ b/app/views/collections/form.html.erb
@@ -25,7 +25,7 @@
     <% component.with_pane(tab_name: :details, label: I18n.t('collections.edit.panes.details.label'), selected: true, form_id:) do %>
       <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :title, label: I18n.t('collections.edit.fields.title.label'), container_classes: 'mb-4') %>
       <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :description, label: I18n.t('collections.edit.fields.description.label')) %>
-      <%= render NestedComponentPresenter.for(form:, field_name: :contact_emails, model_class: ContactEmailForm, form_component: ContactEmails::EditComponent, hidden_label: true, bordered: false) %>
+      <%= render NestedComponentPresenter.for(form:, field_name: :contact_emails, model_class: ContactEmailForm, form_component: ContactEmails::EditComponent, hidden_label: true, bordered: false, single_field: true) %>
     <% end %>
 
     <% component.with_pane(tab_name: :related_links, label: I18n.t('collections.edit.panes.related_links.label'), form_id:) do %>

--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -45,7 +45,7 @@
     <% component.with_pane(tab_name: :title, label: t('works.edit.panes.title.label'), form_id:) do %>
       <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :title, label: t('works.edit.fields.title.label'),
                                                          help_text: t('works.edit.fields.title.help_text'), width: 500, container_classes: 'mb-4') %>
-      <%= render NestedComponentPresenter.for(form:, field_name: :contact_emails, model_class: ContactEmailForm, form_component: ContactEmails::EditComponent, hidden_label: true, bordered: false) %>
+      <%= render NestedComponentPresenter.for(form:, field_name: :contact_emails, model_class: ContactEmailForm, form_component: ContactEmails::EditComponent, hidden_label: true, bordered: false, single_field: true) %>
     <% end %>
     <% component.with_pane(tab_name: :authors, label: t('works.edit.panes.authors.label'), form_id:, help_text: t('works.edit.panes.authors.help_text')) do %>
       <%= render NestedComponentPresenter.for(form:, field_name: :authors, model_class: AuthorForm, form_component: Contributors::EditComponent, hidden_label: true, reorderable: true) %>
@@ -53,7 +53,7 @@
 
     <% component.with_pane(tab_name: :abstract, label: t('works.edit.panes.abstract.label'), form_id:, help_text: t('works.edit.panes.abstract.help_text')) do %>
       <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :abstract, label: t('works.edit.fields.abstract.label')) %>
-      <%= render NestedComponentPresenter.for(form:, field_name: :keywords, model_class: KeywordForm, form_component: Keywords::EditComponent, hidden_label: false, bordered: false) %>
+      <%= render NestedComponentPresenter.for(form:, field_name: :keywords, model_class: KeywordForm, form_component: Keywords::EditComponent, hidden_label: false, bordered: false, single_field: true) %>
     <% end %>
 
     <% component.with_pane(tab_name: :types, form_id:) do %>

--- a/spec/components/elements/forms/repeatable_nested_component_spec.rb
+++ b/spec/components/elements/forms/repeatable_nested_component_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Elements::Forms::RepeatableNestedComponent, type: :component do
       expect(page).to have_field('URL')
       expect(page).to have_no_css('label.visually-hidden')
       expect(page).to have_css('div.border-3')
+      expect(page).to have_no_css('div.align-items-stretch')
     end
   end
 
@@ -42,6 +43,22 @@ RSpec.describe Elements::Forms::RepeatableNestedComponent, type: :component do
     it 'does not include the border classes' do
       render_inline(component)
       expect(page).to have_no_css('div.border-3')
+    end
+  end
+
+  context 'when a single field' do
+    subject(:component) do
+      described_class.new(form:, field_name: :contact_emails, model_class: ContactEmailForm,
+                          form_component: ContactEmails::EditComponent, hidden_label:, bordered:, single_field:)
+    end
+
+    let(:single_field) { true }
+    let(:hidden_label) { false }
+    let(:bordered) { true }
+
+    it 'aligns the delete icon' do
+      render_inline(component)
+      expect(page).to have_css('div.align-items-stretch')
     end
   end
 end


### PR DESCRIPTION
Resolves #337. The trash can should be aligned with the input field on repeatable forms with only one visible field (contact emails and keywords)

_Before_:

![Screenshot 2025-01-10 at 8 54 10 AM](https://github.com/user-attachments/assets/1155ff22-097f-43ec-a315-5965dfe5274d)

_After_: 
![Screenshot 2025-01-10 at 11 02 50 AM](https://github.com/user-attachments/assets/0ca2f1d3-6307-4edd-bf85-7538345f440a)

![Screenshot 2025-01-10 at 11 02 57 AM](https://github.com/user-attachments/assets/b44384d3-d871-41a6-881a-ce18355c0684)
