### PR TITLE
Adds state for deposit and RabbitMQ machinery.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'bootsnap', require: false
 
 # Additional gems
 gem 'action_policy'
+gem 'bunny' # RabbitMQ client
 gem 'cocina-models'
 gem 'config'
 gem 'datacite'
@@ -52,6 +53,7 @@ gem 'edtf'
 gem 'frozen_record' # For licenses
 gem 'honeybadger'
 gem 'kaminari' # For pagination
+gem 'kicks' # Background processing of rabbitMQ messages. (Formerly sneakers.)
 gem 'okcomputer'
 gem 'state_machines-activerecord'
 gem 'validate_url'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     airbrussh (1.5.3)
       sshkit (>= 1.6.1, != 1.7.0)
+    amq-protocol (2.3.2)
     ast (2.4.2)
     attr_extras (7.1.0)
     base64 (0.2.0)
@@ -100,6 +101,9 @@ GEM
     bundler-audit (0.9.2)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    bunny (2.23.0)
+      amq-protocol (~> 2.3, >= 2.3.1)
+      sorted_set (~> 1, >= 1.0.2)
     capistrano (3.19.2)
       airbrussh (>= 1.0.0)
       i18n
@@ -297,6 +301,12 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    kicks (3.1.1)
+      bunny (~> 2.19)
+      concurrent-ruby (~> 1.0)
+      rake (>= 12.3, < 14.0)
+      serverengine (~> 2.1)
+      thor
     language_server-protocol (3.17.0.3)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -416,6 +426,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rbtree (0.4.6)
     rdoc (6.11.0)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
@@ -480,6 +491,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    serverengine (2.4.0)
+      base64 (~> 0.1)
+      logger (~> 1.4)
+      sigdump (~> 0.2.2)
+    set (1.1.1)
+    sigdump (0.2.5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -503,6 +520,9 @@ GEM
       fugit (~> 1.11.0)
       railties (>= 7.1)
       thor (~> 1.3.1)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     sshkit (1.23.2)
       base64
       net-scp (>= 1.1.2)
@@ -574,6 +594,7 @@ DEPENDENCIES
   action_policy
   bcrypt (~> 3.1.7)
   bootsnap
+  bunny
   capistrano-passenger
   capistrano-rails
   capybara
@@ -597,6 +618,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kaminari
+  kicks
   mission_control-jobs
   okcomputer
   overmind

--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -12,15 +12,19 @@ class DepositCollectionJob < ApplicationJob
     new_cocina_object = perform_persist
     druid = new_cocina_object.externalIdentifier
 
+    collection.update!(druid:)
+
     assign_participants(:managers)
     assign_participants(:depositors)
 
-    Sdr::Repository.accession(druid:) if deposit
-
     ModelSync::Collection.call(collection:, cocina_object: new_cocina_object)
 
-    # The wait page will refresh until deposit_job_started_at is nil.
-    collection.update!(deposit_job_started_at: nil, druid:)
+    if deposit
+      Sdr::Repository.accession(druid:)
+      collection.accession!
+    else
+      collection.deposit_persist_complete!
+    end
   end
 
   private

--- a/app/jobs/deposit_complete_job.rb
+++ b/app/jobs/deposit_complete_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Called when accessioning / deposit is complete.
+class DepositCompleteJob
+  include Sneakers::Worker
+  # This worker will connect to "h3.deposit_complete" queue
+  # env is set to nil since by default the actual queue name would be
+  # "h3.deposit_complete_development"
+
+  # It is possible that this deposit event was initiated outside of h3. For
+  # example, if the embargo was lifted, DSA would open and close a version. The
+  # workflow message "end-accession" would end up here.  We must be able to handle
+  # these messages in addition to those that result from depositing in h3.
+  from_queue 'h3.deposit_complete', env: nil
+
+  def work(msg)
+    druid = parse_message(msg)
+    Honeybadger.context(druid:)
+    Rails.logger.info("Deposit complete on #{druid}")
+
+    object = Work.find_by(druid:) || Collection.find_by!(druid:)
+    object.accession_complete! if object.accessioning?
+
+    ack!
+  end
+
+  def parse_message(msg)
+    json = JSON.parse(msg)
+    json.fetch('druid')
+  end
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -3,6 +3,8 @@
 # Model for a collection.
 # Note that this model does not contain any cocina data.
 class Collection < ApplicationRecord
+  include DepositStateMachine
+
   belongs_to :user
   has_many :works, dependent: :destroy
 
@@ -29,16 +31,6 @@ class Collection < ApplicationRecord
   enum :license_option, { required: 'required', depositor_selects: 'depositor_selects' }, suffix: true
   enum :custom_rights_statement_option, { no: 'no', provided: 'provided', depositor_selects: 'depositor_selects' },
        suffix: true
-
-  # deposit_job_started_at indicates that the job is queued or running.
-  # User should be "waiting" until the job is completed.
-  def deposit_job_started?
-    deposit_job_started_at.present?
-  end
-
-  def deposit_job_finished?
-    deposit_job_started_at.nil?
-  end
 
   def max_release_date
     duration = case release_duration

--- a/app/models/concerns/deposit_state_machine.rb
+++ b/app/models/concerns/deposit_state_machine.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Defines the deposit states for an object.
+module DepositStateMachine
+  extend ActiveSupport::Concern
+
+  included do
+    # In general, the version status should be used for the status of an object.
+    # However, deposit_state is used for very specific purposes.
+    # In particular, persisting is used to indicate that the DepositWorkJob is queued / running.
+    # Accessioning is used to track if the accessioning of an object originated with H3.
+    # That way when the rabbitMQ message for the end of the accessioning is received,
+    # it can be determined if H3 users should be notified.
+    state_machine :deposit_state, initial: :deposit_none do
+      event :deposit_persist do
+        transition deposit_none: :deposit_persisting
+      end
+
+      # As part of the deposit job, accessioning may or may not be started.
+      # If accessioning is started, the accessioning state is set.
+      # If accessioning is not started, the state is set to none.
+      event :deposit_persist_complete do
+        transition deposit_persisting: :deposit_none
+      end
+
+      event :accession do
+        transition deposit_persisting: :accessioning
+      end
+
+      event :accession_complete do
+        transition accessioning: :deposit_none
+      end
+
+      before_transition accessioning: :deposit_none do |object|
+        Notifier.publish(Notifier::ACCESSIONING_COMPLETE, object:)
+      end
+    end
+  end
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -3,6 +3,8 @@
 # Model for a work.
 # Note that this model does not contain any cocina data.
 class Work < ApplicationRecord
+  include DepositStateMachine
+
   belongs_to :user
   belongs_to :collection
 
@@ -37,16 +39,6 @@ class Work < ApplicationRecord
     self.review_rejected_reason = reason
     self.review_state_event = 'reject'
     save!
-  end
-
-  # deposit_job_started_at indicates that the job is queued or running.
-  # User should be "waiting" until the job is completed.
-  def deposit_job_started?
-    deposit_job_started_at.present?
-  end
-
-  def deposit_job_finished?
-    deposit_job_started_at.nil?
   end
 
   def doi_assigned?

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -11,6 +11,8 @@ class Notifier
   REVIEW_APPROVED = 'review_approved'
   REVIEW_REJECTED = 'review_rejected'
 
+  ACCESSIONING_COMPLETE = 'accessioning_complete'
+
   # Publishes an event with the given name and payload
   # @param event_name [String] the name of the event
   # @param payload [Hash] the payload to include with the event

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -66,3 +66,21 @@ set :assets_manifests, lambda {
 # Namespace crontab entries by application and stage
 set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
 set :whenever_roles, [:scheduler]
+
+# Manage sneakers via systemd (from dlss-capistrano gem)
+set :sneakers_systemd_use_hooks, true
+
+namespace :rabbitmq do
+  desc 'Runs rake rabbitmq:setup'
+  task setup: ['deploy:set_rails_env'] do
+    on roles(:worker) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, 'rabbitmq:setup'
+        end
+      end
+    end
+  end
+
+  before 'sneakers_systemd:start', 'rabbitmq:setup'
+end

--- a/config/initializers/kicks.rb
+++ b/config/initializers/kicks.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'sneakers'
+
+conn = Bunny.new(hostname: Settings.rabbitmq.hostname,
+                 vhost: Settings.rabbitmq.vhost,
+                 username: Settings.rabbitmq.username,
+                 password: Settings.rabbitmq.password)
+Sneakers.configure connection: conn
+Sneakers.logger.level = Logger::INFO
+Sneakers.error_reporters << proc { |exception, _worker, context_hash| Honeybadger.notify(exception, context_hash) }

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -7,3 +7,11 @@ require 'okcomputer'
 # /status/<name-of-check> for a specific check (e.g. for nagios warning)
 OkComputer.mount_at = 'status'
 OkComputer.check_in_parallel = true
+
+if Settings.rabbitmq.enabled
+  OkComputer::Registry.register 'rabbit',
+                                OkComputer::RabbitmqCheck.new(hostname: Settings.rabbitmq.hostname,
+                                                              vhost: Settings.rabbitmq.vhost,
+                                                              username: Settings.rabbitmq.username,
+                                                              password: Settings.rabbitmq.password)
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,3 +49,10 @@ terms_url: https://sdr.sites.stanford.edu/documentation/understanding-sdr-terms-
 newsletter_url: https://stanford.us20.list-manage.com/subscribe?u=139e1b2d3df8f8cacd77c8160&id=4f4148a871
 
 host: 'localhost:3000'
+
+rabbitmq:
+  enabled: false
+  hostname: localhost
+  vhost: /
+  username: guest
+  password: guest

--- a/db/migrate/20250122135332_add_deposit_state_to_work.rb
+++ b/db/migrate/20250122135332_add_deposit_state_to_work.rb
@@ -1,0 +1,7 @@
+class AddDepositStateToWork < ActiveRecord::Migration[8.0]
+  def change
+    add_column :works, :deposit_state, :string, default: 'deposit_none', null: false
+    add_index :works, :deposit_state
+    remove_column :works, :deposit_job_started_at
+  end
+end

--- a/db/migrate/20250122145633_add_deposit_state_to_collection.rb
+++ b/db/migrate/20250122145633_add_deposit_state_to_collection.rb
@@ -1,0 +1,7 @@
+class AddDepositStateToCollection < ActiveRecord::Migration[8.0]
+  def change
+    add_column :collections, :deposit_state, :string, default: 'deposit_none', null: false
+    add_index :collections, :deposit_state
+    remove_column :collections, :deposit_job_started_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -165,7 +165,6 @@ CREATE TABLE public.collections (
     user_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    deposit_job_started_at timestamp(6) without time zone,
     object_updated_at timestamp(6) without time zone,
     release_option character varying,
     release_duration character varying,
@@ -178,7 +177,8 @@ CREATE TABLE public.collections (
     custom_rights_statement_custom_instructions character varying,
     email_when_participants_changed boolean DEFAULT true NOT NULL,
     email_depositors_status_changed boolean DEFAULT true NOT NULL,
-    review_enabled boolean DEFAULT false NOT NULL
+    review_enabled boolean DEFAULT false NOT NULL,
+    deposit_state character varying DEFAULT 'deposit_none'::character varying NOT NULL
 );
 
 
@@ -328,14 +328,14 @@ CREATE TABLE public.works (
     druid character varying,
     title character varying NOT NULL,
     user_id bigint,
-    deposit_job_started_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     collection_id bigint NOT NULL,
     object_updated_at timestamp(6) without time zone,
     doi_assigned boolean DEFAULT false NOT NULL,
     review_state character varying DEFAULT 'none_review'::character varying NOT NULL,
-    review_rejected_reason character varying
+    review_rejected_reason character varying,
+    deposit_state character varying DEFAULT 'deposit_none'::character varying NOT NULL
 );
 
 
@@ -544,6 +544,13 @@ CREATE UNIQUE INDEX index_collection_reviewers_on_collection_id_and_user_id ON p
 
 
 --
+-- Name: index_collections_on_deposit_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_collections_on_deposit_state ON public.collections USING btree (deposit_state);
+
+
+--
 -- Name: index_collections_on_druid; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -597,6 +604,13 @@ CREATE UNIQUE INDEX index_users_on_email_address ON public.users USING btree (em
 --
 
 CREATE INDEX index_works_on_collection_id ON public.works USING btree (collection_id);
+
+
+--
+-- Name: index_works_on_deposit_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_works_on_deposit_state ON public.works USING btree (deposit_state);
 
 
 --
@@ -690,6 +704,8 @@ ALTER TABLE ONLY public.active_storage_attachments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250122145633'),
+('20250122135332'),
 ('20250121174735'),
 ('20250120142833'),
 ('20250116173206'),

--- a/lib/tasks/rabbitmq.rake
+++ b/lib/tasks/rabbitmq.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :rabbitmq do
+  desc 'Setup routing'
+  task setup: :environment do
+    require 'bunny'
+
+    conn = Bunny.new(hostname: Settings.rabbitmq.hostname,
+                     vhost: Settings.rabbitmq.vhost,
+                     username: Settings.rabbitmq.username,
+                     password: Settings.rabbitmq.password).tap(&:start)
+
+    channel = conn.create_channel
+
+    # connect topic to the queue
+    exchange = channel.topic('sdr.workflow')
+    queue = channel.queue('h3.deposit_complete', durable: true)
+    queue.bind(exchange, routing_key: 'end-accession.completed')
+
+    conn.close
+  end
+end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -39,8 +39,8 @@ FactoryBot.define do
       depositors { create_list(:user, depositors_count) }
     end
 
-    trait :deposit_job_started do
-      deposit_job_started_at { Time.zone.now }
+    trait :persisting do
+      deposit_state { 'deposit_persisting' }
     end
 
     trait :with_druid do

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
     object_updated_at { Time.zone.now }
     doi_assigned { true }
 
-    trait :deposit_job_started do
-      deposit_job_started_at { Time.zone.now }
+    trait :persisting do
+      deposit_state { 'deposit_persisting' }
     end
 
     trait :with_druid do

--- a/spec/jobs/deposit_collection_job_spec.rb
+++ b/spec/jobs/deposit_collection_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DepositCollectionJob do
 
   context 'when a new collection' do
     let(:collection_form) { CollectionForm.new(title: collection.title, managers_attributes:, depositors_attributes:) }
-    let(:collection) { create(:collection, :deposit_job_started) }
+    let(:collection) { create(:collection, :persisting) }
     let(:managers_attributes) { [{ sunetid: manager.sunetid }, { sunetid: 'stepking' }] }
     let(:depositors_attributes) { [{ sunetid: 'joehill' }] }
     let(:manager) { create(:user) }
@@ -34,7 +34,7 @@ RSpec.describe DepositCollectionJob do
         .with(cocina_object: an_instance_of(Cocina::Models::RequestCollection))
       expect(Sdr::Repository).to have_received(:accession).with(druid:)
 
-      expect(collection.reload.deposit_job_finished?).to be true
+      expect(collection.reload.accessioning?).to be true
 
       # These expectations verify that the new manager and depositor were created and associated with the collection.
       # As well as verifying that an existing managers name is not overwritten.
@@ -51,7 +51,7 @@ RSpec.describe DepositCollectionJob do
 
   context 'when an existing collection' do
     let(:collection_form) { CollectionForm.new(title: collection_title_fixture, druid:, lock: 'abc123') }
-    let(:collection) { create(:collection, :deposit_job_started, druid:) }
+    let(:collection) { create(:collection, :persisting, druid:) }
 
     before do
       allow(Sdr::Repository).to receive_messages(open_if_needed: cocina_object, update: cocina_object)
@@ -67,7 +67,7 @@ RSpec.describe DepositCollectionJob do
       expect(Sdr::Repository).not_to have_received(:accession)
 
       expect(collection.reload.title).to eq(collection_title_fixture)
-      expect(collection.deposit_job_finished?).to be true
+      expect(collection.deposit_none?).to be true
     end
   end
 end

--- a/spec/jobs/deposit_complete_job_spec.rb
+++ b/spec/jobs/deposit_complete_job_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DepositCompleteJob do
+  subject(:job) { described_class.new }
+
+  let(:message) { { druid: object.druid }.to_json }
+
+  context 'when a work' do
+    let(:object) { create(:work, :with_druid, deposit_state: 'accessioning') }
+
+    it 'marks the accessioning as complete' do
+      expect { job.work(message) }.to change {
+        object.reload.deposit_state
+      }.from('accessioning').to('deposit_none')
+    end
+
+    it 'returns ack' do
+      expect(job.work(message)).to eq(:ack)
+    end
+  end
+
+  context 'when a collection' do
+    let(:object) { create(:collection, :with_druid, deposit_state: 'accessioning') }
+
+    it 'marks the accessioning as complete' do
+      expect { job.work(message) }.to change {
+        object.reload.deposit_state
+      }.from('accessioning').to('deposit_none')
+    end
+
+    it 'returns ack' do
+      expect(job.work(message)).to eq(:ack)
+    end
+  end
+
+  context 'when not accessioning' do
+    let(:object) { create(:work, :with_druid) }
+
+    it 'does not change the deposit state' do
+      expect { job.work(message) }.not_to(change { object.reload.deposit_state })
+    end
+
+    it 'returns ack' do
+      expect(job.work(message)).to eq(:ack)
+    end
+  end
+end

--- a/spec/jobs/deposit_work_job_spec.rb
+++ b/spec/jobs/deposit_work_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DepositWorkJob do
 
   context 'when a new work' do
     let(:work_form) { WorkForm.new(title: work.title, content_id: content.id, collection_druid: collection.druid) }
-    let(:work) { create(:work, :deposit_job_started, collection:, user:) }
+    let(:work) { create(:work, :persisting, collection:, user:) }
 
     it 'registers a new work' do
       expect do
@@ -35,7 +35,7 @@ RSpec.describe DepositWorkJob do
         .with(cocina_object: an_instance_of(Cocina::Models::RequestDRO), assign_doi: true)
       expect(Sdr::Repository).to have_received(:accession).with(druid:)
 
-      expect(work.reload.deposit_job_finished?).to be true
+      expect(work.reload.accessioning?).to be true
       expect(work.pending_review?).to be false
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe DepositWorkJob do
     let(:work_form) do
       WorkForm.new(title: work.title, content_id: content.id, collection_druid: collection.druid, doi_option: 'no')
     end
-    let(:work) { create(:work, :deposit_job_started, collection:) }
+    let(:work) { create(:work, :persisting, collection:) }
 
     it 'registers a new work' do
       described_class.perform_now(work_form:, work:, deposit: true, request_review: false)
@@ -58,7 +58,7 @@ RSpec.describe DepositWorkJob do
       WorkForm.new(title: title_fixture, druid:, content_id: content.id, lock: 'abc123',
                    collection_druid: collection.druid)
     end
-    let(:work) { create(:work, :deposit_job_started, druid:) }
+    let(:work) { create(:work, :persisting, druid:) }
 
     before do
       allow(Sdr::Repository).to receive_messages(open_if_needed: cocina_object, update: cocina_object)
@@ -79,7 +79,7 @@ RSpec.describe DepositWorkJob do
 
       expect(work.reload.title).to eq(title_fixture)
 
-      expect(work.deposit_job_finished?).to be true
+      expect(work.deposit_none?).to be true
     end
   end
 
@@ -87,7 +87,7 @@ RSpec.describe DepositWorkJob do
     let(:user) { create(:user, agreed_to_terms_at: nil) }
 
     let(:work_form) { WorkForm.new(title: work.title, content_id: content.id, collection_druid: collection.druid) }
-    let(:work) { create(:work, :deposit_job_started, collection:, user:) }
+    let(:work) { create(:work, :persisting, collection:, user:) }
 
     before do
       allow(Sdr::Repository).to receive(:register).and_return(cocina_object)
@@ -102,7 +102,7 @@ RSpec.describe DepositWorkJob do
 
   context 'when review requested' do
     let(:work_form) { WorkForm.new(title: work.title, content_id: content.id, collection_druid: collection.druid) }
-    let(:work) { create(:work, :deposit_job_started, collection:) }
+    let(:work) { create(:work, :persisting, collection:) }
 
     it 'registers a new work' do
       described_class.perform_now(work_form:, work:, deposit: true, request_review: true)

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -57,4 +57,15 @@ RSpec.describe Collection do
                                                                                  user:)
     end
   end
+
+  describe '.accession_complete!' do
+    let(:collection) { create(:collection, deposit_state: 'accessioning') }
+
+    it 'changes state and sends a notification' do
+      expect do
+        collection.accession_complete!
+      end.to change(collection, :deposit_state).from('accessioning').to('deposit_none')
+      expect(Notifier).to have_received(:publish).with(Notifier::ACCESSIONING_COMPLETE, object: collection)
+    end
+  end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -33,4 +33,13 @@ RSpec.describe Work do
       expect(Notifier).to have_received(:publish).with(Notifier::REVIEW_REJECTED, work:)
     end
   end
+
+  describe '.accession_complete!' do
+    let(:work) { create(:work, deposit_state: 'accessioning') }
+
+    it 'changes state and sends a notification' do
+      expect { work.accession_complete! }.to change(work, :deposit_state).from('accessioning').to('deposit_none')
+      expect(Notifier).to have_received(:publish).with(Notifier::ACCESSIONING_COMPLETE, object: work)
+    end
+  end
 end

--- a/spec/requests/edit_collection_spec.rb
+++ b/spec/requests/edit_collection_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Edit collection' do
   end
 
   context 'when the deposit job started' do
-    let!(:collection) { create(:collection, :deposit_job_started, druid:) }
+    let!(:collection) { create(:collection, :persisting, druid:) }
 
     before do
       sign_in(create(:user))

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Edit work' do
   end
 
   context 'when the deposit job started' do
-    let!(:work) { create(:work, :deposit_job_started, druid:) }
+    let!(:work) { create(:work, :persisting, druid:) }
 
     before do
       sign_in(create(:user))

--- a/spec/requests/show_collection_spec.rb
+++ b/spec/requests/show_collection_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Show collection' do
   end
 
   context 'when the deposit job started' do
-    let!(:collection) { create(:collection, :deposit_job_started, druid:, user:) }
+    let!(:collection) { create(:collection, :persisting, druid:, user:) }
     let(:user) { create(:user) }
 
     before do

--- a/spec/requests/show_work_spec.rb
+++ b/spec/requests/show_work_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Show work' do
   end
 
   context 'when the deposit job started' do
-    let!(:work) { create(:work, :deposit_job_started, druid:, user:) }
+    let!(:work) { create(:work, :persisting, druid:, user:) }
     let(:user) { create(:user) }
 
     before do


### PR DESCRIPTION
The RabbitMQ machinery is needed so that we know when accessioning is complete.

The deposit state is so that we can track when a work/collection is being persisted and accessioned.