### PR TITLE
Change approach to adding collection owner as a manager.

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -17,7 +17,7 @@ class CollectionsController < ApplicationController
 
   def new
     authorize! Collection
-    @collection_form = CollectionForm.new
+    @collection_form = CollectionForm.new(managers_attributes: [{ sunetid: current_user.sunetid }, {}])
 
     render :form
   end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -13,8 +13,6 @@ class Collection < ApplicationRecord
   has_many :managers, through: :collection_managers, source: :user
   has_many :reviewers, through: :collection_reviewers, source: :user
 
-  before_create :add_user_as_manager
-
   enum :release_option, { immediate: 'immediate', depositor_selects: 'depositor_selects' }, suffix: true
   enum :release_duration, { six_months: '6 months', one_year: '1 year', two_years: '2 years', three_years: '3 years' },
        suffix: true
@@ -52,10 +50,6 @@ class Collection < ApplicationRecord
                  3.years
                end
     Time.zone.today + duration
-  end
-
-  def add_user_as_manager
-    managers << user if user.present? && managers.exclude?(user)
   end
 
   def review_enabled?

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -9,32 +9,13 @@ RSpec.describe Collection do
     allow(Notifier).to receive(:publish)
   end
 
-  describe 'add user to collection' do
-    it 'adds the collection owner to the collection' do
-      collection = described_class.create(title: collection_title_fixture, user:)
-      expect(collection.managers).to eq([user])
-      expect(Notifier).to have_received(:publish).with(Notifier::MANAGER_ADDED, collection:, user:)
-    end
+  describe 'Add manager to collection' do
+    let(:collection) { described_class.create(title: collection_title_fixture, user:) }
 
-    context 'when collection owner is already a manager' do
-      it 'does not add the collection owner to the collection' do
-        collection = described_class.create(title: collection_title_fixture, user:, managers: [user])
-        expect(collection.managers).to eq([user])
-      end
-    end
-
-    context 'when no collection owner' do
-      it 'does not add the collection owner to the collection' do
-        collection = described_class.create(title: collection_title_fixture)
-        expect(collection.managers).to be_empty
-      end
-    end
-
-    context 'when a collection owner id is provided' do
-      it 'adds the collection owner to the collection' do
-        collection = described_class.create(title: collection_title_fixture, user_id: user.id)
-        expect(collection.managers).to eq([user])
-      end
+    it 'sends an event' do
+      collection.managers << user
+      expect(Notifier).to have_received(:publish).with(Notifier::MANAGER_ADDED, collection:,
+                                                                                user:)
     end
   end
 

--- a/spec/system/create_collection_deposit_spec.rb
+++ b/spec/system/create_collection_deposit_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe 'Create a collection deposit' do
     click_link_or_button('Next')
     expect(page).to have_css('.nav-link.active', text: 'Participants')
     expect(page).to have_text('Managers')
-    fill_in('collection_managers_attributes_0_sunetid', with: 'stepking')
+    expect(page).to have_field('SUNet ID', with: user.sunetid)
+    fill_in('collection_managers_attributes_1_sunetid', with: 'stepking')
     fill_in('collection_depositors_attributes_0_sunetid', with: 'joehill')
 
     # Clicking on Next to go to Deposit


### PR DESCRIPTION
The previous approach didn't work correctly, as the after_create callback would add the collection owner as a manager and that would be overwritten by the DepositCollectionJob.

This changes the approach to add the collection owner as a pre-filled value on the collection form.