### PR TITLE
Normalizes line breaks for abstract.

### DIFF
--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -3,6 +3,7 @@
 class ApplicationForm
   include ActiveModel::Model # Include this one first!
   include ActiveModel::NestedAttributes
+  include ActiveModel::Validations::Callbacks
 
   FORM_CLASS_SUFFIX = 'Form'
 

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -29,6 +29,7 @@ class WorkForm < ApplicationForm
 
   attribute :abstract, :string
   validates :abstract, presence: true, on: :deposit
+  before_validation ->(work_form) { work_form.abstract = LinebreakSupport.normalize(work_form.abstract) }
 
   attribute :citation, :string
   attribute :auto_generate_citation, :boolean

--- a/app/services/linebreak_support.rb
+++ b/app/services/linebreak_support.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Support methods for line breaks
+class LinebreakSupport
+  # Normalize line breaks to CR+LF
+  def self.normalize(text)
+    return text if text.nil?
+
+    text.encode(Encoding::UTF_8, universal_newline: true).encode(Encoding::UTF_8, crlf_newline: true)
+  end
+end

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -39,7 +39,7 @@
 <% end %>
 
 <%= render Elements::Tables::TableComponent.new(id: 'description-table', classes: 'mb-5', label: 'Abstract and keywords') do |component| %>
-  <% component.with_row(label: 'Abstract', values: [@work_presenter.abstract]) %>
+  <% component.with_row(label: 'Abstract', values: [simple_format(@work_presenter.abstract).html_safe]) %> <%# erb_lint:disable ErbSafety %>
   <% component.with_row(label: 'Keywords', values: [@work_presenter.keywords]) %>
 <% end %>
 

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe WorkForm do
         authors_attributes: authors_fixture,
         work_type:,
         work_subtypes:,
-        other_work_subtype:
+        other_work_subtype:,
+        abstract:
       )
     end
     let(:work_type) { '' }
     let(:work_subtypes) { [] }
     let(:other_work_subtype) { '' }
+    let(:abstract) { abstract_fixture }
 
     context 'when saving draft with blank work type' do
       it 'is valid' do
@@ -140,6 +142,23 @@ RSpec.describe WorkForm do
       it 'is invalid' do
         expect(form).not_to be_valid
       end
+    end
+  end
+
+  describe 'Abstract linefeed normalization' do
+    let(:form) do
+      described_class.new(
+        title: title_fixture,
+        contact_emails_attributes: contact_emails_fixture,
+        authors_attributes: authors_fixture,
+        abstract:
+      )
+    end
+    let(:abstract) { "This is a test.\n\nThis is a second paragraph." }
+
+    it 'normalizes linefeeds' do
+      expect(form).to be_valid
+      expect(form.abstract).to eq("This is a test.\r\n\r\nThis is a second paragraph.")
     end
   end
 end

--- a/spec/services/linebreak_support_spec.rb
+++ b/spec/services/linebreak_support_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LinebreakSupport do
+  it 'normalizes to CRLF' do
+    expect(described_class.normalize("foo\r\nbar")).to eq("foo\r\nbar")
+    expect(described_class.normalize("foo\nbar")).to eq("foo\r\nbar")
+    expect(described_class.normalize("foo\rbar")).to eq("foo\r\nbar")
+    expect(described_class.normalize("foo\n\nbar")).to eq("foo\r\n\r\nbar")
+  end
+end


### PR DESCRIPTION
closes #519

<img width="593" alt="image" src="https://github.com/user-attachments/assets/0c4207eb-ee48-4ba7-8f36-b88c75e02588" />

<img width="443" alt="image" src="https://github.com/user-attachments/assets/8b685414-d2f1-4d1e-9798-846eb5931ca7" />
