### PR TITLE
Do not memoize in DepositCompleteJob.

### DIFF
--- a/app/jobs/deposit_complete_job.rb
+++ b/app/jobs/deposit_complete_job.rb
@@ -32,7 +32,7 @@ class DepositCompleteJob
   private
 
   def message
-    @message ||= JSON.parse(@msg_str)
+    JSON.parse(@msg_str)
   end
 
   def druid


### PR DESCRIPTION
Sneakers re-uses the instance, which was causing the new message to not be processed.