### PR TITLE
[DEV QoL SPIKE] Quiet warnings when building CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "stylelint-config-standard-scss": "^14.0.0"
   },
   "scripts": {
-    "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules",
+    "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --quiet",
     "build:css:prefix": "postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css",
     "build:css": "yarn build:css:compile && yarn build:css:prefix",
     "watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"yarn build:css\"",


### PR DESCRIPTION
Trimmer, saner output that doesn't inundate us with noise, 90% of which we are powerless to fix (because it's in dependencies like bootstrap):

```shell
$ bin/dev
system | Tmux socket name: overmind-hungry-hungry-hippo-tp8bTK3qyPofgItHqxRPv
system | Tmux session ID: hungry-hungry-hippo
system | Listening at ./.overmind.sock
css    | Started with pid 49102...
web    | Started with pid 49101...
jobs   | Started with pid 49103...
yarn install v1.22.19
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.11s.
yarn run v1.22.19
$ nodemon --watch ./app/assets/stylesheets/ --ext scss --exec "yarn build:css"
css    | [nodemon] 3.1.9
css    | [nodemon] to restart at any time, enter `rs`
css    | [nodemon] watching path(s): app/assets/stylesheets/**/*
css    | [nodemon] watching extensions: scss
css    | [nodemon] starting `yarn build:css`
web    | => Booting Puma
web    | => Rails 8.0.1 application starting in development
web    | => Run `bin/rails server --help` for more startup options
$ yarn build:css:compile && yarn build:css:prefix
web    | Puma starting in single mode...
web    | * Puma version: 6.5.0 ("Sky's Version")
web    | * Ruby version: ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
web    | *  Min threads: 3
web    | *  Max threads: 3
web    | *  Environment: development
web    | *          PID: 49104
web    | * Listening on http://127.0.0.1:3000
web    | * Listening on http://[::1]:3000
web    | Use Ctrl-C to stop
$ sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --quiet
$ postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css
css    | [nodemon] clean exit - waiting for changes before restart
```