### PR TITLE
Use JSON coverage formatter in CI

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,12 @@ require 'simplecov'
 
 SimpleCov.start :rails do
   add_filter '/lib/tasks/'
+
+  if ENV['CI']
+    require 'simplecov_json_formatter'
+
+    formatter SimpleCov::Formatter::JSONFormatter
+  end
 end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'


### PR DESCRIPTION
This currently works automagically because the CC_TEST_REPORTER_ID is set in CircleCI, but we do not want to depend on the presence of a CodeClimate env var forever. Less magic.
