### PR TITLE
Update the component library to v2025-02-04

### DIFF
--- a/app/assets/stylesheets/component_library_overrides.css
+++ b/app/assets/stylesheets/component_library_overrides.css
@@ -2,7 +2,4 @@
   /* Use dark identity bar */
   --identity-bar-color: white;
   --identity-bar-bg-color: var(--stanford-cardinal);
-
-  /* White logo for footer */
-  --sul-logo-color: white;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, 'data-turbo-track': 'reload' %>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-02-03/styles/sul.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-02-04/styles/sul.css">
     <link rel="stylesheet" href="https://unpkg.com/stimulus-datepicker@1.0.9/css/datepicker.css" data-turbo-track="reload">
     <%= stylesheet_link_tag 'component_library_overrides' %>
     <%= javascript_importmap_tags %>


### PR DESCRIPTION
This brings in updates to the header (darker border line) and removes the need for
a component library override for the footer.
