### PR TITLE
Add collection license tab

### DIFF
--- a/app/components/collections/edit/license_component.html.erb
+++ b/app/components/collections/edit/license_component.html.erb
@@ -1,0 +1,23 @@
+<fieldset>
+  <div class="form-check d-flex pt-2">
+    <div class="ps-2">
+      <%= form.radio_button :license_option, 'required', class: 'form-check-input' %>
+      <%= form.label :license_option_required, 'Require license for all deposits', class: 'form-check-label' %>
+    </div>
+    <div class="ps-2">
+      <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :license, options: license_options, required: true, hidden_label: true, label:, width: 250, container_classes: 'mb-4', label_classes: 'h5') %>
+    </div>
+    <div class="ps-2">
+      <a href="https://sdr.library.stanford.edu/documentation/license-options">Get help selecting a license</a>
+    </div>
+  </div>
+  <div class="form-check d-flex pt-2">
+    <div class="ps-2">
+      <%= form.radio_button :license_option, 'depositor_selects', class: 'form-check-input' %>
+      <%= form.label :license_option_depositor_selects, 'Depositor selects license', class: 'form-check-label' %>
+    </div>
+    <div class="ps-2">
+      <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :suggested_license, options: license_options, required: true, hidden_label: true, label:, width: 250, container_classes: 'mb-4', label_classes: 'h5') %>
+    </div>
+  </div>
+</fieldset>

--- a/app/components/collections/edit/license_component.html.erb
+++ b/app/components/collections/edit/license_component.html.erb
@@ -17,7 +17,7 @@
       <%= form.label :license_option_depositor_selects, 'Depositor selects license', class: 'form-check-label' %>
     </div>
     <div class="ps-2">
-      <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :suggested_license, options: license_options, required: true, hidden_label: true, label:, width: 250, container_classes: 'mb-4', label_classes: 'h5') %>
+      <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :default_license, options: license_options, required: true, hidden_label: true, label:, width: 250, container_classes: 'mb-4', label_classes: 'h5') %>
     </div>
   </div>
 </fieldset>

--- a/app/components/collections/edit/license_component.html.erb
+++ b/app/components/collections/edit/license_component.html.erb
@@ -5,10 +5,10 @@
       <%= form.label :license_option_required, 'Require license for all deposits', class: 'form-check-label' %>
     </div>
     <div class="ps-2">
-      <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :license, options: license_options, required: true, hidden_label: true, label:, width: 250, container_classes: 'mb-4', label_classes: 'h5') %>
+      <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :license, options: license_options, hidden_label: true, label:, width: 250, container_classes: 'mb-4') %>
     </div>
     <div class="ps-2">
-      <a href="https://sdr.library.stanford.edu/documentation/license-options">Get help selecting a license</a>
+      <%= helpers.link_to_new_tab('Get help selecting a license', Settings.license_url) %>
     </div>
   </div>
   <div class="form-check d-flex pt-2">
@@ -17,7 +17,7 @@
       <%= form.label :license_option_depositor_selects, 'Depositor selects license', class: 'form-check-label' %>
     </div>
     <div class="ps-2">
-      <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :default_license, options: license_options, required: true, hidden_label: true, label:, width: 250, container_classes: 'mb-4', label_classes: 'h5') %>
+      <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :default_license, options: license_options, hidden_label: true, label:, width: 250, container_classes: 'mb-4') %>
     </div>
   </div>
 </fieldset>

--- a/app/components/collections/edit/license_component.rb
+++ b/app/components/collections/edit/license_component.rb
@@ -11,32 +11,18 @@ module Collections
 
       attr_reader :form
 
-      def field_name
-        :license
-      end
-
       def label
         helpers.t('license.edit.fields.label')
-      end
-
-      def help_text
-        helpers.t('collections.edit.fields.license.help_text')
       end
 
       def license_options
         License::GROUPS.to_h do |group|
           licenses = License.where(group:).filter_map do |license|
-            # Include all non-deprecated licenses and the current license (even if deprecated).
-            [license.label, license.id] if !license.deprecated || license.id == current_license
+            # Include all non-deprecated licenses
+            [license.label, license.id] unless license.deprecated
           end
           [group, licenses]
         end
-      end
-
-      def current_license
-        # TODO
-        # form.license || '' # Treat nil as no license ('')
-        ''
       end
     end
   end

--- a/app/components/collections/edit/license_component.rb
+++ b/app/components/collections/edit/license_component.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Collections
+  module Edit
+    # Select field for license
+    class LicenseComponent < ApplicationComponent
+      def initialize(form:)
+        @form = form
+        super()
+      end
+
+      attr_reader :form
+
+      def field_name
+        :license
+      end
+
+      def label
+        helpers.t('license.edit.fields.label')
+      end
+
+      def help_text
+        helpers.t('collections.edit.fields.license.help_text')
+      end
+
+      def license_options
+        License::GROUPS.to_h do |group |
+          licenses = License.where(group:).filter_map do |license|
+            # Include all non-deprecated licenses and the current license (even if deprecated).
+            [license.label, license.id] if !license.deprecated || license.id == current_license
+          end
+          [group, licenses]
+        end
+      end
+
+      def current_license
+        # TODO
+        # form.license || '' # Treat nil as no license ('')
+        ''
+      end
+    end
+  end
+end

--- a/app/components/collections/edit/license_component.rb
+++ b/app/components/collections/edit/license_component.rb
@@ -24,7 +24,7 @@ module Collections
       end
 
       def license_options
-        License::GROUPS.to_h do |group |
+        License::GROUPS.to_h do |group|
           licenses = License.where(group:).filter_map do |license|
             # Include all non-deprecated licenses and the current license (even if deprecated).
             [license.label, license.id] if !license.deprecated || license.id == current_license

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -36,7 +36,7 @@ class CollectionsController < ApplicationController
     render :form
   end
 
-  def create
+  def create # rubocop:disable Metrics/AbcSize
     authorize! Collection
     @collection_form = CollectionForm.new(**collection_params)
     if @collection_form.valid?

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -36,7 +36,7 @@ class CollectionsController < ApplicationController
     render :form
   end
 
-  def create # rubocop:disable Metrics/AbcSize
+  def create
     authorize! Collection
     @collection_form = CollectionForm.new(**collection_params)
     if @collection_form.valid?
@@ -45,8 +45,6 @@ class CollectionsController < ApplicationController
                                       release_duration: @collection_form.release_duration,
                                       access: @collection_form.access,
                                       doi_option: @collection_form.doi_option,
-                                      license_option: @collection_form.license_option,
-                                      license: @collection_form.license,
                                       user: current_user,
                                       deposit_state_event: 'deposit_persist')
       DepositCollectionJob.perform_later(collection:, collection_form: @collection_form)

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -45,6 +45,8 @@ class CollectionsController < ApplicationController
                                       release_duration: @collection_form.release_duration,
                                       access: @collection_form.access,
                                       doi_option: @collection_form.doi_option,
+                                      license_option: @collection_form.license_option,
+                                      license: @collection_form.license,
                                       user: current_user,
                                       deposit_state_event: 'deposit_persist')
       DepositCollectionJob.perform_later(collection:, collection_form: @collection_form)

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -29,6 +29,19 @@ class CollectionForm < ApplicationForm
   attribute :access, :string, default: 'world'
   validates :access, inclusion: { in: %w[world stanford depositor_selects] }
 
+  attribute :license_option, :string, default: 'required'
+  validates :license_option, inclusion: { in: %w[required depositor_selects] }
+
+  attribute :license, :string
+  with_options if: -> { license_option == 'required' } do
+    validate :license_present
+  end
+
+  attribute :suggested_license
+  with_options if: -> { license_option == 'depositor_selects' } do
+    validate :suggested_license_present
+  end
+
   attribute :release_option, :string, default: 'immediate'
   validates :release_option, inclusion: { in: %w[immediate depositor_selects] }
 
@@ -45,4 +58,16 @@ def duration_must_be_present
   return if release_duration.present?
 
   errors.add(:release_duration, 'select a valid duration for release')
+end
+
+def license_present
+  return if license.present?
+
+  errors.add(:license, 'select a valid license')
+end
+
+def suggested_license_present
+  return if suggested_license.present?
+
+  errors.add(:suggested_license, 'select a valid license')
 end

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -37,9 +37,9 @@ class CollectionForm < ApplicationForm
     validate :license_present
   end
 
-  attribute :suggested_license
+  attribute :default_license
   with_options if: -> { license_option == 'depositor_selects' } do
-    validate :suggested_license_present
+    validate :default_license_present
   end
 
   attribute :release_option, :string, default: 'immediate'
@@ -66,8 +66,8 @@ def license_present
   errors.add(:license, 'select a valid license')
 end
 
-def suggested_license_present
-  return if suggested_license.present?
+def default_license_present
+  return if default_license.present?
 
-  errors.add(:suggested_license, 'select a valid license')
+  errors.add(:default_license, 'select a valid license')
 end

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -33,14 +33,10 @@ class CollectionForm < ApplicationForm
   validates :license_option, inclusion: { in: %w[required depositor_selects] }
 
   attribute :license, :string
-  with_options if: -> { license_option == 'required' } do
-    validate :license_present
-  end
+  validates :license, presence: true, if: -> { license_option == 'required' }
 
   attribute :default_license
-  with_options if: -> { license_option == 'depositor_selects' } do
-    validate :default_license_present
-  end
+  validates :default_license, presence: true, if: -> { license_option == 'depositor_selects' }
 
   attribute :release_option, :string, default: 'immediate'
   validates :release_option, inclusion: { in: %w[immediate depositor_selects] }
@@ -58,16 +54,4 @@ def duration_must_be_present
   return if release_duration.present?
 
   errors.add(:release_duration, 'select a valid duration for release')
-end
-
-def license_present
-  return if license.present?
-
-  errors.add(:license, 'select a valid license')
-end
-
-def default_license_present
-  return if default_license.present?
-
-  errors.add(:default_license, 'select a valid license')
 end

--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -68,6 +68,8 @@ class DepositCollectionJob < ApplicationJob
   end
 
   def license
-    @collection_form.license_option == 'depositor_selects' ? @collection_form.suggested_license : @collection_form.license
+    return @collection_form.license if @collection_form.license_option == 'required'
+
+    @collection_form.suggested_license
   end
 end

--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -15,6 +15,8 @@ class DepositCollectionJob < ApplicationJob
                        release_option: @collection_form.release_option,
                        release_duration: @collection_form.release_duration,
                        access: @collection_form.access,
+                       license_option: @collection_form.license_option,
+                       license:,
                        doi_option: @collection_form.doi_option)
 
     assign_participants(:managers)
@@ -63,5 +65,9 @@ class DepositCollectionJob < ApplicationJob
 
   def sunetid_to_email_address(sunetid)
     "#{sunetid}#{User::EMAIL_SUFFIX}"
+  end
+
+  def license
+    @collection_form.license_option == 'depositor_selects' ? @collection_form.suggested_license : @collection_form.license
   end
 end

--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -70,6 +70,6 @@ class DepositCollectionJob < ApplicationJob
   def license
     return @collection_form.license if @collection_form.license_option == 'required'
 
-    @collection_form.suggested_license
+    @collection_form.default_license
   end
 end

--- a/app/services/to_cocina/collection/mapper.rb
+++ b/app/services/to_cocina/collection/mapper.rb
@@ -35,7 +35,7 @@ module ToCocina
           label: collection_form.title,
           description: ToCocina::Collection::DescriptionMapper.call(collection_form:),
           version: collection_form.version,
-          access: { view: 'world' },
+          access:,
           identification: { sourceId: source_id },
           administrative: { hasAdminPolicy: Settings.apo }
         }.compact
@@ -45,6 +45,12 @@ module ToCocina
         params.tap do |params_hash|
           params_hash[:administrative][:partOfProject] = Settings.project_tag
         end
+      end
+
+      def access
+        return { view: 'world' } unless collection_form.license.present?
+
+        { view: 'world', license: collection_form.license }
       end
     end
   end

--- a/app/services/to_cocina/collection/mapper.rb
+++ b/app/services/to_cocina/collection/mapper.rb
@@ -48,7 +48,7 @@ module ToCocina
       end
 
       def access
-        return { view: 'world' } unless collection_form.license.present?
+        return { view: 'world' } if collection_form.license.blank?
 
         { view: 'world', license: collection_form.license }
       end

--- a/app/services/to_cocina/collection/mapper.rb
+++ b/app/services/to_cocina/collection/mapper.rb
@@ -48,9 +48,7 @@ module ToCocina
       end
 
       def access
-        return { view: 'world' } if collection_form.license.blank?
-
-        { view: 'world', license: collection_form.license }
+        { view: 'world', license: collection_form.license }.compact
       end
     end
   end

--- a/app/services/to_collection_form/mapper.rb
+++ b/app/services/to_collection_form/mapper.rb
@@ -33,12 +33,11 @@ module ToCollectionForm
         release_duration: collection.release_duration,
         access: collection.access,
         license_option: collection.license_option,
-        license: collection.license,
         doi_option: collection.doi_option,
         managers_attributes: participant_attributes(:managers),
         depositors_attributes: participant_attributes(:depositors),
         version: cocina_object.version
-      }
+      }.merge(license)
     end
     # rubocop:enable Metrics/AbcSize
 
@@ -49,6 +48,12 @@ module ToCollectionForm
       collection.send(role).map do |participant|
         { sunetid: participant.sunetid }
       end
+    end
+
+    def license
+      return { license: collection.license } if collection.license_option == 'required'
+
+      { suggested_license: collection.license }
     end
   end
 end

--- a/app/services/to_collection_form/mapper.rb
+++ b/app/services/to_collection_form/mapper.rb
@@ -37,7 +37,7 @@ module ToCollectionForm
         managers_attributes: participant_attributes(:managers),
         depositors_attributes: participant_attributes(:depositors),
         version: cocina_object.version
-      }.merge(license)
+      }.merge(license_params)
     end
     # rubocop:enable Metrics/AbcSize
 
@@ -50,7 +50,7 @@ module ToCollectionForm
       end
     end
 
-    def license
+    def license_params
       return { license: collection.license } if collection.license_option == 'required'
 
       { default_license: collection.license }

--- a/app/services/to_collection_form/mapper.rb
+++ b/app/services/to_collection_form/mapper.rb
@@ -32,6 +32,8 @@ module ToCollectionForm
         release_option: collection.release_option,
         release_duration: collection.release_duration,
         access: collection.access,
+        license_option: collection.license_option,
+        license: collection.license,
         doi_option: collection.doi_option,
         managers_attributes: participant_attributes(:managers),
         depositors_attributes: participant_attributes(:depositors),

--- a/app/services/to_collection_form/mapper.rb
+++ b/app/services/to_collection_form/mapper.rb
@@ -53,7 +53,7 @@ module ToCollectionForm
     def license
       return { license: collection.license } if collection.license_option == 'required'
 
-      { suggested_license: collection.license }
+      { default_license: collection.license }
     end
   end
 end

--- a/app/views/collections/form.html.erb
+++ b/app/views/collections/form.html.erb
@@ -20,6 +20,7 @@
   <% component.with_tab(label: I18n.t('collections.edit.panes.details.tab_label'), tab_name: :details, selected: true) %>
   <% component.with_tab(label: I18n.t('collections.edit.panes.related_links.tab_label'), tab_name: :related_links) %>
   <% component.with_tab(label: I18n.t('collections.edit.panes.access.tab_label'), tab_name: :access) %>
+  <% component.with_tab(label: I18n.t('collections.edit.panes.license.tab_label'), tab_name: :license) %>
   <% component.with_tab(label: I18n.t('collections.edit.panes.participants.tab_label'), tab_name: :participants) %>
   <% component.with_tab(label: I18n.t('collections.edit.panes.deposit.tab_label'), tab_name: :deposit) %>
   <%# The panes below need a form in order to render their contents. This provides a "fake" form to use for that purpose. %>
@@ -42,6 +43,13 @@
     <% component.with_pane do %>
       <%= render Collections::Edit::PaneComponent.new(tab_name: :access, label: I18n.t('collections.edit.panes.access.label')) do %>
         <%= render Collections::Edit::AccessSettingsComponent.new(form:) %>
+      <% end %>
+    <% end %>
+
+    <% component.with_pane do %>
+      <%= render Collections::Edit::PaneComponent.new(tab_name: :license, label: I18n.t('collections.edit.panes.license.label')) do %>
+        <p><%= t('collections.edit.panes.license.help_text') %></p>
+        <%= render Collections::Edit::LicenseComponent.new(form:) %>
       <% end %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,12 @@ en:
           attributes:
             orcid:
               invalid: 'must be formatted as "XXXX-XXXX-XXXX-XXXX"'
+        collection:
+          attributes:
+            license:
+              blank: 'select a valid license'
+            default_license:
+              blank: 'select a valid license'
   time:
     formats:
       long: '%B %d, %Y'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,7 +222,7 @@ en:
         access:
           world: 'Everyone -- anyone in the world will be able to download the files for all deposits in this collection.'
           stanford: 'Stanford Community -- only members of the Stanford community will be able to download the files for all deposits in this collection.'
-          depositor_selects: 'Depositor selects -- default for all deposits will be that everyone can download the files, but Depositor can choose to 
+          depositor_selects: 'Depositor selects -- default for all deposits will be that everyone can download the files, but Depositor can choose to
             restrict file download for their deposit to the Stanford community.'
         doi_option:
           doi_yes: 'Yes, a DOI will be assigned to each deposit in this collection.'
@@ -245,7 +245,8 @@ en:
           tab_label: 'License'
           label: 'License'
           help_text: >
-            More text here.
+            We highly recommend every deposit be assigned a license when possible. A license helps other who access the
+            content to understand what the Depositor is allowing them to do with the work and under what conditions.
         related_links:
           tab_label: 'Related links'
           label: 'Links to related content (optional)'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -47,6 +47,7 @@ datacite:
 
 terms_url: https://sdr.sites.stanford.edu/documentation/understanding-sdr-terms-deposit
 newsletter_url: https://stanford.us20.list-manage.com/subscribe?u=139e1b2d3df8f8cacd77c8160&id=4f4148a871
+license_url: https://sdr.library.stanford.edu/documentation/license-options
 
 host: 'localhost:3000'
 

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -10,8 +10,8 @@ FactoryBot.define do
     doi_option { 'yes' }
     custom_rights_statement_option { 'provided' }
     provided_custom_rights_statement { 'My custom rights statement' }
-    license_option { 'depositor_selects' }
-    license { 'https://www.apache.org/licenses/LICENSE-2.0' }
+    license_option { 'required' }
+    license { 'https://creativecommons.org/licenses/by/4.0/legalcode' }
     review_enabled { false }
 
     trait :with_review_workflow do

--- a/spec/services/importers/collection_spec.rb
+++ b/spec/services/importers/collection_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Importers::Collection do
       access: 'stanford',
       doi_option: 'yes',
       license_option: 'required',
-      required_license: 'CC0-1.0',
+      required_license: 'https://creativecommons.org/licenses/by/4.0/legalcode',
       default_license: nil,
       allow_custom_rights_statement: true,
       provided_custom_rights_statement: nil,

--- a/spec/support/collection_fixtures.rb
+++ b/spec/support/collection_fixtures.rb
@@ -51,3 +51,7 @@ end
 def doi_option_fixture
   'yes'
 end
+
+def collection_license_fixture
+  'https://creativecommons.org/licenses/by/4.0/legalcode'
+end

--- a/spec/support/collection_mapping_fixtures.rb
+++ b/spec/support/collection_mapping_fixtures.rb
@@ -10,6 +10,8 @@ module CollectionMappingFixtures
       release_option: 'depositor_selects',
       release_duration: 'one_year',
       access: 'depositor_selects',
+      license_option: 'required',
+      license: collection_license_fixture,
       doi_option: 'yes',
       contact_emails_attributes: contact_emails_fixture,
       related_links_attributes: related_links_fixture,
@@ -42,7 +44,7 @@ module CollectionMappingFixtures
         version: 1,
         identification: { sourceId: collection_source_id_fixture },
         administrative: { hasAdminPolicy: Settings.apo, partOfProject: Settings.project_tag },
-        access: { view: 'world' }
+        access: { view: 'world', license: collection_license_fixture }
       }
     )
   end
@@ -65,7 +67,7 @@ module CollectionMappingFixtures
         version: 2,
         identification: { sourceId: collection_source_id_fixture },
         administrative: { hasAdminPolicy: Settings.apo },
-        access: { view: 'world' }
+        access: { view: 'world', license: collection_license_fixture }
       }
     )
   end

--- a/spec/system/create_collection_deposit_spec.rb
+++ b/spec/system/create_collection_deposit_spec.rb
@@ -75,6 +75,16 @@ RSpec.describe 'Create a collection deposit' do
     expect(page).to have_checked_field('Immediately')
     expect(page).to have_select('Release duration', selected: 'Select an option')
 
+    # Clicking on Next to go to License tab
+    click_link_or_button('Next')
+    expect(page).to have_css('.nav-link.active', text: 'License')
+    expect(page).to have_text('License')
+    expect(page).to have_checked_field('Require license for all deposits')
+    expect(page).to have_select('License', selected: 'No License')
+    find_by_id('collection_license').click
+    select('CC-BY-4.0 Attribution International', from: 'collection_license')
+    expect(page).to have_select('License', selected: 'CC-BY-4.0 Attribution International')
+
     # Clicking on Next to go to Participants tab
     click_link_or_button('Next')
     expect(page).to have_css('.nav-link.active', text: 'Participants')

--- a/spec/system/create_work_deposit_spec.rb
+++ b/spec/system/create_work_deposit_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe 'Create a work deposit' do
     allow(Sdr::Repository).to receive(:find).with(druid:).and_invoke(->(_arg) { @registered_cocina_object })
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
     create(:collection, user:, druid: collection_druid_fixture, managers: [user],
-                        custom_rights_statement_option: 'depositor_selects', doi_option: 'depositor_selects')
+                        custom_rights_statement_option: 'depositor_selects', doi_option: 'depositor_selects',
+                        license_option: 'depositor_selects', license: 'https://www.apache.org/licenses/LICENSE-2.0')
     sign_in(user)
   end
 

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -107,6 +107,16 @@ RSpec.describe 'Edit a collection' do
     select('3 years in the future', from: 'collection_release_duration')
     expect(page).to have_select('Release duration', selected: '3 years in the future')
 
+    # Clicking on Next to go to License tab
+    # click_link_or_button('Next')
+    # expect(page).to have_css('.nav-link.active', text: 'License')
+    # expect(page).to have_text('License')
+    # expect(page).to have_checked_field('Require license for all deposits')
+    # expect(page).to have_select('License', selected: 'No License')
+    # find_by_id('collection_license').click
+    # select('CC-BY-4.0 Attribution International', from: 'collection_license')
+    # expect(page).to have_select('License', selected: 'CC-BY-4.0 Attribution International')
+
     # Clicking on Next to go to Participants tab
     click_link_or_button('Next')
     expect(page).to have_css('.nav-link.active', text: 'Participants')

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -108,14 +108,14 @@ RSpec.describe 'Edit a collection' do
     expect(page).to have_select('Release duration', selected: '3 years in the future')
 
     # Clicking on Next to go to License tab
-    # click_link_or_button('Next')
-    # expect(page).to have_css('.nav-link.active', text: 'License')
-    # expect(page).to have_text('License')
-    # expect(page).to have_checked_field('Require license for all deposits')
-    # expect(page).to have_select('License', selected: 'No License')
-    # find_by_id('collection_license').click
-    # select('CC-BY-4.0 Attribution International', from: 'collection_license')
-    # expect(page).to have_select('License', selected: 'CC-BY-4.0 Attribution International')
+    click_link_or_button('Next')
+    expect(page).to have_css('.nav-link.active', text: 'License')
+    expect(page).to have_checked_field('Require license for all deposits')
+    expect(page).to have_select('License', selected: 'CC-BY-4.0 Attribution International')
+    find_by_id('collection_license_option_depositor_selects').click
+    find_by_id('collection_default_license').click
+    select('CC-BY-4.0 Attribution International', from: 'collection_default_license')
+    expect(page).to have_select('License', selected: 'CC-BY-4.0 Attribution International')
 
     # Clicking on Next to go to Participants tab
     click_link_or_button('Next')

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe 'Show a collection' do
       expect(page).to have_css('td', text: 'User agrees that')
       expect(page).to have_css('tr', text: 'Additional terms of use')
       expect(page).to have_css('td', text: 'My custom rights statement')
-      expect(page).to have_css('tr', text: 'Default license (depositor selects)')
-      expect(page).to have_css('td', text: 'Apache-2.0')
+      expect(page).to have_css('tr', text: 'Required license')
+      expect(page).to have_css('td', text: 'CC-BY-4.0 Attribution International')
     end
 
     # Participants table

--- a/spec/system/validate_collection_deposit_spec.rb
+++ b/spec/system/validate_collection_deposit_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Validate a collection deposit' do
     sign_in(user, groups:)
   end
 
-  it 'validates a work' do
+  it 'validates a collection' do
     visit collection_path
 
     expect(page).to have_css('h1', text: 'Untitled collection')
@@ -33,7 +33,7 @@ RSpec.describe 'Validate a collection deposit' do
     find_by_id('collection_release_option_depositor_selects').click
     expect(page).to have_select('Release duration', selected: 'Select an option')
 
-    # Depositing the work
+    # Depositing the collection
     find('.nav-link', text: 'Deposit', exact_text: true).click
     expect(page).to have_css('.nav-link.active', text: 'Deposit')
     click_link_or_button('Deposit')
@@ -66,6 +66,28 @@ RSpec.describe 'Validate a collection deposit' do
     expect(page).to have_css('.invalid-feedback.is-invalid', text: 'select a valid duration for release')
     select('3 years in the future', from: 'collection_release_duration')
     expect(page).to have_select('Release duration', selected: '3 years in the future')
+
+    # License is marked invalid
+    find('.nav-link', text: 'License').click
+    expect(page).to have_css('.invalid-feedback.is-invalid', text: 'select a valid license')
+    find_by_id('collection_license_option_depositor_selects').click
+
+    # Try to deposit again
+    find('.nav-link', text: 'Deposit', exact_text: true).click
+    expect(page).to have_css('.nav-link.active', text: 'Deposit')
+    click_link_or_button('Deposit')
+    expect(page).to have_css('h1', text: collection_title_fixture)
+    expect(page).to have_current_path(collection_path)
+
+    # Alert
+    expect(page).to have_css('.alert-danger', text: 'Required fields have not been filled out.')
+
+    # License is still marked invalid
+    find('.nav-link', text: 'License').click
+    expect(page).to have_css('.invalid-feedback.is-invalid', text: 'select a valid license')
+    find_by_id('collection_license_option_depositor_selects').click
+    select('CC-BY-4.0 Attribution International', from: 'collection_default_license')
+    expect(page).to have_select('License', selected: 'CC-BY-4.0 Attribution International')
 
     # Try to deposit again
     find('.nav-link', text: 'Deposit', exact_text: true).click


### PR DESCRIPTION
Fixes #272 

Note: I'm curious if saving the license to cocina for a collection makes sense. While I'm pretty sure it's not really used at all in H3, perhaps it is used elsewhere so we need to include it.

![Screenshot 2025-02-05 at 2 00 52 PM](https://github.com/user-attachments/assets/dd861ec7-2d38-4ab9-b4c3-ffcd7a0f0ffb)
