### PR TITLE
Allow No License as a valid option when creating a collection

### DIFF
--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -33,10 +33,7 @@ class CollectionForm < ApplicationForm
   validates :license_option, inclusion: { in: %w[required depositor_selects] }
 
   attribute :license, :string
-  validates :license, presence: true, if: -> { license_option == 'required' }
-
   attribute :default_license
-  validates :default_license, presence: true, if: -> { license_option == 'depositor_selects' }
 
   attribute :release_option, :string, default: 'immediate'
   validates :release_option, inclusion: { in: %w[immediate depositor_selects] }

--- a/app/services/to_cocina/collection/mapper.rb
+++ b/app/services/to_cocina/collection/mapper.rb
@@ -48,7 +48,7 @@ module ToCocina
       end
 
       def access
-        { view: 'world', license: collection_form.license }.compact
+        { view: 'world', license: collection_form.license }.compact_blank!
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,12 +44,6 @@ en:
           attributes:
             orcid:
               invalid: 'must be formatted as "XXXX-XXXX-XXXX-XXXX"'
-        collection:
-          attributes:
-            license:
-              blank: 'select a valid license'
-            default_license:
-              blank: 'select a valid license'
   time:
     formats:
       long: '%B %d, %Y'

--- a/spec/system/validate_collection_deposit_spec.rb
+++ b/spec/system/validate_collection_deposit_spec.rb
@@ -67,28 +67,6 @@ RSpec.describe 'Validate a collection deposit' do
     select('3 years in the future', from: 'collection_release_duration')
     expect(page).to have_select('Release duration', selected: '3 years in the future')
 
-    # License is marked invalid
-    find('.nav-link', text: 'License').click
-    expect(page).to have_css('.invalid-feedback.is-invalid', text: 'select a valid license')
-    find_by_id('collection_license_option_depositor_selects').click
-
-    # Try to deposit again
-    find('.nav-link', text: 'Deposit', exact_text: true).click
-    expect(page).to have_css('.nav-link.active', text: 'Deposit')
-    click_link_or_button('Deposit')
-    expect(page).to have_css('h1', text: collection_title_fixture)
-    expect(page).to have_current_path(collection_path)
-
-    # Alert
-    expect(page).to have_css('.alert-danger', text: 'Required fields have not been filled out.')
-
-    # License is still marked invalid
-    find('.nav-link', text: 'License').click
-    expect(page).to have_css('.invalid-feedback.is-invalid', text: 'select a valid license')
-    find_by_id('collection_license_option_depositor_selects').click
-    select('CC-BY-4.0 Attribution International', from: 'collection_default_license')
-    expect(page).to have_select('License', selected: 'CC-BY-4.0 Attribution International')
-
     # Try to deposit again
     find('.nav-link', text: 'Deposit', exact_text: true).click
     expect(page).to have_css('.nav-link.active', text: 'Deposit')


### PR DESCRIPTION
- Remove the validation on license selection as "No License" is a valid selection.
- Do not include the license key in the cocina data if the value is blank as it fails cocina validation.