### PR TITLE
Allow collection depositor to view but not edit collecion settings

### DIFF
--- a/app/components/collections/show/header_component.html.erb
+++ b/app/components/collections/show/header_component.html.erb
@@ -1,12 +1,12 @@
 <div class="d-flex justify-content-between">
   <div>
     <%= render Elements::HeadingComponent.new(level: :h1, text: title, classes: 'mb-4 d-inline-block') %>
-    <%= render Edit::EditIconButtonComponent.new(presenter:, classes: 'mx-2 py-0 mb-2', icon_classes: 'h4') if helpers.allowed_to?(:edit?, presenter.collection) %>
+    <%= render Edit::EditIconButtonComponent.new(presenter:, classes: 'mx-2 py-0 mb-2', icon_classes: 'h4') if edit? %>
 
     <span class="ms-4 fst-italic status"><%= status_message %></span>
   </div>
   <div class="d-flex align-items-start">
-    <%= render Edit::EditDraftButtonComponent.new(presenter:, label: 'Edit') if helpers.allowed_to?(:edit?, presenter.collection) %>
+    <%= render Edit::EditDraftButtonComponent.new(presenter:, label: 'Edit') if edit? %>
     <% if !presenter.first_draft? && allowed_to_create_work? %>
       <%= render Elements::ButtonLinkComponent.new(link: new_work_path(collection_druid: presenter.druid),
                                                    label: 'Deposit to this collection',

--- a/app/components/collections/show/header_component.html.erb
+++ b/app/components/collections/show/header_component.html.erb
@@ -1,12 +1,12 @@
 <div class="d-flex justify-content-between">
   <div>
     <%= render Elements::HeadingComponent.new(level: :h1, text: title, classes: 'mb-4 d-inline-block') %>
-    <%= render Edit::EditIconButtonComponent.new(presenter:, classes: 'mx-2 py-0 mb-2', icon_classes: 'h4') %>
+    <%= render Edit::EditIconButtonComponent.new(presenter:, classes: 'mx-2 py-0 mb-2', icon_classes: 'h4') if helpers.allowed_to?(:edit?, presenter.collection) %>
 
     <span class="ms-4 fst-italic status"><%= status_message %></span>
   </div>
   <div class="d-flex align-items-start">
-    <%= render Edit::EditDraftButtonComponent.new(presenter:, label: 'Edit') %>
+    <%= render Edit::EditDraftButtonComponent.new(presenter:, label: 'Edit') if helpers.allowed_to?(:edit?, presenter.collection) %>
     <% if !presenter.first_draft? && allowed_to_create_work? %>
       <%= render Elements::ButtonLinkComponent.new(link: new_work_path(collection_druid: presenter.druid),
                                                    label: 'Deposit to this collection',

--- a/app/components/collections/show/header_component.rb
+++ b/app/components/collections/show/header_component.rb
@@ -15,6 +15,10 @@ module Collections
       def allowed_to_create_work?
         helpers.allowed_to?(:create_work?, presenter.collection)
       end
+
+      def edit?
+        helpers.allowed_to?(:edit?, presenter.collection)
+      end
     end
   end
 end

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class CollectionPolicy < ApplicationPolicy
-  alias_rule :show?, :update?, :edit?, :wait?, :destroy?, to: :manage?
+  alias_rule :update?, :edit?, :wait?, :destroy?, to: :manage?
+
+  def show?
+    collection_depositor? || manage?
+  end
 
   def manage?
     collection_manager? || record.user_id == user.id
@@ -26,5 +30,9 @@ class CollectionPolicy < ApplicationPolicy
 
   def collection_manager?
     record.managers.include?(user)
+  end
+
+  def collection_depositor?
+    record.depositors.include?(user)
   end
 end

--- a/spec/requests/show_collection_spec.rb
+++ b/spec/requests/show_collection_spec.rb
@@ -23,6 +23,30 @@ RSpec.describe 'Show collection' do
     end
   end
 
+  context 'when the user is a collection depositor' do
+    let(:depositor) { create(:user) }
+    let(:cocina_object) { collection_with_metadata_fixture }
+
+    before do
+      create(:collection, druid:, depositors: [depositor])
+      allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
+      allow(Sdr::Repository).to receive(:status)
+        .with(druid:)
+        .and_return(
+          VersionStatus.new(status:
+          instance_double(Dor::Services::Client::ObjectVersion::VersionStatus, open?: true,
+                                                                               version: 1, openable?: true))
+        )
+      sign_in(depositor)
+    end
+
+    it 'shows the collection' do
+      get "/collections/#{druid}"
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   context 'when the deposit job started' do
     let!(:collection) { create(:collection, :registering_or_updating, druid:, user:) }
     let(:user) { create(:user) }


### PR DESCRIPTION
Fixes #625 

As the creator the edit button is available:

![Screenshot 2025-02-06 at 2 15 03 PM](https://github.com/user-attachments/assets/cb575a92-ca47-47b5-9088-ee0dd6e6d345)

And now as a depositor you can see the page, but there is no edit button:

![Screenshot 2025-02-06 at 2 14 20 PM](https://github.com/user-attachments/assets/27a28fba-0c49-4f6f-934c-bebde5efc9aa)
