### PR TITLE
Set proper dashboard link in breadcrumbs

### DIFF
--- a/app/views/collections/form.html.erb
+++ b/app/views/collections/form.html.erb
@@ -1,6 +1,6 @@
 <% content_for :breadcrumbs do %>
   <%= render Elements::BreadcrumbNavComponent.new do |component| %>
-    <% component.with_breadcrumb(text: 'Dashboard', link: root_path) %>
+    <% component.with_breadcrumb(text: 'Dashboard', link: dashboard_path) %>
     <% if (current_page?(action: :new) || (controller.action_name == 'create')) %>
       <% component.with_breadcrumb(text: t('collections.edit.no_title')) %>
     <% else %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :breadcrumbs do %>
   <%= render Elements::BreadcrumbNavComponent.new do |component| %>
-    <% component.with_breadcrumb(text: 'Dashboard', link: root_path) %>
+    <% component.with_breadcrumb(text: 'Dashboard', link: dashboard_path) %>
     <% if current_page?(action: :new) %>
       <% component.with_breadcrumb(text: I18n.t('collections.edit.no_title')) %>
     <% else %>

--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -1,6 +1,6 @@
 <% content_for :breadcrumbs do %>
   <%= render Elements::BreadcrumbNavComponent.new do |component| %>
-    <% component.with_breadcrumb(text: 'Dashboard', link: root_path) %>
+    <% component.with_breadcrumb(text: 'Dashboard', link: dashboard_path) %>
     <% component.with_breadcrumb(text: @collection.title, link: collection_path(druid: @work_form.collection_druid)) %>
     <% if (current_page?(action: :new) || (controller.action_name == 'create')) %>
       <% component.with_breadcrumb(text: I18n.t('works.edit.no_title')) %>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :breadcrumbs do %>
   <%= render Elements::BreadcrumbNavComponent.new do |component| %>
-    <% component.with_breadcrumb(text: 'Dashboard', link: root_path) %>
+    <% component.with_breadcrumb(text: 'Dashboard', link: dashboard_path) %>
     <% component.with_breadcrumb(text: @work_presenter.collection.title, link: collection_path(druid: @work_presenter.collection.druid)) %>
     <% component.with_breadcrumb(text: @work_presenter.title) %>
   <% end %>

--- a/spec/system/create_collection_deposit_spec.rb
+++ b/spec/system/create_collection_deposit_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe 'Create a collection deposit' do
     visit dashboard_path
     click_link_or_button('Create a new collection')
 
+    # Breadcrumb
+    expect(page).to have_link('Dashboard', href: dashboard_path)
+    expect(page).to have_css('.breadcrumb-item', text: 'Untitled collection')
+
     expect(page).to have_css('h1', text: 'Untitled collection')
 
     # Footer buttons

--- a/spec/system/create_work_deposit_spec.rb
+++ b/spec/system/create_work_deposit_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Create a work deposit' do
     # Stubbing out for show page
     allow(Sdr::Repository).to receive(:find).with(druid:).and_invoke(->(_arg) { @registered_cocina_object })
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
-    create(:collection, user:, druid: collection_druid_fixture, managers: [user],
+    create(:collection, user:, title: collection_title_fixture, druid: collection_druid_fixture, managers: [user],
                         custom_rights_statement_option: 'depositor_selects', doi_option: 'depositor_selects',
                         license_option: 'depositor_selects', license: 'https://www.apache.org/licenses/LICENSE-2.0')
     sign_in(user)
@@ -39,6 +39,11 @@ RSpec.describe 'Create a work deposit' do
   it 'creates and deposits a work' do
     visit dashboard_path
     click_link_or_button('Deposit to this collection')
+
+    # Breadcrumb
+    expect(page).to have_link('Dashboard', href: dashboard_path)
+    expect(page).to have_link(collection_title_fixture, href: collection_path(collection_druid_fixture))
+    expect(page).to have_css('.breadcrumb-item', text: 'Untitled deposit')
 
     expect(page).to have_css('h1', text: 'Untitled deposit')
 

--- a/spec/system/create_work_draft_spec.rb
+++ b/spec/system/create_work_draft_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Create a work draft' do
     click_link_or_button('Deposit to this collection')
 
     # Breadcrumbs
-    expect(page).to have_link('Dashboard', href: root_path)
+    expect(page).to have_link('Dashboard', href: dashboard_path)
     expect(page).to have_link(collection_title_fixture, href: collection_path(collection_druid_fixture))
     expect(page).to have_css('.breadcrumb-item', text: 'Untitled deposit')
 

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Show a collection' do
     visit collection_path(druid)
 
     # Breadcrumb
-    expect(page).to have_link('Dashboard', href: root_path)
+    expect(page).to have_link('Dashboard', href: dashboard_path)
     expect(page).to have_css('.breadcrumb-item', text: collection.title)
 
     # Tabs

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe 'Show a work' do
       visit work_path(druid)
 
       # Breadcrumbs
-      expect(page).to have_link('Dashboard', href: root_path)
+      expect(page).to have_link('Dashboard', href: dashboard_path)
       expect(page).to have_link(collection.title, href: collection_path(collection.druid))
       expect(page).to have_css('.breadcrumb-item', text: work.title)
 


### PR DESCRIPTION
I noticed that the `Dashboard` link in the breadcrumbs goes to the home page which is a bit confusing and makes it really odd to have to go collection > home > enter just to get back to the dashboard.

This fixes that to `dashboard_path` 