### PR TITLE
Add missing text to home page.

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -87,7 +87,9 @@
     </div>
   </div>
 
-  <div class="row mt-5 justify-content-center gy-2">
+  <div class="h2 text-center mt-5">What Stanford researchers say about SDR</div>
+
+  <div class="row mt-3 justify-content-center gy-2">
     <div class="col-md-4 col-sm-12">
       <%= render Home::QuoteCardComponent.new do %>
         "I am definitely hearing more and more appreciation for the flexibility of SDR from my faculty colleagues who are racing to keep up with data sharing mandates from journals and funders. Way to be ahead of the curve!"


### PR DESCRIPTION
closes #645

<img width="1192" alt="image" src="https://github.com/user-attachments/assets/a9af2ce7-7282-41aa-914a-1ed8e0be0b2d" />
