### PR TITLE
Handle array params.

### DIFF
--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -14,7 +14,12 @@ class ApplicationForm
   end
 
   def self.user_editable_attributes
-    (attribute_names - immutable_attributes).map(&:to_sym)
+    (attribute_names.map(&:to_sym) - immutable_attributes.map(&:to_sym)).map do |attribute_name|
+      # Could not find a way to determine when attribute is an array.
+      # This approach is based on the assumption that every attribute will
+      # have a type EXCEPT for arrays.
+      type_for_attribute(attribute_name).type.nil? ? { attribute_name => [] } : attribute_name
+    end
   end
 
   def self.immutable_attributes

--- a/spec/forms/application_form_spec.rb
+++ b/spec/forms/application_form_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe ApplicationForm do
   describe '.user_editable_attributes' do
     let(:test_form_class) do
       Class.new(described_class) do
-        def self.attribute_names
-          %i[foo bar baz]
-        end
+        attribute :foo, :string
+        attribute :bar, array: true
+        attribute :baz, :string
 
         def self.immutable_attributes
           [:baz]
@@ -45,7 +45,7 @@ RSpec.describe ApplicationForm do
     end
 
     it 'returns attributes not declared as immutable' do
-      expect(TestForm.user_editable_attributes).to eq(%i[foo bar])
+      expect(TestForm.user_editable_attributes).to eq([:foo, { bar: [] }])
     end
   end
 

--- a/spec/system/create_work_deposit_spec.rb
+++ b/spec/system/create_work_deposit_spec.rb
@@ -199,5 +199,10 @@ RSpec.describe 'Create a work deposit' do
     expect(page).to have_css('h1', text: title_fixture)
     expect(page).to have_css('.status', text: 'Depositing')
     expect(page).to have_no_link('Edit or deposit')
+
+    # Has work types and subtypes
+    expect(page).to have_text('Text')
+    expect(page).to have_text('Thesis')
+    expect(page).to have_text('3D model')
   end
 end


### PR DESCRIPTION
This allows work subtypes to be persisted.

closes #654