### PR TITLE
Changes validation logic and label for contributor names.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,12 @@ en:
     stanford: 'Stanford Community'
     world: 'Everyone'
     depositor_selects: 'Depositor selects'
+  contributors:
+    validation:
+      first_name:
+        blank: 'must provide a first name'
+      last_name:
+        blank: 'must provide a last name'
   date:
     fields:
       year:

--- a/spec/forms/contributor_form_spec.rb
+++ b/spec/forms/contributor_form_spec.rb
@@ -93,12 +93,26 @@ RSpec.describe ContributorForm do
       end
     end
 
+    context 'when depositing and missing part of a name' do
+      let(:first_name) { 'Jane' }
+      let(:last_name) { '' }
+
+      it 'is not valid' do
+        expect(form.valid?(:deposit)).to be false
+        expect(form.errors.size).to eq(1)
+        expect(form.errors[:last_name]).to eq(['must provide a last name'])
+      end
+    end
+
     context 'when depositing and missing name' do
       let(:first_name) { '' }
       let(:last_name) { '' }
 
       it 'is not valid' do
         expect(form.valid?(:deposit)).to be false
+        expect(form.errors.size).to eq(2)
+        expect(form.errors[:first_name]).to eq(['must provide a first name'])
+        expect(form.errors[:last_name]).to eq(['must provide a last name'])
       end
     end
 


### PR DESCRIPTION
closes #662

This PR:
* Changes the label for a missing first / last name.
* Simplifies the logic by getting rid of the special handling for ORCID names. (Now when there is an ORCID it is handled like other names.)
* Avoid duplicating validations.