### PR TITLE
Add timestamps to log entries

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,10 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [
+    ->(_request) { Time.now.iso8601 },
+    :request_id
+  ]
   config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,13 @@ Rails.application.configure do
     ->(_request) { Time.now.iso8601 },
     :request_id
   ]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+
+  # Log to STDOUT if env var is set
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger           = ActiveSupport::Logger.new($stdout)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")


### PR DESCRIPTION
Having timestamps in logs makes them more useful to developers.