### PR TITLE
Adds help link to license tab of work form.

### DIFF
--- a/app/components/works/edit/license_component.html.erb
+++ b/app/components/works/edit/license_component.html.erb
@@ -1,10 +1,13 @@
 <div class="pane-section">
-  <% if required_license_option? %>
+  <div class="d-flex">
     <%= render Edit::LabelComponent.new(label_text: 'License') %>
+    <div class="ms-4"><%= helpers.link_to_new_tab 'Get help selecting a license', Settings.license_url %></div>
+  </div>
+  <% if required_license_option? %>
     <p>The license for this deposit is <%= license_label %></p>
     <%= form.hidden_field :license %>
   <% else %>
-    <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name:, options: license_options, required: true, label:, help_text:, width: 500, container_classes: 'mb-4') %>
+    <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name:, options: license_options, required: true, label:, help_text:, width: 500, container_classes: 'mb-4', hidden_label: true) %>
   <% end %>
 
   <p class="mt-4"><%= helpers.t('license.edit.license_terms_of_use') %></p>

--- a/spec/components/works/edit/license_component_spec.rb
+++ b/spec/components/works/edit/license_component_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Works::Edit::LicenseComponent, type: :component do
     it 'renders the select' do
       render_inline(described_class.new(form:, license_presenter:))
 
+      expect(page).to have_link('Get help selecting a license', href: 'https://sdr.library.stanford.edu/documentation/license-options')
       expect(page).to have_select('license')
       expect(page).to have_css('optgroup[label="Creative Commons"]')
       expect(page).to have_css('option[value="https://creativecommons.org/licenses/by/4.0/legalcode"]',
@@ -41,6 +42,8 @@ RSpec.describe Works::Edit::LicenseComponent, type: :component do
 
     it 'states the license and renders a hidden field' do
       render_inline(described_class.new(form:, license_presenter:))
+
+      expect(page).to have_link('Get help selecting a license', href: 'https://sdr.library.stanford.edu/documentation/license-options')
 
       expect(page).to have_text('The license for this deposit is CC-BY-4.0 Attribution International')
       expect(page).to have_field('license', type: 'hidden', with: 'https://creativecommons.org/licenses/by/4.0/legalcode')


### PR DESCRIPTION
closes #598

<img width="886" alt="image" src="https://github.com/user-attachments/assets/26a8d70a-631b-4f4d-897e-b207ec4b349a" />
