### PR TITLE
Release duration select prompt should always be available in collection access form

### DIFF
--- a/app/javascript/controllers/release_controller.js
+++ b/app/javascript/controllers/release_controller.js
@@ -6,21 +6,35 @@ export default class extends Controller {
   connect () {
     if (this.releaseImmediateTarget.checked) {
       this.resetReleaseDuration()
+    } else {
+      this.insertPromptOption()
     }
   }
 
   resetReleaseDuration () {
-    // If the release_option radio button selection is "immediate",
-    // the release_duration field should be reset to empty and a prompt.
+    // Reset the release_duration dropdown to a prompt, or create prompt if it does not exist
     const durationDropdown = this.releaseDurationTarget.querySelector('select')
     if (durationDropdown.querySelector('option[value=""]')) {
       durationDropdown.value = ''
+      durationDropdown.selected = true
     } else { // the dropdown needs to be reset to show "Select an option"
-      const blankDuration = document.createElement('option')
-      blankDuration.value = ''
-      blankDuration.text = 'Select an option'
-      blankDuration.selected = true
-      durationDropdown.insertBefore(blankDuration, durationDropdown.firstChild)
+      this.insertPromptOption()
     }
+  }
+
+  insertPromptOption () {
+    // Prompt option is not included in the dropdown when loading a saved collection
+    // or when fails validation so add it back for consistency, with appropriate selection.
+    const durationDropdown = this.releaseDurationTarget.querySelector('select')
+    const blankDuration = document.createElement('option')
+    blankDuration.value = ''
+    blankDuration.text = 'Select an option'
+    blankDuration.selected = false
+    if (this.releaseImmediateTarget.checked) {
+      blankDuration.selected = true
+    } else if (durationDropdown.classList.contains('is-invalid')) {
+      blankDuration.selected = true
+    }
+    durationDropdown.insertBefore(blankDuration, durationDropdown.firstChild)
   }
 }


### PR DESCRIPTION
Previously, if a saved collection with a release duration was then edited, the prompt "Select an option" would not be present in the dropdown if the user then decided to change the selection. This is because the values loaded into the dropdown in were only the valid options. This tweak adds it back in that situation and also handles the invalid state. 

![Screenshot 2025-02-13 at 9 34 33 AM](https://github.com/user-attachments/assets/5df4a5c9-36f9-4b9d-92f4-01650d3dad6a)
