### PR TITLE
Add the arm64-darwin-24 platform to avoid Gemfile.lock confusion

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,6 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
-    bcrypt_pbkdf (1.1.1-arm64-darwin)
     benchmark (0.4.0)
     better_html (2.1.1)
       actionview (>= 6.0)
@@ -592,6 +591,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
It seems like we need the specific platform versions (at least here in H3) to avoid too much Gemfile.lock noise.