### PR TITLE
Notify collection managers & reviewers on participant changes

### DIFF
--- a/app/components/collections/edit/participant_notifications_component.html.erb
+++ b/app/components/collections/edit/participant_notifications_component.html.erb
@@ -1,0 +1,4 @@
+<div class="mb-5">
+  <%= render Elements::Forms::CheckboxComponent.new(form:, field_name: :email_when_participants_changed, label: 'Send email to Collection Managers and Reviewers when participants are added/removed.') %>
+  <%= render Elements::Forms::CheckboxComponent.new(form:, field_name: :email_depositors_status_changed, label: 'Send email to Depositors whose status has changed.') %>
+</div>

--- a/app/components/collections/edit/participant_notifications_component.rb
+++ b/app/components/collections/edit/participant_notifications_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Collections
+  module Edit
+    # Component for rendering the review workflow pane.
+    class ParticipantNotificationsComponent < ApplicationComponent
+      def initialize(form:)
+        @form = form
+        super()
+      end
+
+      attr_reader :form
+    end
+  end
+end

--- a/app/components/collections/edit/participant_notifications_component.rb
+++ b/app/components/collections/edit/participant_notifications_component.rb
@@ -2,7 +2,7 @@
 
 module Collections
   module Edit
-    # Component for rendering the review workflow pane.
+    # Component for rendering the participant notification options.
     class ParticipantNotificationsComponent < ApplicationComponent
       def initialize(form:)
         @form = form

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -47,6 +47,8 @@ class CollectionForm < ApplicationForm
   validates :doi_option, inclusion: { in: %w[yes no depositor_selects] }
 
   attribute :review_enabled, :boolean, default: false
+  attribute :email_when_participants_changed, :boolean, default: true
+  attribute :email_depositors_status_changed, :boolean, default: true
 end
 
 def duration_must_be_present

--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -42,7 +42,9 @@ class DepositCollectionJob < ApplicationJob
                        license_option: collection_form.license_option,
                        license:,
                        doi_option: collection_form.doi_option,
-                       review_enabled: collection_form.review_enabled)
+                       review_enabled: collection_form.review_enabled,
+                       email_when_participants_changed: collection_form.email_when_participants_changed,
+                       email_depositors_status_changed: collection_form.email_depositors_status_changed)
 
     assign_participants(:managers)
     assign_participants(:depositors)

--- a/app/mailers/collections_mailer.rb
+++ b/app/mailers/collections_mailer.rb
@@ -10,6 +10,13 @@ class CollectionsMailer < ApplicationMailer
          subject: "Invitation to deposit to the #{@collection.title} collection in the SDR")
   end
 
+  def deposit_access_removed_email
+    return unless @collection.email_depositors_status_changed
+
+    mail(to: @user.email_address, subject: "Your Depositor permissions for the #{@collection.title} " \
+                                           'collection in the SDR have been removed')
+  end
+
   def manage_access_granted_email
     mail(to: @user.email_address, subject: "You are invited to participate as a Manager in the #{@collection.title} " \
                                            'collection in the SDR')
@@ -18,6 +25,15 @@ class CollectionsMailer < ApplicationMailer
   def review_access_granted_email
     mail(to: @user.email_address, subject: "You are invited to participate as a Reviewer in the #{@collection.title} " \
                                            'collection in the SDR')
+  end
+
+  def participants_changed_email
+    return unless @collection.email_when_participants_changed
+
+    User.where(id: @collection.managers).or(User.where(id: @collection.reviewers)).distinct.each do |user|
+      @user = user
+      mail(to: @user.email_address, subject: "Participant changes for the #{@collection.title} collection in the SDR")
+    end
   end
 
   private

--- a/app/mailers/collections_mailer.rb
+++ b/app/mailers/collections_mailer.rb
@@ -30,7 +30,7 @@ class CollectionsMailer < ApplicationMailer
   def participants_changed_email
     return unless @collection.email_when_participants_changed
 
-    User.where(id: @collection.managers).or(User.where(id: @collection.reviewers)).distinct.each do |user|
+    (@collection.managers + @collection.reviewers).uniq.each do |user|
       @user = user
       mail(to: @user.email_address, subject: "Participant changes for the #{@collection.title} collection in the SDR")
     end

--- a/app/models/collection_depositor.rb
+++ b/app/models/collection_depositor.rb
@@ -8,4 +8,5 @@ class CollectionDepositor < ApplicationRecord
   belongs_to :collection
 
   after_create -> { Notifier.publish(Notifier::DEPOSITOR_ADDED, user:, collection:) }
+  after_destroy -> { Notifier.publish(Notifier::DEPOSITOR_REMOVED, user:, collection:) }
 end

--- a/app/models/collection_manager.rb
+++ b/app/models/collection_manager.rb
@@ -8,4 +8,5 @@ class CollectionManager < ApplicationRecord
   belongs_to :collection
 
   after_create -> { Notifier.publish(Notifier::MANAGER_ADDED, user:, collection:) }
+  after_destroy -> { Notifier.publish(Notifier::MANAGER_REMOVED, user:, collection:) }
 end

--- a/app/models/collection_reviewer.rb
+++ b/app/models/collection_reviewer.rb
@@ -8,4 +8,5 @@ class CollectionReviewer < ApplicationRecord
   belongs_to :collection
 
   after_create -> { Notifier.publish(Notifier::REVIEWER_ADDED, user:, collection:) }
+  after_destroy -> { Notifier.publish(Notifier::REVIEWER_REMOVED, user:, collection:) }
 end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -7,6 +7,10 @@ class Notifier
   REVIEWER_ADDED = 'reviewer_added'
   DEPOSITOR_ADDED = 'depositor_added'
 
+  MANAGER_REMOVED = 'manager_removed'
+  REVIEWER_REMOVED = 'reviewer_removed'
+  DEPOSITOR_REMOVED = 'depositor_removed'
+
   REVIEW_REQUESTED = 'review_requested'
   REVIEW_APPROVED = 'review_approved'
   REVIEW_REJECTED = 'review_rejected'

--- a/app/views/collections/form.html.erb
+++ b/app/views/collections/form.html.erb
@@ -57,6 +57,7 @@
       <%= render Collections::Edit::PaneComponent.new(tab_name: :participants, label: I18n.t('collections.edit.panes.participants.label'), help_text: t('collections.edit.panes.participants.help_text')) do %>
         <%= render NestedComponentPresenter.for(form:, field_name: :managers, model_class: ManagerForm, form_component: Collections::ContributorComponent, fieldset_classes: 'pane-section') %>
         <%= render NestedComponentPresenter.for(form:, field_name: :depositors, model_class: DepositorForm, form_component: Collections::ContributorComponent, fieldset_classes: 'pane-section') %>
+        <%= render Collections::Edit::ParticipantNotificationsComponent.new(form:) %>
       <% end %>
     <% end %>
 

--- a/app/views/collections_mailer/deposit_access_removed_email.html.erb
+++ b/app/views/collections_mailer/deposit_access_removed_email.html.erb
@@ -1,0 +1,16 @@
+<%= render Emails::SalutationComponent.new(user: @user) %>
+
+<p>A Manager of the <%= @collection.title %> collection has updated the permissions
+   for this collection and removed you as a Depositor. You no longer have permission
+   to deposit to this collection. Please contact the collection Managers below
+   if you have questions about this change.</p>
+
+<p>Collection Managers:<br>
+  <% @collection.managers.each do |manager| %>
+    <%= manager.email_address %><br>
+  <% end %>
+</p>
+
+<p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
+
+<p>The Stanford Digital Repository Team</p>

--- a/app/views/collections_mailer/deposit_access_removed_email.html.erb
+++ b/app/views/collections_mailer/deposit_access_removed_email.html.erb
@@ -1,8 +1,8 @@
 <%= render Emails::SalutationComponent.new(user: @user) %>
 
 <p>A Manager of the <%= @collection.title %> collection has updated the permissions
-   for this collection and removed you as a Depositor. You no longer have permission
-   to deposit to this collection. Please contact the collection Managers below
+   for this collection and removed you as a depositor. You no longer have permission
+   to deposit to this collection. Please contact the collection managers below
    if you have questions about this change.</p>
 
 <p>Collection Managers:<br>
@@ -11,6 +11,6 @@
   <% end %>
 </p>
 
-<p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
+<%= render Emails::ContactComponent.new %>
 
-<p>The Stanford Digital Repository Team</p>
+<%= render Emails::SignatureComponent.new %>

--- a/app/views/collections_mailer/participants_changed_email.html.erb
+++ b/app/views/collections_mailer/participants_changed_email.html.erb
@@ -1,0 +1,8 @@
+<%= render Emails::SalutationComponent.new(user: @user) %>
+
+<p>Members have been either added to or removed from the <%= @collection.title %> collection. Please see the
+   history section at the bottom of the collection details page to see the changes made.</p>
+
+<p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
+
+<p>The Stanford Digital Repository Team</p>

--- a/app/views/collections_mailer/participants_changed_email.html.erb
+++ b/app/views/collections_mailer/participants_changed_email.html.erb
@@ -3,6 +3,6 @@
 <p>Members have been either added to or removed from the <%= @collection.title %> collection. Please see the
    history section at the bottom of the collection details page to see the changes made.</p>
 
-<p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
+<%= render Emails::ContactComponent.new %>
 
-<p>The Stanford Digital Repository Team</p>
+<%= render Emails::SignatureComponent.new %>

--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -1,13 +1,32 @@
 # frozen_string_literal: true
 
-Rails.application.config.after_initialize do
+Rails.application.config.after_initialize do # rubocop:disable Style/BlockLength
   # Subscriptions for CollectionsMailer
+  # Depositor change notifications
   Notifier.subscribe_mailer(event_name: Notifier::DEPOSITOR_ADDED, mailer_class: CollectionsMailer,
                             mailer_method: :invitation_to_deposit_email)
+  Notifier.subscribe_mailer(event_name: Notifier::DEPOSITOR_REMOVED, mailer_class: CollectionsMailer,
+                            mailer_method: :deposit_access_removed_email)
+  Notifier.subscribe_mailer(event_name: Notifier::DEPOSITOR_ADDED, mailer_class: CollectionsMailer,
+                            mailer_method: :participants_changed_email)
+  Notifier.subscribe_mailer(event_name: Notifier::DEPOSITOR_REMOVED, mailer_class: CollectionsMailer,
+                            mailer_method: :participants_changed_email)
+
+  # Manager change notifications
   Notifier.subscribe_mailer(event_name: Notifier::MANAGER_ADDED, mailer_class: CollectionsMailer,
                             mailer_method: :manage_access_granted_email)
+  Notifier.subscribe_mailer(event_name: Notifier::MANAGER_ADDED, mailer_class: CollectionsMailer,
+                            mailer_method: :participants_changed_email)
+  Notifier.subscribe_mailer(event_name: Notifier::MANAGER_REMOVED, mailer_class: CollectionsMailer,
+                            mailer_method: :participants_changed_email)
+
+  # Reviewer change notifications
   Notifier.subscribe_mailer(event_name: Notifier::REVIEWER_ADDED, mailer_class: CollectionsMailer,
                             mailer_method: :review_access_granted_email)
+  Notifier.subscribe_mailer(event_name: Notifier::REVIEWER_ADDED, mailer_class: CollectionsMailer,
+                            mailer_method: :participants_changed_email)
+  Notifier.subscribe_mailer(event_name: Notifier::REVIEWER_REMOVED, mailer_class: CollectionsMailer,
+                            mailer_method: :participants_changed_email)
 
   # Subscriptions for ReviewsMailer
   Notifier.subscribe_mailer(event_name: Notifier::REVIEW_REQUESTED, mailer_class: ReviewsMailer,

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -13,6 +13,8 @@ FactoryBot.define do
     license_option { 'required' }
     license { 'https://creativecommons.org/licenses/by/4.0/legalcode' }
     review_enabled { false }
+    email_when_participants_changed { false }
+    email_depositors_status_changed { false }
 
     trait :with_review_workflow do
       transient do

--- a/spec/jobs/deposit_collection_job_spec.rb
+++ b/spec/jobs/deposit_collection_job_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe DepositCollectionJob do
       expect(new_manager.name).to eq('stepking')
       expect(new_depositor.name).to eq('joehill')
       expect(manager.name).not_to eq(manager.sunetid)
+      expect(collection.email_when_participants_changed).to be true
+      expect(collection.email_depositors_status_changed).to be true
     end
   end
 

--- a/spec/mailers/collections_mailer_spec.rb
+++ b/spec/mailers/collections_mailer_spec.rb
@@ -22,6 +22,31 @@ RSpec.describe CollectionsMailer do
     end
   end
 
+  describe '#deposit_access_removed_email' do
+    let(:collection) do
+      create(:collection,
+             title: '20 Minutes into the Future',
+             managers: [manager],
+             email_depositors_status_changed: true)
+    end
+    let(:mail) { described_class.with(user:, collection:).deposit_access_removed_email }
+    let(:manager) { create(:user) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq 'Your Depositor permissions for the 20 Minutes into the Future collection ' \
+                                 'in the SDR have been removed'
+      expect(mail.to).to eq [user.email_address]
+      expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'renders the body with salutation of first name' do
+      expect(mail).to match_body('Dear Maxwell,')
+      expect(mail).to match_body('A Manager of the 20 Minutes into the Future collection has updated the permissions ' \
+                                 'for this collection and removed you as a Depositor.')
+      expect(mail).to match_body(manager.email_address)
+    end
+  end
+
   describe '#manage_access_granted_email' do
     let(:mail) { described_class.with(user:, collection:).manage_access_granted_email }
 
@@ -55,6 +80,32 @@ RSpec.describe CollectionsMailer do
       expect(mail).to match_body('You have been invited to review new deposits ' \
                                  'to the 20 Minutes into the Future collection')
       expect(mail).to match_body('Subscribe to the SDR newsletter</a> for feature updates')
+    end
+  end
+
+  describe '#participants_changed_email' do
+    let(:collection) do
+      create(:collection,
+             title: '20 Minutes into the Future',
+             managers: [manager],
+             email_when_participants_changed: true)
+    end
+    let(:mail) { described_class.with(user:, collection:).participants_changed_email }
+    let(:manager) { create(:user) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq 'Participant changes for the 20 Minutes into the Future ' \
+                                 'collection in the SDR'
+      expect(mail.to).to eq [manager.email_address]
+      expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'renders the body' do
+      expect(mail).to match_body("Dear #{manager.first_name},")
+      expect(mail).to match_body('Members have been either added to or removed from the ' \
+                                 '20 Minutes into the Future collection. Please see the ' \
+                                 'history section at the bottom of the collection details ' \
+                                 'page to see the changes made.')
     end
   end
 end

--- a/spec/system/create_collection_deposit_spec.rb
+++ b/spec/system/create_collection_deposit_spec.rb
@@ -91,6 +91,10 @@ RSpec.describe 'Create a collection deposit' do
     expect(page).to have_field('SUNet ID', with: user.sunetid)
     fill_in('collection_managers_attributes_1_sunetid', with: 'stepking')
     fill_in('collection_depositors_attributes_0_sunetid', with: 'joehill')
+    expect(page).to have_checked_field('Send email to Collection Managers and Reviewers ' \
+                                       'when participants are added/removed',
+                                       with: '1')
+    expect(page).to have_checked_field('Send email to Depositors whose status has changed.', with: '1')
 
     # Clicking on Next to go to Workflow
     click_link_or_button('Next')

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -128,6 +128,9 @@ RSpec.describe 'Edit a collection' do
       fill_in('SUNet ID', with: 'joehill')
     end
 
+    find('label', text: 'Send email to Collection Managers and Reviewers when participants are added/removed').click
+    find('label', text: 'Send email to Depositors whose status has changed.').click
+
     # Clicking on Next to go to Workflow
     click_link_or_button('Next')
     expect(page).to have_css('.nav-link.active', text: 'Workflow')


### PR DESCRIPTION
Fixes #711 

- Enables setting participant notification options on the collection
- Adds notification emails to managers and reviews when participants change
- Adds notification when deposit access removed.

![Screenshot 2025-02-19 at 9 41 59 AM](https://github.com/user-attachments/assets/b5f5525e-c102-4fe6-bc06-e26c31bd4fd4)
