### PR TITLE
Sort file basenames numerically

### DIFF
--- a/app/models/content_file.rb
+++ b/app/models/content_file.rb
@@ -8,7 +8,7 @@ class ContentFile < ApplicationRecord
 
   enum :file_type, attached: 'attached', deposited: 'deposited'
 
-  scope :path_order, -> { order(path_parts: :asc, basename: :asc, extname: :asc) }
+  scope :path_order, -> { order(path_parts: :asc).order('basename COLLATE "numeric"').order(extname: :asc) }
   scope :shown, -> { where(hide: false) }
 
   def hidden?

--- a/db/migrate/20250220231211_sort_content_files_basename_numerically.rb
+++ b/db/migrate/20250220231211_sort_content_files_basename_numerically.rb
@@ -1,0 +1,9 @@
+class SortContentFilesBasenameNumerically < ActiveRecord::Migration[8.0]
+  def up
+    execute "CREATE COLLATION numeric (provider = icu, locale = 'en-u-kn')"
+  end
+
+  def down
+    execute "DROP COLLATION numeric"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -9,6 +9,13 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+--
+-- Name: numeric; Type: COLLATION; Schema: public; Owner: -
+--
+
+CREATE COLLATION public."numeric" (provider = icu, locale = 'en-u-kn');
+
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -706,6 +713,7 @@ ALTER TABLE ONLY public.active_storage_attachments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250220231211'),
 ('20250123195702'),
 ('20250123120038'),
 ('20250122145633'),


### PR DESCRIPTION
This uses a DB collation so we can sort in Postgres, but only on demand, not by default.

![Screenshot from 2025-02-20 15-33-11](https://github.com/user-attachments/assets/ca7e3f6d-75c7-4b47-9e37-76b5f5eb09f3)

