### PR TITLE
Update year validation message and style invalid input text to not wrap

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,6 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
-    bcrypt_pbkdf (1.1.1-arm64-darwin)
     benchmark (0.4.0)
     better_html (2.1.1)
       actionview (>= 6.0)

--- a/app/components/elements/forms/field_component.rb
+++ b/app/components/elements/forms/field_component.rb
@@ -6,7 +6,7 @@ module Elements
     class FieldComponent < ApplicationComponent
       def initialize(form:, field_name:, required: false, hidden_label: false, label: nil, help_text: nil, # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
                      disabled: false, hidden: false, data: {}, input_data: {}, placeholder: nil, width: nil,
-                     label_classes: [], container_classes: [], input_classes: [], tooltip: nil)
+                     label_classes: [], container_classes: [], input_classes: [], tooltip: nil, error_classes: [])
         @form = form
         @field_name = field_name
         @required = required
@@ -23,6 +23,7 @@ module Elements
         @container_classes = container_classes
         @input_classes = input_classes
         @tooltip = tooltip
+        @error_classes = error_classes
         super()
       end
 
@@ -51,6 +52,10 @@ module Elements
 
       def input_classes
         merge_classes(@input_classes)
+      end
+
+      def error_classes
+        merge_classes(@error_classes)
       end
 
       delegate :id, to: :form, prefix: true

--- a/app/components/elements/forms/invalid_feedback_component.rb
+++ b/app/components/elements/forms/invalid_feedback_component.rb
@@ -31,7 +31,7 @@ module Elements
 
       def classes
         # Adding is-invalid to trigger the tab error.
-        merge_classes(%w[invalid-feedback is-invalid d-block text-nowrap], @classes)
+        merge_classes(%w[invalid-feedback is-invalid d-block], @classes)
       end
     end
   end

--- a/app/components/elements/forms/invalid_feedback_component.rb
+++ b/app/components/elements/forms/invalid_feedback_component.rb
@@ -31,7 +31,7 @@ module Elements
 
       def classes
         # Adding is-invalid to trigger the tab error.
-        merge_classes(%w[invalid-feedback is-invalid d-block], @classes)
+        merge_classes(%w[invalid-feedback is-invalid d-block text-nowrap], @classes)
       end
     end
   end

--- a/app/components/elements/forms/text_field_component.html.erb
+++ b/app/components/elements/forms/text_field_component.html.erb
@@ -2,5 +2,5 @@
   <%= render Elements::Forms::LabelComponent.new(form:, field_name:, tooltip:, label_text: label, hidden_label:, classes: label_classes) %>
   <%= render Elements::Forms::HelpTextComponent.new(id: help_text_id, help_text:) %>
   <%= form.text_field field_name, class: 'form-control', required:, aria: field_aria, disabled:, data: input_data, placeholder:, style: styles, form: form_id %>
-  <%= render Elements::Forms::InvalidFeedbackComponent.new(form:, field_name:) %>
+  <%= render Elements::Forms::InvalidFeedbackComponent.new(form:, field_name:, classes: error_classes) %>
 <% end %>

--- a/app/components/works/edit/date_input_component.html.erb
+++ b/app/components/works/edit/date_input_component.html.erb
@@ -1,8 +1,13 @@
 <%= tag.div data: { controller: 'form-date' }, class: reset_class  do %>
   <div class="row">
     <div class="col-3">
-      <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :year, label: helpers.t('date.fields.year.label'),
-                                                         input_data: { form_date_target: 'year', action: 'form-date#update' }, container_classes: 'mb-2', width: 85) %>
+      <%= render Elements::Forms::TextFieldComponent.new(form:,
+                                                         field_name: :year,
+                                                         label: helpers.t('date.fields.year.label'),
+                                                         input_data: { form_date_target: 'year', action: 'form-date#update' },
+                                                         container_classes: 'mb-2',
+                                                         error_classes: 'text-nowrap',
+                                                         width: 85) %>
     </div>
     <div class="col-5">
       <%= render Elements::Forms::SelectMonthFieldComponent.new(form:, field_name: :month, label: helpers.t('date.fields.month.label'),

--- a/app/components/works/edit/date_input_component.html.erb
+++ b/app/components/works/edit/date_input_component.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-3">
       <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :year, label: helpers.t('date.fields.year.label'),
-                                                         input_data: { form_date_target: 'year', action: 'form-date#update' }, container_classes: 'mb-2') %>
+                                                         input_data: { form_date_target: 'year', action: 'form-date#update' }, container_classes: 'mb-2', width: 85) %>
     </div>
     <div class="col-5">
       <%= render Elements::Forms::SelectMonthFieldComponent.new(form:, field_name: :month, label: helpers.t('date.fields.month.label'),

--- a/app/components/works/edit/dates_component.html.erb
+++ b/app/components/works/edit/dates_component.html.erb
@@ -1,5 +1,5 @@
   <div class="row pane-section">
-    <div class="col-lg-5">
+    <div class="col-lg-6">
       <%= render NestedComponentPresenter.for(form:, field_name: :publication_date, model_class: DateForm, form_component: Works::Edit::DateInputComponent) %>
     </div>
   </div>

--- a/app/forms/date_form.rb
+++ b/app/forms/date_form.rb
@@ -6,7 +6,7 @@ class DateForm < ApplicationForm
   validates :year, numericality: { greater_than_or_equal_to: 1000, allow_nil: true }
   validates :year, numericality: { less_than_or_equal_to: Time.zone.now.year,
                                    allow_nil: true,
-                                   message: 'Must be in the past' } # rubocop:disable Rails/I18nLocaleTexts
+                                   message: I18n.t('date.validation.year.less_than_or_equal_to') }
   validates :year, presence: true, if: -> { month.present? }
   attribute :month, :integer
   validates :month, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 12, allow_nil: true }

--- a/app/forms/date_form.rb
+++ b/app/forms/date_form.rb
@@ -3,8 +3,10 @@
 # Form object for handling date input
 class DateForm < ApplicationForm
   attribute :year, :integer
-  validates :year,
-            numericality: { greater_than_or_equal_to: 1000, less_than_or_equal_to: Time.zone.now.year, allow_nil: true }
+  validates :year, numericality: { greater_than_or_equal_to: 1000, allow_nil: true }
+  validates :year, numericality: { less_than_or_equal_to: Time.zone.now.year,
+                                   allow_nil: true,
+                                   message: 'Must be in the past' } # rubocop:disable Rails/I18nLocaleTexts
   validates :year, presence: true, if: -> { month.present? }
   attribute :month, :integer
   validates :month, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 12, allow_nil: true }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,9 @@ en:
         label: 'Day'
       approximate:
         label: 'Approximate'
+    validation:
+      year:
+        less_than_or_equal_to: 'must be in the past'
   depositors:
     edit:
       legend: 'Depositors'


### PR DESCRIPTION
Fixes #661 

Message for dates that are too early:
![Screenshot 2025-02-21 at 1 44 39 PM](https://github.com/user-attachments/assets/b8567bed-a856-41fc-bcc0-67040bf5b2f1)

Message for dates that are in the future:
![Screenshot 2025-02-21 at 1 44 52 PM](https://github.com/user-attachments/assets/e0400cf0-3376-410c-85df-a3dab1acff93)
