### PR TITLE
Update logic to avoid unexpected create/destroy callbacks

### DIFF
--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -88,7 +88,7 @@ class DepositCollectionJob < ApplicationJob
   def remove_deleted_participants(role, participants)
     collection.send(role)
               .reject { |user| participants.include?(user) }
-              .map { |user| collection.send(role).delete(user) }
+              .map { |user| collection.send(role).destroy(user) }
   end
 
   def sunetid_to_email_address(sunetid)

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -4,41 +4,85 @@ require 'rails_helper'
 
 RSpec.describe Collection do
   let(:user) { create(:user) }
+  let(:collection) { described_class.create(title: collection_title_fixture, user:) }
 
   before do
     allow(Notifier).to receive(:publish)
   end
 
-  describe 'Add manager to collection' do
-    let(:collection) { described_class.create(title: collection_title_fixture, user:) }
-
-    it 'sends an event' do
-      collection.managers << user
-      expect(Notifier).to have_received(:publish).with(Notifier::MANAGER_ADDED, collection:,
-                                                                                user:)
-      expect(Notifier).not_to have_received(:publish).with(Notifier::MANAGER_REMOVED)
-    end
-  end
-
-  describe 'Add depositor to collection' do
-    let(:collection) { described_class.create(title: collection_title_fixture, user:) }
-
-    it 'sends an event' do
-      collection.depositors << user
-      expect(Notifier).to have_received(:publish).with(Notifier::DEPOSITOR_ADDED, collection:,
+  describe 'Add participants to a collection' do
+    context 'when adding a manager to collection' do
+      it 'only sends a MANAGER_ADDED event' do
+        collection.managers << user
+        expect(Notifier).to have_received(:publish).with(Notifier::MANAGER_ADDED, collection:,
                                                                                   user:)
-      expect(Notifier).not_to have_received(:publish).with(Notifier::DEPOSITOR_REMOVED)
+        expect(Notifier).not_to have_received(:publish).with(Notifier::MANAGER_REMOVED)
+      end
+    end
+
+    context 'when adding a depositor to collection' do
+      it 'only sends a DEPOSITOR_ADDED event' do
+        collection.depositors << user
+        expect(Notifier).to have_received(:publish).with(Notifier::DEPOSITOR_ADDED, collection:,
+                                                                                    user:)
+        expect(Notifier).not_to have_received(:publish).with(Notifier::DEPOSITOR_REMOVED)
+      end
+    end
+
+    context 'when adding a reviewer to collection' do
+      it 'only sends a REVIEWER_ADDED event' do
+        collection.reviewers << user
+        expect(Notifier).to have_received(:publish).with(Notifier::REVIEWER_ADDED, collection:,
+                                                                                   user:)
+        expect(Notifier).not_to have_received(:publish).with(Notifier::REVIEWER_REMOVED)
+      end
     end
   end
 
-  describe 'Add reviewer to collection' do
-    let(:collection) { described_class.create(title: collection_title_fixture, user:) }
+  describe 'Remove participants from a collection' do
+    context 'when removing a manager to collection' do
+      let(:manager) { create(:user) }
 
-    it 'sends an event' do
-      collection.reviewers << user
-      expect(Notifier).to have_received(:publish).with(Notifier::REVIEWER_ADDED, collection:,
-                                                                                 user:)
-      expect(Notifier).not_to have_received(:publish).with(Notifier::REVIEWER_REMOVED)
+      before do
+        collection.managers << manager
+      end
+
+      it 'only sends a MANAGER_REMOVED event' do
+        collection.managers.destroy(manager)
+        expect(Notifier).to have_received(:publish).with(Notifier::MANAGER_REMOVED, collection:,
+                                                                                    user: manager)
+        expect(Notifier).not_to have_received(:publish).with(Notifier::MANAGER_ADDED, collection:)
+      end
+    end
+
+    context 'when removing a depositor from collection' do
+      let(:depositor) { create(:user) }
+
+      before do
+        collection.depositors << depositor
+      end
+
+      it 'only sends a DEPOSITOR_REMOVED event' do
+        collection.depositors.destroy(depositor)
+        expect(Notifier).to have_received(:publish).with(Notifier::DEPOSITOR_REMOVED, collection:,
+                                                                                      user: depositor)
+        expect(Notifier).not_to have_received(:publish).with(Notifier::DEPOSITOR_ADDED, collection:)
+      end
+    end
+
+    context 'when removing a reviewer from collection' do
+      let(:reviewer) { create(:user) }
+
+      before do
+        collection.reviewers << reviewer
+      end
+
+      it 'only sends a REVIEWER_REMOVED event' do
+        collection.reviewers.destroy(reviewer)
+        expect(Notifier).to have_received(:publish).with(Notifier::REVIEWER_REMOVED, collection:,
+                                                                                     user: reviewer)
+        expect(Notifier).not_to have_received(:publish).with(Notifier::REVIEWER_ADDED, collection:)
+      end
     end
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Collection do
       collection.managers << user
       expect(Notifier).to have_received(:publish).with(Notifier::MANAGER_ADDED, collection:,
                                                                                 user:)
+      expect(Notifier).not_to have_received(:publish).with(Notifier::MANAGER_REMOVED)
     end
   end
 
@@ -26,6 +27,7 @@ RSpec.describe Collection do
       collection.depositors << user
       expect(Notifier).to have_received(:publish).with(Notifier::DEPOSITOR_ADDED, collection:,
                                                                                   user:)
+      expect(Notifier).not_to have_received(:publish).with(Notifier::DEPOSITOR_REMOVED)
     end
   end
 
@@ -36,6 +38,7 @@ RSpec.describe Collection do
       collection.reviewers << user
       expect(Notifier).to have_received(:publish).with(Notifier::REVIEWER_ADDED, collection:,
                                                                                  user:)
+      expect(Notifier).not_to have_received(:publish).with(Notifier::REVIEWER_REMOVED)
     end
   end
 

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Edit a collection' do
 
   let(:druid) { collection_druid_fixture }
   let(:user) { create(:user) }
+  let(:manager) { create(:user, name: 'alborland', email_address: 'alborland@stanford.edu') }
   let(:groups) { ['dlss:hydrus-app-collection-creators'] }
 
   let(:cocina_object) do
@@ -44,7 +45,7 @@ RSpec.describe 'Edit a collection' do
     end
     allow(Sdr::Repository).to receive(:accession)
 
-    create(:collection, druid:, user:)
+    create(:collection, druid:, user:, managers: [manager])
 
     sign_in(user, groups:)
   end
@@ -116,7 +117,16 @@ RSpec.describe 'Edit a collection' do
     expect(form_instances[0]).to have_text('SUNet ID') # Manager
     expect(form_instances[1]).to have_text('SUNet ID') # Depositor
 
-    # Fill in the manager form
+    # Remove the first manager
+    within form_instances[0] do
+      expect(page).to have_field('SUNet ID', with: manager.sunetid)
+      find('button[data-action="click->nested-form#delete"]').click
+    end
+
+    click_link_or_button('+ Add another manager')
+    form_instances = all('.form-instance')
+
+    # Add a new manager
     within form_instances[0] do
       fill_in('SUNet ID', with: 'stepking')
     end
@@ -157,5 +167,6 @@ RSpec.describe 'Edit a collection' do
     # License
     expect(page).to have_css('th', text: 'Default license')
     expect(page).to have_css('td', text: 'CC-BY-4.0 Attribution International')
+    expect(page).to have_no_content('aborland@stanford.edu')
   end
 end


### PR DESCRIPTION
Fixes #798 by only removing participants when actually removed instead of clearing and then re-adding which triggered the after callback email notifications.