### PR TITLE
Adds spacing between DOI label and help.

### DIFF
--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -81,7 +81,7 @@
         <%= render Works::Edit::DoiComponent.new(form:, collection: @collection) %>
 
         <% component.with_help do %>
-          <%= link_to_new_tab('What is a DOI?', 'https://sdr.library.stanford.edu/documentation/purls-dois-and-orcid-ids') %>
+          <%= link_to_new_tab('What is a DOI?', 'https://sdr.library.stanford.edu/documentation/purls-dois-and-orcid-ids', class: 'ms-3') %>
         <% end %>
       <% end %>
     <% end %>


### PR DESCRIPTION
closes #816

![image](https://github.com/user-attachments/assets/3e8e7f1b-77f1-4e0a-b4bd-660a020a52cb)
