### PR TITLE
Exclude vendor/* from erb_lint runs

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -1,6 +1,6 @@
 ---
 exclude:
-  - '**/vendor/**/*'
+  - 'vendor/**/*'
 linters:
   Rubocop:
     enabled: true


### PR DESCRIPTION
I'm not sure if this line has always been broken or not, but Aaron found some odd erb_lint behavior in CI and my working hypothesis is that occasionally linting stuff in `vendor` (which is where the bundled gems are stuffed in CI-land) borks things.

CI is now linting ~100 fewer ERBs (all from dependencies, none that we want to lint)