### PR TITLE
Ensure custom terms of use entry instructions are populated

### DIFF
--- a/app/components/works/edit/terms_of_use_component.html.erb
+++ b/app/components/works/edit/terms_of_use_component.html.erb
@@ -5,6 +5,6 @@
     <p><%= provided_custom_rights_statement %></p>
     <%= form.hidden_field :custom_rights_statement, value: provided_custom_rights_statement %>
   <% else %>
-    <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :custom_rights_statement, help_text: instructions, label: "#{label} (optional)", tooltip:, label_classes: 'fw-bold') %>
+    <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :custom_rights_statement, help_text: custom_rights_statement_instructions, label: "#{label} (optional)", tooltip:, label_classes: 'fw-bold') %>
   <% end %>
 </div>

--- a/app/components/works/edit/terms_of_use_component.rb
+++ b/app/components/works/edit/terms_of_use_component.rb
@@ -13,18 +13,9 @@ module Works
       attr_reader :form
 
       delegate :provided_custom_rights_statement_option?, :provided_custom_rights_statement,
-               :custom_rights_statement_custom_instructions, to: :@collection
-
-      def instructions
-        custom_rights_statement_custom_instructions.presence || default_instructions
-      end
+               :custom_rights_statement_instructions, to: :@collection
 
       private
-
-      def default_instructions
-        'Enter additional terms of use not covered by your chosen license or the default terms shown above, ' \
-          'which also displays on the PURL page.'
-      end
 
       def label
         helpers.t('works.edit.fields.custom_rights_statement.label')

--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -40,8 +40,8 @@ class CollectionPresenter < FormPresenter
     when 'provided'
       collection.provided_custom_rights_statement
     else
-      if collection.custom_rights_statement_custom_instructions.present?
-        "Allow user to enter with instructions: #{collection.custom_rights_statement_custom_instructions}"
+      if collection.custom_rights_statement_instructions.present?
+        "Allow user to enter with instructions: #{collection.custom_rights_statement_instructions}"
       else
         'Allow user to enter'
       end

--- a/app/services/importers/collection.rb
+++ b/app/services/importers/collection.rb
@@ -41,7 +41,7 @@ module Importers
         collection.license = license
         collection.custom_rights_statement_option = custom_rights_statement_option
         collection.provided_custom_rights_statement = collection_json['provided_custom_rights_statement']
-        collection.custom_rights_statement_custom_instructions = collection_json['custom_rights_statement_custom_instructions'] # rubocop:disable Layout/LineLength
+        collection.custom_rights_statement_instructions = custom_rights_statement_instructions
         collection.email_when_participants_changed = collection_json['email_when_participants_changed']
         collection.email_depositors_status_changed = collection_json['email_depositors_status_changed']
         collection.review_enabled = collection_json['review_enabled']
@@ -89,6 +89,15 @@ module Importers
       else
         'depositor_selects'
       end
+    end
+
+    # This field was renamed via migration; we want to populate it with a default
+    # if left empty in H2 and the collection is set to 'depositor selects'
+    def custom_rights_statement_instructions
+      return unless custom_rights_statement_option == 'depositor_selects'
+
+      collection_json['custom_rights_statement_custom_instructions'].presence ||
+        I18n.t('terms_of_use.default_use_statement_instructions')
     end
 
     def users_from(field)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,6 +216,8 @@ en:
         Reviewers can approve, edit, or return works to Depositors. Reviewers cannot edit collection information or settings and cannot add or remove collection participants.
   terms_of_deposit:
     faq: 'FAQs and download Terms of Deposit'
+  terms_of_use:
+    default_use_statement_instructions: 'Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on the PURL page.'
   works:
     edit:
       breadcrumb: 'Edit'

--- a/db/migrate/20250224190134_custom_rights_statement_default.rb
+++ b/db/migrate/20250224190134_custom_rights_statement_default.rb
@@ -1,0 +1,5 @@
+class CustomRightsStatementDefault < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :collections, :custom_rights_statement_custom_instructions, :custom_rights_statement_instructions
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -181,7 +181,7 @@ CREATE TABLE public.collections (
     license character varying,
     custom_rights_statement_option character varying,
     provided_custom_rights_statement character varying,
-    custom_rights_statement_custom_instructions character varying,
+    custom_rights_statement_instructions character varying,
     email_when_participants_changed boolean DEFAULT true NOT NULL,
     email_depositors_status_changed boolean DEFAULT true NOT NULL,
     review_enabled boolean DEFAULT false NOT NULL,
@@ -713,6 +713,7 @@ ALTER TABLE ONLY public.active_storage_attachments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250224190134'),
 ('20250220231211'),
 ('20250123195702'),
 ('20250123120038'),
@@ -739,4 +740,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241115001126'),
 ('20241111223829'),
 ('20241106143736');
-

--- a/spec/components/works/edit/terms_of_use_component_spec.rb
+++ b/spec/components/works/edit/terms_of_use_component_spec.rb
@@ -21,25 +21,10 @@ RSpec.describe Works::Edit::TermsOfUseComponent, type: :component do
     end
   end
 
-  context 'with default instructions' do
-    let(:collection) do
-      instance_double(Collection, provided_custom_rights_statement_option?: false,
-                                  custom_rights_statement_custom_instructions: nil)
-    end
-
-    it 'renders the default instructions and input' do
-      render_inline(described_class.new(form:, collection:))
-
-      expect(page).to have_css('label', text: 'Additional terms of use (optional)')
-      expect(page).to have_css('.form-text', text: 'Enter additional terms of use not covered')
-      expect(page).to have_field('custom_rights_statement', type: 'textarea')
-    end
-  end
-
   context 'with provided instructions' do
     let(:collection) do
       instance_double(Collection, provided_custom_rights_statement_option?: false,
-                                  custom_rights_statement_custom_instructions: instructions)
+                                  custom_rights_statement_instructions: instructions)
     end
 
     let(:instructions) { 'What terms do you want?' }

--- a/spec/services/importers/collection_spec.rb
+++ b/spec/services/importers/collection_spec.rb
@@ -108,7 +108,8 @@ RSpec.describe Importers::Collection do
       expect(collection.yes_doi_option?).to be(true)
       expect(collection.required_license_option?).to be(true)
       expect(collection.depositor_selects_custom_rights_statement_option?).to be(true)
-      expect(collection.custom_rights_statement_custom_instructions).to eq('These are the instructions')
+      expect(collection.custom_rights_statement_instructions).to eq('These are the instructions')
+      expect(collection.custom_rights_statement_option).to eq('depositor_selects')
       expect(collection.email_when_participants_changed).to be(true)
       expect(collection.email_depositors_status_changed).to be(false)
       expect(collection.review_enabled).to be(true)
@@ -127,6 +128,17 @@ RSpec.describe Importers::Collection do
         described_class.call(collection_json:)
       end.to raise_error(Importers::Error,
                          "Collection #{druid} cannot be roundtripped").and not_change(Collection, :count)
+    end
+  end
+
+  context 'when depositor selects rights statement but there are no instructions' do
+    it 'uses the default custom rights statement instructions' do
+      collection_json['custom_rights_statement_custom_instructions'] = nil
+      collection = described_class.call(collection_json:)
+
+      expect(collection.custom_rights_statement_instructions).to eq(
+        I18n.t('terms_of_use.default_use_statement_instructions')
+      )
     end
   end
 end


### PR DESCRIPTION
This implements a change discussed at standup that sets the
instructions for entering custom terms of use at import time,
so that they are never empty after migrating data from H2.

Previously, we were substituting empty instructions with a
default value at render time in the Work form. It was possible
to have selected 'depositor enters terms of use' but not
provide any instructions for doing that.

This also allows for renaming the field to something slightly
shorter and easier to remember.

Prep for #274, where we want to make this field in the
Collection form required and also pre-populate it with our
default.
