### PR TITLE
Include contributor citation status on work show page.

### DIFF
--- a/app/components/works/show/contributors_show_component.rb
+++ b/app/components/works/show/contributors_show_component.rb
@@ -13,16 +13,18 @@ module Works
       attr_reader :contributors, :work_presenter
 
       def headers
-        %w[Contributor ORCID Role]
+        ['Contributor', 'ORCID', 'Role', 'Include in citation?']
       end
 
       def values_for(contributor)
         values = [
           contributor_name(contributor).presence,
           orcid_link(contributor),
-          contributor_role_label(contributor)
+          contributor_role_label(contributor),
+          helpers.human_boolean(contributor.cited)
         ]
-        return [] unless values.any?
+        # Note that this excludes the cited status since it always has a value.
+        return [] unless values.first(3).any?
 
         values
       end

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -180,16 +180,24 @@ RSpec.describe 'Show a work' do
         expect(page).to have_css('td', text: contact_emails_fixture.pluck(:email).join(', '))
       end
 
-      # Authors
+      # Contributors table
       within('table#contributors-table') do
         expect(page).to have_css('caption', text: 'Contributors')
         expect(page).to have_link('Edit', href: edit_work_path(druid, tab: 'contributors'))
         expect(page).to have_css('th', text: 'Contributor')
         expect(page).to have_css('th', text: 'ORCID')
         expect(page).to have_css('th', text: 'Role')
-        expect(page).to have_css('td', text: contributors_fixture.first['first_name'])
-        expect(page).to have_css('td', text: contributors_fixture.first['last_name'])
-        expect(page).to have_css('td', text: "#{Settings.orcid.url}#{contributors_fixture.first['orcid']}")
+        expect(page).to have_css('th', text: 'Include in citation?')
+        within('tbody tr:nth-of-type(1)') do
+          expect(page).to have_css('td:nth-of-type(1)', text: 'Jane Stanford')
+          expect(page).to have_css('td:nth-of-type(2)', text: 'https://orcid.org/0001-0002-0003-0004')
+          expect(page).to have_css('td:nth-of-type(3)', text: 'Author')
+          expect(page).to have_css('td:nth-of-type(4)', text: 'Yes')
+        end
+        within('tbody tr:nth-of-type(3)') do
+          expect(page).to have_css('td:nth-of-type(1)', text: 'Department of Philosophy, Stanford University')
+          expect(page).to have_css('td:nth-of-type(4)', text: 'No')
+        end
       end
 
       # Description table


### PR DESCRIPTION
closes #823

![image](https://github.com/user-attachments/assets/359850c4-01eb-4374-942d-1cbfdca64f2a)
