### PR TITLE
Fix alignment of ORCID tooltip.

### DIFF
--- a/app/components/elements/forms/toggle_component.html.erb
+++ b/app/components/elements/forms/toggle_component.html.erb
@@ -1,5 +1,7 @@
 <%= tag.div class: container_classes, data: do %>
-  <%= render Elements::Forms::LabelComponent.new(form:, field_name:, label_text: label, classes: label_classes, hidden_label:, tooltip:) %>
+  <div class="d-flex"> <%# Aligns label and tooltip %>
+    <%= render Elements::Forms::LabelComponent.new(form:, field_name:, label_text: label, classes: label_classes, hidden_label:, tooltip:) %>
+  </div>
   <div class="btn-group btn-group-toggle" role="group">
     <%= left_toggle_option %>
     <%= right_toggle_option %>


### PR DESCRIPTION
closes #923

![image](https://github.com/user-attachments/assets/c32e1b95-65f3-4ae8-9803-8e7f7722e4e9)
