### PR TITLE
Handle nil object_updated_at for work.

### DIFF
--- a/app/components/admin/works_list_component.rb
+++ b/app/components/admin/works_list_component.rb
@@ -24,7 +24,7 @@ module Admin
         link_to(work.collection.title, collection_or_wait_path(work.collection)),
         @status_map[work.id].status_message,
         work.druid,
-        I18n.l(work.object_updated_at, format: '%b %d, %Y')
+        work.object_updated_at ? I18n.l(work.object_updated_at, format: '%b %d, %Y') : nil
       ]
     end
   end


### PR DESCRIPTION
closes #934

I suspect this is bad data, but added check in case. This is the same as https://github.com/sul-dlss/hungry-hungry-hippo/blob/main/app/components/dashboard/show/works_list_component.rb#L36