### PR TITLE
[HOLD] Set tooltips trigger to focus only

### DIFF
--- a/app/components/elements/tooltip_component.rb
+++ b/app/components/elements/tooltip_component.rb
@@ -17,7 +17,7 @@ module Elements
           bs_html: true,
           bs_toggle: 'tooltip',
           bs_title: tooltip,
-          bs_trigger: 'click focus',
+          bs_trigger: 'focus',
           tooltips_target: 'icon'
         }
       )


### PR DESCRIPTION
Fixes #947

When `click` is one of the triggers and the icon is tabbable, the tooltips become difficult to dismiss via clicks (counter-intuitively), and even persist beyond tab navigation events.
