### PR TITLE
Update rack to address CVE-2025-27111

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,7 +391,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.10)
+    rack (3.1.11)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)


### PR DESCRIPTION
```
Name: rack
Version: 3.1.10
CVE: CVE-2025-27111
GHSA: GHSA-8cgq-6mh2-7j6v
Criticality: Unknown
URL: https://github.com/rack/rack/security/advisories/GHSA-8cgq-6mh2-7j6v
Title: Escape Sequence Injection vulnerability in Rack lead to Possible Log Injection
Solution: update to '~> 2.2.12', '~> 3.0.13', '>= 3.1.11'

Vulnerabilities found!
```