### PR TITLE
Standardize on druid as param for collection and work paths

### DIFF
--- a/app/components/dashboard/show/drafts_list_component.rb
+++ b/app/components/dashboard/show/drafts_list_component.rb
@@ -22,7 +22,7 @@ module Dashboard
       def values_for(work)
         [
           link_to(work.title, work_or_wait_path(work)),
-          link_to(work.collection.title, collection_path(druid: work.collection.druid)),
+          link_to(work.collection.title, collection_path(work.collection.druid)),
           I18n.l(work.updated_at, format: '%b %d, %Y')
         ]
       end

--- a/app/components/dashboard/show/pending_review_list_component.rb
+++ b/app/components/dashboard/show/pending_review_list_component.rb
@@ -22,7 +22,7 @@ module Dashboard
       def values_for(work)
         [
           link_to(work.title, work_or_wait_path(work)),
-          link_to(work.collection.title, collection_path(druid: work.collection.druid)),
+          link_to(work.collection.title, collection_path(work.collection.druid)),
           work.user.name,
           I18n.l(work.updated_at, format: '%b %d, %Y')
         ]

--- a/app/components/dashboard/show/works_list_component.html.erb
+++ b/app/components/dashboard/show/works_list_component.html.erb
@@ -11,5 +11,5 @@
   <% end %>
 <% end %>
 <div>
-  <%= link_to('See all deposits', collection_path(druid: collection.druid, tab: 'deposits'), class: 'fw-bold') if see_all? %>
+  <%= link_to('See all deposits', collection_path(collection, tab: 'deposits'), class: 'fw-bold') if see_all? %>
 </div>

--- a/app/controllers/admin/druid_search_controller.rb
+++ b/app/controllers/admin/druid_search_controller.rb
@@ -24,9 +24,9 @@ module Admin
 
     def redirect_to_work_or_collection
       path = if @druid_search_form.collection.present?
-               collection_path(druid: @druid_search_form.druid)
+               collection_path(@druid_search_form.druid)
              else
-               work_path(druid: @druid_search_form.druid)
+               work_path(@druid_search_form.druid)
              end
       render turbo_stream: turbo_stream.action(:full_page_redirect, path)
     end

--- a/app/controllers/admin/move_controller.rb
+++ b/app/controllers/admin/move_controller.rb
@@ -55,7 +55,7 @@ module Admin
       # This breaks out of the turbo frame.
       respond_to do |format|
         format.turbo_stream do
-          render turbo_stream: turbo_stream.action(:full_page_redirect, wait_works_path(work))
+          render turbo_stream: turbo_stream.action(:full_page_redirect, wait_works_path(work.id))
         end
       end
     end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -30,7 +30,7 @@ class CollectionsController < ApplicationController
 
     unless editable?
       flash[:danger] = I18n.t('collections.edit.messages.cannot_be_edited')
-      return redirect_to collection_path(druid: params[:druid])
+      return redirect_to collection_path(params[:druid])
     end
 
     # This updates the Collection with the latest metadata from the Cocina object.
@@ -71,7 +71,7 @@ class CollectionsController < ApplicationController
     @collection = Collection.find(params[:id])
     authorize! @collection
 
-    redirect_to collection_path(druid: @collection.druid) unless @collection.deposit_registering_or_updating?
+    redirect_to collection_path(@collection) unless @collection.deposit_registering_or_updating?
   end
 
   private

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -36,7 +36,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
 
     unless editable?
       flash[:warning] = helpers.t('works.edit.messages.cannot_be_edited_html', support_email: Settings.support_email)
-      return redirect_to work_path(druid: params[:druid]), status: :see_other
+      return redirect_to work_path(params[:druid]), status: :see_other
     end
 
     # This updates the Work with the latest metadata from the Cocina object.
@@ -89,9 +89,9 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
     if @version_status.version == 1
       collection_druid = @work.collection.druid
       @work.destroy!
-      redirect_to collection_path(druid: collection_druid)
+      redirect_to collection_path(collection_druid)
     else
-      redirect_to work_path(druid: @work.druid)
+      redirect_to work_path(@work)
     end
   end
 
@@ -103,7 +103,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
     @no_flash = true
     flash.keep
 
-    redirect_to work_path(druid: @work.druid) unless @work.deposit_registering_or_updating?
+    redirect_to work_path(@work) unless @work.deposit_registering_or_updating?
   end
 
   def review
@@ -202,7 +202,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
       wait_works_path(@work.id)
     else
       @work.reject_with_reason!(reason: @review_form.reject_reason)
-      work_path(druid: @work.druid)
+      work_path(@work)
     end
   end
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -55,4 +55,8 @@ class Collection < ApplicationRecord
   def first_version?
     version == 1
   end
+
+  def to_param
+    druid
+  end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -52,4 +52,8 @@ class Work < ApplicationRecord
   def bare_druid
     druid&.delete_prefix('druid:')
   end
+
+  def to_param
+    druid
+  end
 end

--- a/app/presenters/work_presenter.rb
+++ b/app/presenters/work_presenter.rb
@@ -33,7 +33,7 @@ class WorkPresenter < FormPresenter
   end
 
   def collection_link
-    link_to(collection.title, Rails.application.routes.url_helpers.collection_path(druid: collection.druid))
+    link_to(collection.title, Rails.application.routes.url_helpers.collection_path(collection))
   end
 
   def deposited_at

--- a/app/views/admin/collection_search/search.html.erb
+++ b/app/views/admin/collection_search/search.html.erb
@@ -1,5 +1,5 @@
 <% @collections.each do |collection| %>
-  <%= tag.li class: 'list-group-item', role: 'option', data: { autocomplete_value: collection_path(druid: collection.druid) } do %><%= collection.title %><% end %>
+  <%= tag.li class: 'list-group-item', role: 'option', data: { autocomplete_value: collection_path(collection) } do %><%= collection.title %><% end %>
 <% end %>
 <% if @collections.empty? %>
   <li class="list-group-item" role="option" aria-disabled="true">No collections found</li>

--- a/app/views/collections/form.html.erb
+++ b/app/views/collections/form.html.erb
@@ -5,7 +5,7 @@
       <% if (current_page?(action: :new) || (controller.action_name == 'create')) %>
         <% component.with_breadcrumb(text: t('collections.edit.no_title')) %>
       <% else %>
-        <% component.with_collection_breadcrumb(text: @collection_form.title, link: collection_path(druid: @collection_form.druid)) %>
+        <% component.with_collection_breadcrumb(text: @collection_form.title, link: collection_path(@collection_form.druid)) %>
       <% end %>
       <%# include an Edit breadcrumb only if title exists %>
       <% if @collection_form.title.present? %>

--- a/app/views/collections_mailer/first_version_created_email.html.erb
+++ b/app/views/collections_mailer/first_version_created_email.html.erb
@@ -2,7 +2,7 @@
 
 <p>The following new collection has been created in H3:</p>
 
-<p><%= link_to @collection.title, collection_url(@collection) %><br>
+<p><%= link_to @collection.title, collection_url(@collection.druid) %><br>
 Created by <%= @collection.user.name %> <%= @collection.user.email_address %></p>
 
 <%= render Emails::SignatureComponent.new %>

--- a/app/views/collections_mailer/invitation_to_deposit_email.html.erb
+++ b/app/views/collections_mailer/invitation_to_deposit_email.html.erb
@@ -1,7 +1,7 @@
 <%= render Emails::SalutationComponent.new(user: @user) %>
 
 <p>You have been invited to deposit to the <%= @collection.title %> collection in the Stanford Digital Repository.
-  Start your deposit at <%= link_to collection_url(@collection), collection_url(@collection, anchor: 'deposits') %>.</p>
+  Start your deposit at <%= link_to collection_url(@collection.druid), collection_url(@collection.druid, anchor: 'deposits') %>.</p>
 
 <p>SDR deposits can be discovered in the Stanford library catalog and can be accessed by others at a persistent link (PURL). <a href="https://purl.stanford.edu/wd068fv8349">Example of a PURL.</a>
 

--- a/app/views/reviews_mailer/pending_email.html.erb
+++ b/app/views/reviews_mailer/pending_email.html.erb
@@ -4,7 +4,7 @@
   The item "<%= @work.title %>" has been submitted for review in the
   <%= @collection.title %> collection by <%= @work.user.name %>,
   a collection manager, or an SDR admin. You can access this item directly
-  at <%= link_to nil, work_url(druid: @work.druid) %>.
+  at <%= link_to nil, work_url(@work) %>.
 </p>
 
 <p>

--- a/app/views/reviews_mailer/rejected_email.html.erb
+++ b/app/views/reviews_mailer/rejected_email.html.erb
@@ -5,7 +5,7 @@
 
 <p style="margin-left: 2rem; font-weight: bold;"><%= @work.review_rejected_reason %></p>
 
-<p>Click <%= link_to nil, edit_work_url(druid: @work.druid) %> to revisit your deposit.</p>
+<p>Click <%= link_to nil, edit_work_url(@work) %> to revisit your deposit.</p>
 
 <%= render Emails::ContactComponent.new %>
 

--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -2,11 +2,11 @@
   <% content_for :breadcrumbs do %>
     <%= render Elements::BreadcrumbNavComponent.new do |component| %>
       <% component.with_breadcrumb(text: 'Dashboard', link: dashboard_path) %>
-      <% component.with_collection_breadcrumb(text: @collection.title, link: collection_path(druid: @work_form.collection_druid)) %>
+      <% component.with_collection_breadcrumb(text: @collection.title, link: collection_path(@work_form.collection_druid)) %>
       <% if (current_page?(action: :new) || (controller.action_name == 'create')) %>
         <% component.with_breadcrumb(text: I18n.t('works.edit.no_title')) %>
       <% else %>
-        <% component.with_title_breadcrumb(text: @work_form.title, link: work_path(druid: @work.druid)) %>
+        <% component.with_title_breadcrumb(text: @work_form.title, link: work_path(@work)) %>
         <% component.with_breadcrumb(text: t('works.edit.breadcrumb')) %>
       <% end %>
     <% end %>

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -3,7 +3,7 @@
 <% content_for :breadcrumbs do %>
   <%= render Elements::BreadcrumbNavComponent.new do |component| %>
     <% component.with_breadcrumb(text: 'Dashboard', link: dashboard_path) %>
-    <% component.with_collection_breadcrumb(text: @work_presenter.collection.title, link: collection_path(druid: @work_presenter.collection.druid)) %>
+    <% component.with_collection_breadcrumb(text: @work_presenter.collection.title, link: collection_path(@work_presenter.collection)) %>
     <% component.with_title_breadcrumb(text: @work_presenter.title) %>
   <% end %>
 <% end %>

--- a/app/views/works/wait.html.erb
+++ b/app/views/works/wait.html.erb
@@ -4,7 +4,7 @@
 <% content_for :breadcrumbs do %>
   <%= render Elements::BreadcrumbNavComponent.new do |component| %>
     <% component.with_breadcrumb(text: 'Dashboard', link: dashboard_path) %>
-    <% component.with_collection_breadcrumb(text: @work.collection.title, link: collection_path(druid: @work.collection.druid)) %>
+    <% component.with_collection_breadcrumb(text: @work.collection.title, link: collection_path(@work.collection)) %>
     <% component.with_title_breadcrumb(text: @work.title) %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   resources :collections, only: %i[new create show edit update], param: :druid do
     collection do
-      get 'wait/:id', to: 'collections#wait', as: 'wait'
+      get 'wait/:id', to: 'collections#wait', as: 'wait', param: :id
     end
 
     namespace :admin do
@@ -36,7 +36,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   resources :works, only: %i[new create show edit update destroy], param: :druid do
     collection do
-      get 'wait/:id', to: 'works#wait', as: 'wait'
+      get 'wait/:id', to: 'works#wait', as: 'wait', param: :id
     end
 
     member do

--- a/spec/mailers/collections_mailer_spec.rb
+++ b/spec/mailers/collections_mailer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe CollectionsMailer do
   let(:user) { create(:user, name: 'Max Headroom', first_name: 'Maxwell') }
-  let(:collection) { create(:collection, title: '20 Minutes into the Future') }
+  let(:collection) { create(:collection, :with_druid, title: '20 Minutes into the Future') }
 
   describe '#invitation_to_deposit_email' do
     let(:mail) { described_class.with(user:, collection:).invitation_to_deposit_email }
@@ -144,8 +144,7 @@ RSpec.describe CollectionsMailer do
 
   describe '#first_version_created_email' do
     let(:collection) do
-      create(:collection, user:,
-                          title: '20 Minutes into the Future')
+      create(:collection, :with_druid, user:, title: '20 Minutes into the Future')
     end
     let(:mail) { described_class.with(collection:).first_version_created_email }
 

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Notifier do
   describe 'Publishing an event' do
     include ActiveJob::TestHelper
-    let(:collection) { create(:collection, title: 'My Stuff', reviewers: [reviewer], managers: [manager]) }
+    let(:collection) { create(:collection, :with_druid, title: 'My Stuff', reviewers: [reviewer], managers: [manager]) }
     let(:user) { create(:user) }
     let(:reviewer) { create(:user) }
     let(:manager) { create(:user) }

--- a/spec/system/edit_work_spec.rb
+++ b/spec/system/edit_work_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Edit a work' do
     visit edit_work_path(druid, tab: 'title')
 
     expect(page).to have_css('.breadcrumb-item', text: collection_title_fixture)
-    expect(page).to have_link(collection_title_fixture, href: collection_path(druid: collection_druid_fixture))
+    expect(page).to have_link(collection_title_fixture, href: collection_path(collection_druid_fixture))
     expect(page).to have_css('.breadcrumb-item', text: title_fixture)
     expect(page).to have_css('h1', text: title_fixture)
 

--- a/spec/system/show_discard_work_draft_spec.rb
+++ b/spec/system/show_discard_work_draft_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Discard a work draft' do
       expect(page).to have_current_path(work_path(druid))
       expect(page).to have_no_button('Discard draft')
       expect(page).to have_css('.alert-success', text: 'Draft discarded.')
-      expect(page).to have_current_path(collection_path(druid: collection.druid))
+      expect(page).to have_current_path(collection_path(collection))
 
       expect(Work.find_by(druid:)).to be_nil
     end

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'Show a work' do
 
       # Breadcrumbs
       expect(page).to have_link('Dashboard', href: dashboard_path)
-      expect(page).to have_link(collection.title, href: collection_path(collection.druid))
+      expect(page).to have_link(collection.title, href: collection_path(collection))
       expect(page).to have_css('.breadcrumb-item', text: work.title)
 
       expect(page).to have_css('h1', text: work.title)


### PR DESCRIPTION
Fixes #958

It remains possible to link directly to a collection or work database ID, which we do in a handful of situations where we want to go directly to the "wait" page. Instead of special-casing the druid paths/URLs which are the norm in H3, switch the behavior to special-case the oddballs.
