### PR TITLE
Simplify validation callback mechanics

### DIFF
--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -43,18 +43,18 @@ class CollectionForm < ApplicationForm
   attribute :provided_custom_rights_statement, :string
   validates :provided_custom_rights_statement, length: { maximum: 1000 }
   validates :provided_custom_rights_statement, presence: true, if: -> { custom_rights_statement_option == 'provided' }
-  before_validation lambda { |form|
-    form.provided_custom_rights_statement = LinebreakSupport.normalize(form.provided_custom_rights_statement)
-  }
+  before_validation do
+    self.provided_custom_rights_statement = LinebreakSupport.normalize(provided_custom_rights_statement)
+  end
 
   attribute :custom_rights_statement_instructions, :string
   validates :custom_rights_statement_instructions, length: { maximum: 1000 }
   validates :custom_rights_statement_instructions, presence: true, if: lambda {
     custom_rights_statement_option == 'depositor_selects'
   }
-  before_validation lambda { |form|
-    form.custom_rights_statement_instructions = LinebreakSupport.normalize(form.custom_rights_statement_instructions)
-  }
+  before_validation do
+    self.custom_rights_statement_instructions = LinebreakSupport.normalize(custom_rights_statement_instructions)
+  end
 
   attribute :release_option, :string, default: 'immediate'
   validates :release_option, inclusion: { in: %w[immediate depositor_selects] }

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -36,7 +36,9 @@ class WorkForm < ApplicationForm
 
   attribute :abstract, :string
   validates :abstract, presence: true, on: :deposit
-  before_validation ->(work_form) { work_form.abstract = LinebreakSupport.normalize(work_form.abstract) }
+  before_validation do
+    self.abstract = LinebreakSupport.normalize(abstract)
+  end
 
   attribute :citation, :string
   attribute :auto_generate_citation, :boolean
@@ -49,7 +51,7 @@ class WorkForm < ApplicationForm
   validates :work_type, presence: true, on: :deposit
 
   attribute :work_subtypes, array: true, default: -> { [] }
-  before_validation ->(work_form) { work_form.work_subtypes.compact_blank! }
+  before_validation { work_subtypes.compact_blank! }
   validate :correct_work_subtype_length
 
   attribute :other_work_subtype, :string
@@ -77,9 +79,9 @@ class WorkForm < ApplicationForm
   end
 
   attribute :custom_rights_statement, :string
-  before_validation lambda { |work_form|
-    work_form.custom_rights_statement = LinebreakSupport.normalize(work_form.custom_rights_statement)
-  }
+  before_validation do
+    self.custom_rights_statement = LinebreakSupport.normalize(custom_rights_statement)
+  end
 
   attribute :doi_option, :string, default: 'yes'
   validates :doi_option, inclusion: { in: %w[yes no assigned] }


### PR DESCRIPTION
Could be a six-vs-half-dozen situation, but to my eyes the block syntax is simpler and less noisy than the lambdas. A tiny spike for dev QoL.
