### PR TITLE
Remove length restrictions on terms of use and instructions

### DIFF
--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -41,14 +41,12 @@ class CollectionForm < ApplicationForm
   validates :custom_rights_statement_option, presence: true, inclusion: { in: %w[no provided depositor_selects] }
 
   attribute :provided_custom_rights_statement, :string
-  validates :provided_custom_rights_statement, length: { maximum: 1000 }
   validates :provided_custom_rights_statement, presence: true, if: -> { custom_rights_statement_option == 'provided' }
   before_validation do
     self.provided_custom_rights_statement = LinebreakSupport.normalize(provided_custom_rights_statement)
   end
 
   attribute :custom_rights_statement_instructions, :string
-  validates :custom_rights_statement_instructions, length: { maximum: 1000 }
   validates :custom_rights_statement_instructions, presence: true, if: lambda {
     custom_rights_statement_option == 'depositor_selects'
   }


### PR DESCRIPTION
There are items in the wild with very long ToU, e.g. https://purl.stanford.edu/wg342wx4290. We need to support that.

Presumably there's no reason to stop people from including very detailed instructions, either.