### PR TITLE
Update rack to address cve-2025-27610

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,7 +391,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.11)
+    rack (3.1.12)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)


### PR DESCRIPTION
Small dependency update PR to avoid having to use `SKIP_BUNDLE_AUDIT` in order to deploy