### PR TITLE
Use bare druid in the admin collection list

### DIFF
--- a/app/components/admin/collections_list_component.rb
+++ b/app/components/admin/collections_list_component.rb
@@ -21,7 +21,7 @@ module Admin
     def values_for(collection)
       [
         link_to(collection.title, collection_or_wait_path(collection), data: { turbo_frame: '_top' }),
-        collection.druid,
+        collection.bare_druid,
         roles_for(collection)
       ]
     end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -59,4 +59,8 @@ class Collection < ApplicationRecord
   def to_param
     druid
   end
+
+  def bare_druid
+    druid&.delete_prefix('druid:')
+  end
 end

--- a/spec/components/admin/collections_list_component_spec.rb
+++ b/spec/components/admin/collections_list_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Admin::CollectionsListComponent, type: :component do
     expect(first_row).to have_link(collection.title, href: "/collections/#{collection.druid}") { |a|
       a['data-turbo-frame'] == '_top'
     }
-    expect(first_row).to have_css('td:nth-of-type(2)', text: collection.druid)
+    expect(first_row).to have_css('td:nth-of-type(2)', text: collection.druid.delete_prefix('druid:'))
     expect(first_row).to have_css('td:nth-of-type(3)', text: 'Manager, Depositor')
   end
 end


### PR DESCRIPTION
Updates the collection list to remove the druid prefix and match the work done for the work list in #937 