### PR TITLE
Change autocomplete attribute for newsletter signup

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -77,7 +77,7 @@
             </div>
             <label for="mce-EMAIL" class="visually-hidden">Sign up for our newsletter</label>
             <div class="input-group">
-              <input type="email" value="" name="EMAIL" class="form-control" id="mce-EMAIL" autocomplete="on" placeholder="Enter your email address" required>
+              <input type="email" value="" name="EMAIL" class="form-control" id="mce-EMAIL" autocomplete="email" placeholder="Enter your email address" required>
               <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-primary">
             </div>
           <% end %>


### PR DESCRIPTION
This will actually pre-fill it with the email, if present. Fixes a SODA identified issue.