### PR TITLE
Update work subtype validation when music is selected

### DIFF
--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -60,13 +60,23 @@ RSpec.describe WorkForm do
 
       it 'is invalid' do
         expect(form).not_to be_valid
-        expect(form.errors[:work_subtypes_music]).to include('1 term is the minimum allowed')
+        expect(form.errors[:work_subtypes_music]).to include('1 music term is the minimum allowed')
+      end
+    end
+
+    context 'when Music work type and non music work subtypes' do
+      let(:work_type) { 'Music' }
+      let(:work_subtypes) { ['Newspaper'] }
+
+      it 'is invalid' do
+        expect(form).not_to be_valid
+        expect(form.errors[:work_subtypes_music]).to include('1 music term is the minimum allowed')
       end
     end
 
     context 'when Music work type and one work subtype' do
       let(:work_type) { 'Music' }
-      let(:work_subtypes) { ['Album'] }
+      let(:work_subtypes) { ['Sound'] }
 
       it 'is valid' do
         expect(form).to be_valid

--- a/spec/system/manage_work_type_spec.rb
+++ b/spec/system/manage_work_type_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Edit work type and subtypes for a work' do
     expect(page).to have_css('.alert-danger', text: 'Required fields have not been filled out.')
 
     find('.nav-link.is-invalid', text: 'Type of deposit').click
-    expect(page).to have_css('.invalid-feedback.is-invalid', text: '1 term is the minimum allowed')
+    expect(page).to have_css('.invalid-feedback.is-invalid', text: '1 music term is the minimum allowed')
 
     # Clicking on another work type hides the error message
     choose('Mixed Materials')


### PR DESCRIPTION
Fixes #1064 

Validates that one of the selected subtypes is one of the required music subtypes when the music type is selected.

Refactored into 2 conditional validation, this seems much clearer.

~~DRAFT: After thinking about the codecov failure (there was a single line uncovered) I decided I thought this would be clearer if I used affirmative language (`music_subifields?`) vs negative (`missing_music_subfields?`) which altered the logic a bit. Reworking that and the testing now and then I will undraft.~~