### PR TITLE
Break out of turbo frame on collection deposit list.

### DIFF
--- a/app/components/collections/show/deposits_component.rb
+++ b/app/components/collections/show/deposits_component.rb
@@ -24,7 +24,7 @@ module Collections
       def values_for(work)
         presenter = work_presenter_for(work)
         [
-          helpers.link_to(work.title, work_or_wait_path(work)),
+          helpers.link_to(work.title, work_or_wait_path(work), data: { turbo_frame: '_top' }),
           work.user.name,
           presenter.status_message,
           work.object_updated_at ? helpers.l(work.object_updated_at, format: '%b %d, %Y') : nil,


### PR DESCRIPTION
This was a bug reported by @amyehodge.

To replicate on stage, go to "Mud Season in Vermont" collection, click on Deposits, and then click on "Long list of objects 5" work.

Fix was verified in stage.