### PR TITLE
[SPIKE] Show updated time for files

### DIFF
--- a/app/components/works/edit/content_file_hierarchy_component.html.erb
+++ b/app/components/works/edit/content_file_hierarchy_component.html.erb
@@ -8,6 +8,9 @@
 
 <% component.with_row_leaf(level: path_parts.length + 1, label: filename) do |row_component| %>
   <% row_component.with_cell do %>
+    <%= render Works::Edit::ContentFileUploadedTimeComponent.new(content_file:) %>
+  <% end %>
+  <% row_component.with_cell do %>
     <%= render Works::Edit::ContentFileDescriptionComponent.new(content_file:) %>
   <% end %>
   <% row_component.with_cell do %>

--- a/app/components/works/edit/content_file_uploaded_time_component.html.erb
+++ b/app/components/works/edit/content_file_uploaded_time_component.html.erb
@@ -1,3 +1,3 @@
 <div class="d-flex align-items-center justify-content-between">
-  <span><%= I18n.l(content_file.created_at, format: :uploaded) %></span>
+  <span><%= I18n.l(content_file.updated_at, format: :uploaded) %></span>
 </div>

--- a/app/components/works/edit/content_file_uploaded_time_component.html.erb
+++ b/app/components/works/edit/content_file_uploaded_time_component.html.erb
@@ -1,0 +1,3 @@
+<div class="d-flex align-items-center justify-content-between">
+  <span><%= I18n.l(content_file.created_at, format: :uploaded) %></span>
+</div>

--- a/app/components/works/edit/content_file_uploaded_time_component.rb
+++ b/app/components/works/edit/content_file_uploaded_time_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Works
+  module Edit
+    # Component for rendering the content file uploaded date and time
+    class ContentFileUploadedTimeComponent < ApplicationComponent
+      def initialize(content_file:)
+        @content_file = content_file
+        super()
+      end
+
+      attr_reader :content_file
+    end
+  end
+end

--- a/app/components/works/edit/content_hierarchy_component.html.erb
+++ b/app/components/works/edit/content_hierarchy_component.html.erb
@@ -2,6 +2,7 @@
   <%# These headers are duplicated in app/views/contents/_show.html.erb. %>
   <% component.with_headers([
                               { label: 'File Name' },
+                              { label: 'Uploaded' },
                               { label: 'Description', tooltip: helpers.t('content_files.edit.fields.description.tooltip_html'), style: 'width: 180px;' },
                               { label: 'Hide', tooltip: helpers.t('content_files.edit.fields.hide.tooltip_html'), style: 'width: 85px;' },
                               { label: 'Action', style: 'width: 85px;' }

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -160,7 +160,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def set_content
-    @content = Contents::Builder.call(cocina_object: @cocina_object, user: current_user)
+    @content = Contents::Builder.call(cocina_object: @cocina_object, user: current_user, updated_at: @work.updated_at)
     @work_form.content_id = @content.id
   end
 

--- a/app/services/contents/builder.rb
+++ b/app/services/contents/builder.rb
@@ -7,9 +7,10 @@ module Contents
       new(...).call
     end
 
-    def initialize(cocina_object:, user:)
+    def initialize(cocina_object:, user:, updated_at: nil)
       @cocina_object = cocina_object
       @user = user
+      @updated_at = updated_at
     end
 
     # @return [Content] the created content
@@ -25,7 +26,7 @@ module Contents
 
     private
 
-    attr_reader :cocina_object, :user
+    attr_reader :cocina_object, :user, :updated_at
 
     def content_file_params_for(content:) # rubocop:disable Metrics/AbcSize
       cocina_object.structural.contains.flat_map do |file_set|
@@ -45,7 +46,8 @@ module Contents
             md5_digest: digest_for(type: 'md5', file:),
             sha1_digest: digest_for(type: 'sha1', file:),
             content_id: content.id,
-            hide: !file.administrative.shelve
+            hide: !file.administrative.shelve,
+            updated_at:
           }
         end
       end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,7 @@ module HungryHungryHippo
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Pacific Time (US & Canada)'
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Configure MissionControl-Jobs authentication/authorization

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
   time:
     formats:
       long: '%B %d, %Y'
+      uploaded: '%H:%M:%S %m/%d/%y'
   errors:
     not_authorized: 'You are not authorized to perform the requested action.'
   messages:
@@ -441,7 +442,7 @@ en:
             This section is for links to other web pages that are related to your collection. Enter the text to be displayed on the page in the "Link text" box. This entire text will be hyperlinked to the URL you enter in the "URL" box. Examples of content you might consider linking to are key funder websites,  lab or institute websites, or project pages.
         types:
           tab_label: 'Type of deposit (optional)'
-          label: 'Type of deposit (optional)'       
+          label: 'Type of deposit (optional)'
         access:
           tab_label: 'Access settings'
           label: 'Manage release of deposits for discovery and download'

--- a/spec/services/contents/builder_spec.rb
+++ b/spec/services/contents/builder_spec.rb
@@ -5,11 +5,12 @@ require 'rails_helper'
 RSpec.describe Contents::Builder do
   include WorkMappingFixtures
 
-  subject(:content) { described_class.call(cocina_object: dro_with_structural_fixture(hide:), user:) }
+  subject(:content) { described_class.call(cocina_object: dro_with_structural_fixture(hide:), user:, updated_at:) }
 
   let(:user) { create(:user) }
   let(:expected_content_file) { content_fixture(user:, hide:).content_files.first }
   let(:hide) { false }
+  let(:updated_at) { Time.zone.now }
 
   context 'when file is not hidden' do
     it 'builds Content and Content Files model objects' do


### PR DESCRIPTION
This is a spike on one possible approach to #1061. There is a bit of a challenge in showing meaningful date information with regard to files on a work in H3 as we do not persist them in the database permanently, they are transient for display on the work form.

This approach sets the `content_file.updated_at` value to the `updated_at` value of the work. This at least allows the files table to display relatively accurate date content for a file based on the last time the work was deposited or edited.

Then when uploading new files, the `updated_at` value is accurate to the time the individual file record is created during the work edit session.

The attached screen recording shows that an existing file is displaying a date from yesterday, and then the new file gets the current date and time... And then uploading a file with the same name as the existing file updates it's time to show that it was altered.

This may be an incomplete approach at this time, but shows how we may be able to provide meaningful/helpful information in this way. 

https://github.com/user-attachments/assets/ccf09b2b-8c56-4a40-ac4f-c5cd9b93f506

