### PR TITLE
Adjust accessible label for invalid tabs via aria-labelledby

### DIFF
--- a/app/components/edit/tab_form/tab_component.rb
+++ b/app/components/edit/tab_form/tab_component.rb
@@ -14,7 +14,7 @@ module Edit
       def call
         tag.div(
           class: classes,
-          id: "#{tab_name}-tab",
+          id:,
           data: {
             bs_toggle: 'tab',
             bs_target: "##{pane_id}",
@@ -23,7 +23,8 @@ module Edit
           },
           type: 'button',
           'aria-controls': pane_id,
-          'aria-selected': selected?
+          'aria-selected': selected?,
+          'aria-labelledby': id
         ) do
           label
         end

--- a/app/components/edit/tab_form/tab_list_component.html.erb
+++ b/app/components/edit/tab_form/tab_list_component.html.erb
@@ -22,4 +22,5 @@
       <% end %>
     </div>
   </div>
+  <span id="invalid-description" class="visually-hidden" data-tab-error-target="invalidDescription">Error: required fields missing</span>
 <% end %>

--- a/app/javascript/controllers/tab_error_controller.js
+++ b/app/javascript/controllers/tab_error_controller.js
@@ -2,17 +2,22 @@ import { Controller } from '@hotwired/stimulus'
 import * as bootstrap from 'bootstrap'
 
 export default class extends Controller {
-  static targets = ['tab', 'pane']
+  static targets = ['tab', 'pane', 'invalidDescription']
 
   connect () {
     // For each tab / pane pair, check if the pane contains an invalid input.
-    // If it does, add the is-invalid class to the tab.
+    // If it does, add the is-invalid class to the tab and modify the tab's
+    // accessible label to include the error message.
     this.tabTargets.forEach((tabEl, index) => {
       const paneEl = this.paneTargets[index]
       if (paneEl.querySelector('.is-invalid')) {
         tabEl.classList.add('is-invalid')
+        const currentLabelledBy = tabEl.getAttribute('aria-labelledby')
+        const newLabelledBy = `${currentLabelledBy} ${this.invalidDescriptionTarget.id}`
+        tabEl.setAttribute('aria-labelledby', newLabelledBy)
       }
     })
+
     // Show the first tab that has an invalid input.
     const firstErrorTabEl = this.tabTargets.find(tabEl => tabEl.classList.contains('is-invalid'))
     if (firstErrorTabEl) {


### PR DESCRIPTION
Fixes #908

This alternative approach to #1038 adds a hidden element with
text indicating that a tab is invalid, and then modifies the
tab's label using aria-labelledby so that its name is a combination
of the tab name and the invalid description.

Tested in VO and confirmed it reads something like "Details, Error:
required fields missing, tab, active, 1 of 10".
