### PR TITLE
Adds help text to collection related content tab.

### DIFF
--- a/app/views/collections/form.html.erb
+++ b/app/views/collections/form.html.erb
@@ -43,7 +43,7 @@
         <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :works_contact_email, label: t('collections.edit.fields.works_contact_email.label'), tooltip: t('collections.edit.fields.works_contact_email.tooltip_html'), container_classes: 'pane-section') %>
       <% end %>
 
-      <% component.with_collection_pane(tab_name: :related_links, label: t('collections.edit.panes.related_links.label'), tooltip: t('collections.edit.panes.related_links.tooltip_html'), active_tab_name:, collection_presenter: @collection_presenter) do %>
+      <% component.with_collection_pane(tab_name: :related_links, label: t('collections.edit.panes.related_links.label'), tooltip: t('collections.edit.panes.related_links.tooltip_html'), help_text: t('collections.edit.panes.related_links.help_text'), active_tab_name:, collection_presenter: @collection_presenter) do %>
         <%= render NestedComponentPresenter.for(form:, field_name: :related_links, model_class: RelatedLinkForm, form_component: RelatedLinks::EditComponent, fieldset_classes: 'pane-section', skip_tooltip: true) %>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -456,6 +456,7 @@ en:
         related_links:
           tab_label: 'Related links (optional)'
           label: 'Links to related content (optional)'
+          help_text: 'Links entered here will appear on the page for your collection. They will not appear on individual deposit items.'
           tooltip_html: >-
             This section is for links to other web pages that are related to your collection. Enter the text to be displayed on the page in the "Link text" box. This entire text will be hyperlinked to the URL you enter in the "URL" box. Examples of content you might consider linking to are key funder websites,  lab or institute websites, or project pages.
         types:


### PR DESCRIPTION
closes #1090

![image](https://github.com/user-attachments/assets/2cfd644a-e674-41f7-82a4-7f568e71f9b4)
