### PR TITLE
Don't bold error icon on active tab

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -89,6 +89,7 @@ $container-max-widths: (
           margin-left: 10px;
           display: inline-block;
           font-family: bootstrap-icons;
+          font-weight: normal;
           vertical-align: -15%;
           content: "\F33A"; // exclamation triangle fill
         }


### PR DESCRIPTION
# Before

![Screenshot 2025-03-19 at 11 13 58](https://github.com/user-attachments/assets/0c532def-e384-4462-92e3-380e94fec396)

# After

![Screenshot 2025-03-19 at 11 14 11](https://github.com/user-attachments/assets/4dd168ef-8dcd-40d2-8efc-0ae1114ad3e3)
