### PR TITLE
Shows validation alert for nested errors.

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -45,7 +45,7 @@ class CollectionsController < ApplicationController
   def create
     authorize! Collection
     @collection_form = CollectionForm.new(**collection_params)
-    if @collection_form.valid?(:deposit)
+    if (@valid = @collection_form.valid?(:deposit))
       collection = Collection.create!(title: @collection_form.title,
                                       user: current_user,
                                       deposit_state_event: 'deposit_persist')
@@ -62,7 +62,7 @@ class CollectionsController < ApplicationController
 
     @collection_form = CollectionForm.new(**update_collection_params)
     # The validation_context param determines whether extra validations are applied, e.g., for deposits.
-    if @collection_form.valid?(:deposit)
+    if (@valid = @collection_form.valid?(:deposit))
       @collection.deposit_persist! # Sets the deposit state
       DepositCollectionJob.perform_later(collection: @collection, collection_form: @collection_form, current_user:)
       redirect_to wait_collections_path(@collection.id)

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -56,7 +56,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
     authorize! @collection, with: WorkPolicy
 
     # The validation_context param determines whether extra validations are applied, e.g., for deposits.
-    if @work_form.valid?(validation_context)
+    if (@valid = @work_form.valid?(validation_context))
       work = Work.create!(title: @work_form.title, user: current_user, collection: @collection)
       perform_deposit(work:)
       redirect_to wait_works_path(work.id)
@@ -73,13 +73,11 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
     @work_form = WorkForm.new(**update_work_params)
     @content = Content.find(@work_form.content_id)
 
-    work_is_valid = @work_form.valid?(validation_context)
-
-    if work_is_valid && perform_deposit?
+    if (@valid = @work_form.valid?(validation_context)) && perform_deposit?
       perform_deposit(work: @work)
       redirect_to wait_works_path(@work.id)
     else
-      handle_no_changes if work_is_valid
+      handle_no_changes if @valid
       set_license_presenter
       set_presenter
       render :form, status: :unprocessable_entity

--- a/app/forms/contributor_form.rb
+++ b/app/forms/contributor_form.rb
@@ -45,7 +45,7 @@ class ContributorForm < ApplicationForm
     return false if role_type != 'person'
     return true unless with_names
 
-    first_name.present? && last_name.present?
+    first_name.present? || last_name.present?
   end
 
   def organization?(with_names: false)

--- a/app/views/collections/form.html.erb
+++ b/app/views/collections/form.html.erb
@@ -14,7 +14,7 @@
     <% end %>
   <% end %>
   <%= render Elements::HeadingComponent.new(level: :h1, variant: :h2, text: @collection_form.title || 'Untitled collection', classes: 'mb-3') %>
-  <%= render Elements::AlertComponent.new(variant: :danger, value: t('messages.validation')) if @collection_form.errors.present? %>
+  <%= render Elements::AlertComponent.new(variant: :danger, value: t('messages.validation')) if defined?(@valid) && !@valid %>
   <% discard_draft_form_id = dom_id(@collection_form, 'discard_form') %>
   <%= render Edit::DiscardDraftFormComponent.new(presenter: @collection_presenter, id: discard_draft_form_id) if @collection_presenter %>
   <% active_tab_name = params[:tab]&.to_sym || :details %>

--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -13,7 +13,7 @@
   <% end %>
   <%= render Elements::HeadingComponent.new(level: :h1, variant: :h2, text: @work_form.title || t('works.edit.no_title'), classes: 'mb-3') %>
   <%= render Works::Show::ReviewRejectedComponent.new(work: @work) if @work %>
-  <%= render Elements::AlertComponent.new(variant: :danger, value: t('messages.validation')) if @work_form.errors.present? %>
+  <%= render Elements::AlertComponent.new(variant: :danger, value: t('messages.validation')) if defined?(@valid) && !@valid %>
   <% form_id = dom_id(@work_form, 'tabbed_form') %>
   <% discard_draft_form_id = dom_id(@work_form, 'discard_form') %>
   <%= render Edit::DiscardDraftFormComponent.new(presenter: @work_presenter, id: discard_draft_form_id) if @work_presenter %>


### PR DESCRIPTION
closes #1155

`valid?` checks nested errors. However, `errors` does not include nested errors. Thus, this PR uses the results of `valid?` to determine whether to show validation message instead of checking for the presence of errors.