### PR TITLE
Change tooltips to buttons with generated accessible labels

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -280,6 +280,8 @@ i.icon-xl {
 }
 
 .tooltip-info {
+  background: none;
+  border: none;
   color: var(--stanford-digital-blue);
 }
 

--- a/app/components/edit/tab_form/pane_component.html.erb
+++ b/app/components/edit/tab_form/pane_component.html.erb
@@ -4,7 +4,7 @@
       <% if label || help_text || help? %>
         <div class="pane-header">
           <% if label %><h2 class="h4 tooltip-header"><%= label %></h2><% end %>
-          <%= render Elements::TooltipComponent.new(tooltip:) %>
+          <%= render Elements::TooltipComponent.new(target_label: label, tooltip:) %>
           <% if help_text %><p class="mb-0"><%= help_text || help %></p><% end %>
           <%= help if help? %>
         </div>

--- a/app/components/elements/forms/fieldset_component.html.erb
+++ b/app/components/elements/forms/fieldset_component.html.erb
@@ -5,7 +5,7 @@
     <% else %>
       <%= tag.label class: label_classes do %><%= label %><% end %>
     <% end %>
-    <%= render Elements::TooltipComponent.new(tooltip:) %>
+    <%= render Elements::TooltipComponent.new(target_label: label, tooltip:) %>
     <%= help_link if help_link? %>
   <% end %>
   <%= content %>

--- a/app/components/elements/forms/label_component.html.erb
+++ b/app/components/elements/forms/label_component.html.erb
@@ -2,4 +2,4 @@
   <%= label_text %>
 <% end %>
 <%# This is outside the label so that clicking on it doesn't toggle some inputs like checkboxes. %>
-<%= render Elements::TooltipComponent.new(tooltip:) %>
+<%= render Elements::TooltipComponent.new(target_label: label_text, tooltip:) %>

--- a/app/components/elements/forms/non_repeatable_nested_component.html.erb
+++ b/app/components/elements/forms/non_repeatable_nested_component.html.erb
@@ -2,7 +2,7 @@
   <% component.with_legend do %>
     <h3 class="tooltip-header">
       <%= render Edit::LabelComponent.new(label_text:, hidden_label:) %>
-      <%= render Elements::TooltipComponent.new(tooltip:) %>
+      <%= render Elements::TooltipComponent.new(target_label: label_text, tooltip:) %>
     </h3>
   <% end %>
   <%= tag.div class: 'mb-3' do %>

--- a/app/components/elements/forms/repeatable_nested_component.html.erb
+++ b/app/components/elements/forms/repeatable_nested_component.html.erb
@@ -2,7 +2,7 @@
   <% component.with_legend do %>
     <h3 class="tooltip-header">
       <%= render Edit::LabelComponent.new(label_text:, hidden_label:) %>
-      <%= render Elements::TooltipComponent.new(tooltip:) %>
+      <%= render Elements::TooltipComponent.new(target_label: label_text, tooltip:) %>
     </h3>
   <% end %>
   <%= before_section %>

--- a/app/components/elements/tables/header_component.html.erb
+++ b/app/components/elements/tables/header_component.html.erb
@@ -1,4 +1,4 @@
 <%= tag.th class: classes, style: do %>
   <%= label %>
-  <%= render Elements::TooltipComponent.new(tooltip:) %>
+  <%= render Elements::TooltipComponent.new(target_label: label, tooltip:) %>
 <% end %>

--- a/app/components/elements/tables/row_component.html.erb
+++ b/app/components/elements/tables/row_component.html.erb
@@ -2,7 +2,7 @@
   <% if label.present? %>
     <th class="col-3" scope="row">
       <%= label %>
-      <%= render Elements::TooltipComponent.new(tooltip:) %>
+      <%= render Elements::TooltipComponent.new(target_label: label, tooltip:) %>
     </th>
   <% end %>
   <% values.each do |value| %>

--- a/app/components/elements/tooltip_component.html.erb
+++ b/app/components/elements/tooltip_component.html.erb
@@ -1,0 +1,16 @@
+<%= tag.button(
+      type: 'button',
+      class: 'px-2 tooltip-info',
+      aria: {
+        label: "More information for #{target_label}"
+      },
+      data: {
+        bs_html: true,
+        bs_toggle: 'tooltip',
+        bs_title: tooltip,
+        bs_trigger: 'focus',
+        tooltips_target: 'icon'
+      }
+    ) do %>
+  <%= helpers.info_icon(fill: true) %>
+<% end %>

--- a/app/components/elements/tooltip_component.rb
+++ b/app/components/elements/tooltip_component.rb
@@ -3,29 +3,15 @@
 module Elements
   # Component for rendering a tooltip.
   class TooltipComponent < ApplicationComponent
-    def initialize(tooltip: nil)
+    def initialize(target_label:, tooltip: nil)
+      @target_label = target_label
       @tooltip = tooltip
       super()
     end
 
-    def call
-      helpers.info_icon(
-        fill: true,
-        classes: 'px-2 tooltip-info',
-        tabindex: 0,
-        data: {
-          bs_html: true,
-          bs_toggle: 'tooltip',
-          bs_title: tooltip,
-          bs_trigger: 'focus',
-          tooltips_target: 'icon'
-        }
-      )
-    end
-
     private
 
-    attr_reader :tooltip
+    attr_reader :tooltip, :target_label
 
     def render?
       tooltip.present?

--- a/app/components/works/edit/license_component.html.erb
+++ b/app/components/works/edit/license_component.html.erb
@@ -1,7 +1,7 @@
 <div class="pane-section">
   <div class="d-flex">
     <%= render Edit::LabelComponent.new(label_text: 'License') %>
-    <%= render Elements::TooltipComponent.new(tooltip:) %>
+    <%= render Elements::TooltipComponent.new(target_label: 'License', tooltip:) %>
     <% unless required_license_option? %>
       <div class="ms-4"><%= helpers.link_to_new_tab 'Get help selecting a license', Settings.license_url %></div>
     <% end %>

--- a/app/components/works/edit/terms_of_use_component.html.erb
+++ b/app/components/works/edit/terms_of_use_component.html.erb
@@ -1,7 +1,7 @@
 <div class="pane-section">
   <% if provided_custom_rights_statement_option? %>
     <%= render Edit::LabelComponent.new(label_text: label) %>
-    <%= render Elements::TooltipComponent.new(tooltip:) %>
+    <%= render Elements::TooltipComponent.new(target_label: label, tooltip:) %>
     <p><%= provided_custom_rights_statement %></p>
     <%= form.hidden_field :custom_rights_statement, value: provided_custom_rights_statement %>
   <% else %>

--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -59,7 +59,7 @@
 
           <div class="pane-section">
             <p>
-              Contact email provided by collection manager <%= render Elements::TooltipComponent.new(tooltip: t('works.edit.fields.works_contact_email.tooltip_html')) %>
+              Contact email provided by collection manager <%= render Elements::TooltipComponent.new(target_label: 'Provided contact email', tooltip: t('works.edit.fields.works_contact_email.tooltip_html')) %>
             </p>
             <p>
               <%= @work_form.works_contact_email %>

--- a/spec/components/elements/tables/header_component_spec.rb
+++ b/spec/components/elements/tables/header_component_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe Elements::Tables::HeaderComponent, type: :component do
     render_inline(described_class.new(classes: 'col-6', label: 'First header', tooltip: 'First tooltip'))
 
     expect(page).to have_css('th.col-6', text: 'First header')
-    expect(page).to have_css('i[data-bs-title="First tooltip"]')
+    expect(page).to have_css('.tooltip-info[data-bs-title="First tooltip"]')
   end
 end

--- a/spec/components/elements/tooltip_component_spec.rb
+++ b/spec/components/elements/tooltip_component_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Elements::TooltipComponent, type: :component do
+  let(:target_label) { 'My field' }
+  let(:tooltip) { 'Tooltip text' }
+
+  it 'renders the tooltip when tooltip text is present' do
+    render_inline(described_class.new(target_label:, tooltip:))
+    expect(page).to have_css('.tooltip-info[data-bs-title="Tooltip text"]')
+  end
+
+  it 'does not render the tooltip when tooltip text is absent' do
+    render_inline(described_class.new(target_label:, tooltip: nil))
+    expect(page).to have_no_css('.tooltip-info')
+  end
+
+  it 'gives the tooltip a name using the target label' do
+    render_inline(described_class.new(target_label:, tooltip:))
+    expect(page).to have_css('.tooltip-info[aria-label="More information for My field"]')
+  end
+end


### PR DESCRIPTION
SODA identified four issues with our tooltips:
1. The tooltip trigger must be focusable and operable with a keyboard.
2. If the tooltip content contains functional elements - such as links, buttons or form fields - they must be focusable and operable with a keyboard.
3. The content of the tooltip must be readable with a screen reader.
4. The keyboard focus (Tab key) order and screen reader reading order must be logical.

This PR fixes 1 and 4 by making the tooltips into buttons, which automatically makes them focusable and tabbable in a logical order. It also ensures a reasonable accessible name for the tooltip is generated by passing in the label of whatever the tooltip is tied to in order to generate a name like "More information on my field".

For 3, I've confirmed that you actually _can_ get the tooltip to be read, it's just a little weird in VoiceOver: you have to wait until the title of the tooltip is read ("More information on my field") and then you get informed that you can press a special key combination for more info, at which point it will open a _new_ menu where you can ask for the tooltip. This is...weird, but at the end of the day you can get at the tooltip text, so I'm calling it OK for now.

The only place we have a problem with 2 is the links inside a tooltip here:
https://github.com/sul-dlss/hungry-hungry-hippo/blob/b7998cd4dff6ca5e4d32d20c30d400a7fbe06820/config/locales/en.yml#L262

...but theoretically an SR user still hears the actual link addresses when the tooltip is read and could just navigate there if they needed to go get an ORCID, so it's maybe not as bad as it could be.

All that being the case, I think this PR can be considered to complete #898.