### PR TITLE
Wrap long filenames in hierarchical display.

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -172,6 +172,10 @@ table.table-treegrid {
     font-weight: 600;
     padding: 8px
   }
+
+  td[role="gridcell"] {
+    overflow-wrap: break-word;
+  }
 }
 
 // Following should be set in component library.


### PR DESCRIPTION
closes #1192

![image](https://github.com/user-attachments/assets/1d062807-ec03-4679-ad9b-b7a94197288c)
