### PR TITLE
Organize coverage into discrete groups by application concern

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ accessionWF steps can be completed with:
 bin/rake "development:accession[druid:dh414dd1590]"
 ```
 
-### System tests
+### Tests
 
-#### Javascript
+#### Speeding up system tests
 
-By default, system tests will use headless Chrome, which supports javascript.
+By default, system tests will use the headless Chrome browser driver, which supports JavaScript.
 
-If your test doesn't use javascript, consider using Rack, as it is much faster:
+If your test doesn't use JavaScript, consider using the Rack driver, as it is much faster:
 ```
 RSpec.describe 'Create a work draft', :rack_test do
 ```
@@ -83,6 +83,10 @@ In cases in which Cyperful doesn't work, temporarily using a headed test might b
 ```
 RSpec.describe 'Manage files for a work', :headed_test do
 ```
+
+#### Viewing test coverage
+
+Whenever the test suite is run, RSpec uses SimpleCov to generate test coverage reports. To view the most recent test coverage report in your browser, open `coverage/index.html`. NOTE: if the latest test run did not run against the entire test suite---e.g., if you tested a single file or directory---you should expect the coverage to appear very low.
 
 ### Code Linters
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,8 +2,19 @@
 
 require 'simplecov'
 
+SKIPPABLE_TEST_COVERAGE_CONCERNS = %w[assets javascript views].freeze
+
 SimpleCov.start :rails do
   add_filter '/lib/tasks/'
+
+  # Use SimpleCov groups to break down test coverage per application concern, e.g.,
+  # controllers, models, & jobs. See https://github.com/simplecov-ruby/simplecov#groups
+  Dir.glob('app/*').each do |concern_path|
+    concern = File.basename(concern_path)
+    next if SKIPPABLE_TEST_COVERAGE_CONCERNS.include?(concern)
+
+    add_group concern.capitalize, concern_path
+  end
 
   if ENV['CI']
     require 'simplecov_json_formatter'


### PR DESCRIPTION
This small SimpleCov configuration change provides developers with more information about test coverage.

![Screenshot from 2025-03-25 13-54-57](https://github.com/user-attachments/assets/76b304ef-cd85-40e1-b209-5b5785fe63a1)

