### PR TITLE
Include returned reviewed object in draft list on dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -32,8 +32,8 @@ class DashboardController < ApplicationController
   end
 
   def draft?(work, version_status)
-    return false if work.pending_review? || work.rejected_review?
+    return false if work.pending_review?
 
-    version_status.draft? && work.user == current_user
+    (work.rejected_review? || version_status.draft?) && work.user == current_user
   end
 end

--- a/spec/system/show_dashboard_spec.rb
+++ b/spec/system/show_dashboard_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Show dashboard', :rack_test do
     let!(:work_without_druid) { create(:work, user:, collection:) }
     let!(:draft_work) { create(:work, :with_druid, user:, collection:) }
     let!(:pending_review_work) { create(:work, user:, collection:, review_state: 'pending_review') }
+    let!(:rejected_review_work) { create(:work, user:, collection:, review_state: 'rejected_review') }
     let(:collection) do
       create(:collection, :with_druid, user:, managers: [user], reviewers: [user], review_enabled: true)
     end
@@ -43,6 +44,8 @@ RSpec.describe 'Show dashboard', :rack_test do
       expect(page).to have_css('h2', text: 'Drafts - please complete')
       within('table#drafts-table') do
         expect(page).to have_css('td', text: draft_work.title)
+        expect(page).to have_no_css('td', text: pending_review_work.title)
+        expect(page).to have_css('td', text: rejected_review_work.title)
       end
 
       # Pending review section


### PR DESCRIPTION
Works that are in a rejected review state should be included on the users dashboard as drafts.