### PR TITLE
Decouple the Notifier from mailer/action implementation details

### DIFF
--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -26,15 +26,9 @@ class Notifier
     ActiveSupport::Notifications.instrument(event_name, **payload)
   end
 
-  def self.subscribe_mailer(event_name:, mailer_class:, mailer_method:)
+  def self.subscribe(event_name:)
     ActiveSupport::Notifications.subscribe(event_name) do |event|
-      mailer_class.with(**event.payload).send(mailer_method).deliver_later if Settings.notifications.enabled
-    end
-  end
-
-  def self.subscribe_action(event_name:, action_class:)
-    ActiveSupport::Notifications.subscribe(event_name) do |event|
-      action_class.call(**event.payload) if Settings.notifications.enabled
+      yield event.payload if Settings.notifications.enabled
     end
   end
 end

--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -3,46 +3,63 @@
 Rails.application.config.after_initialize do # rubocop:disable Metrics/BlockLength
   # Subscriptions for CollectionsMailer
   # Depositor change notifications
-  Notifier.subscribe_mailer(event_name: Notifier::DEPOSITOR_ADDED, mailer_class: CollectionsMailer,
-                            mailer_method: :invitation_to_deposit_email)
-  Notifier.subscribe_mailer(event_name: Notifier::DEPOSITOR_REMOVED, mailer_class: CollectionsMailer,
-                            mailer_method: :deposit_access_removed_email)
-  Notifier.subscribe_mailer(event_name: Notifier::DEPOSITOR_ADDED, mailer_class: CollectionsMailer,
-                            mailer_method: :participants_changed_email)
-  Notifier.subscribe_mailer(event_name: Notifier::DEPOSITOR_REMOVED, mailer_class: CollectionsMailer,
-                            mailer_method: :participants_changed_email)
-  Notifier.subscribe_action(event_name: Notifier::DEPOSIT_PERSIST_COMPLETE,
-                            action_class: CollectionDepositPersistCompletedSubscriptionMailer)
+  Notifier.subscribe(event_name: Notifier::DEPOSITOR_ADDED) do |payload|
+    CollectionsMailer.with(**payload).invitation_to_deposit_email.deliver_later
+  end
+  Notifier.subscribe(event_name: Notifier::DEPOSITOR_REMOVED) do |payload|
+    CollectionsMailer.with(**payload).deposit_access_removed_email.deliver_later
+  end
+  Notifier.subscribe(event_name: Notifier::DEPOSITOR_ADDED) do |payload|
+    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
+  end
+  Notifier.subscribe(event_name: Notifier::DEPOSITOR_REMOVED) do |payload|
+    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
+  end
+  Notifier.subscribe(event_name: Notifier::DEPOSIT_PERSIST_COMPLETE) do |payload|
+    CollectionDepositPersistCompletedSubscriptionMailer.call(**payload)
+  end
 
   # Manager change notifications
-  Notifier.subscribe_mailer(event_name: Notifier::MANAGER_ADDED, mailer_class: CollectionsMailer,
-                            mailer_method: :manage_access_granted_email)
-  Notifier.subscribe_mailer(event_name: Notifier::MANAGER_ADDED, mailer_class: CollectionsMailer,
-                            mailer_method: :participants_changed_email)
-  Notifier.subscribe_mailer(event_name: Notifier::MANAGER_REMOVED, mailer_class: CollectionsMailer,
-                            mailer_method: :participants_changed_email)
+  Notifier.subscribe(event_name: Notifier::MANAGER_ADDED) do |payload|
+    CollectionsMailer.with(**payload).manage_access_granted_email.deliver_later
+  end
+  Notifier.subscribe(event_name: Notifier::MANAGER_ADDED) do |payload|
+    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
+  end
+  Notifier.subscribe(event_name: Notifier::MANAGER_REMOVED) do |payload|
+    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
+  end
 
   # Reviewer change notifications
-  Notifier.subscribe_mailer(event_name: Notifier::REVIEWER_ADDED, mailer_class: CollectionsMailer,
-                            mailer_method: :review_access_granted_email)
-  Notifier.subscribe_mailer(event_name: Notifier::REVIEWER_ADDED, mailer_class: CollectionsMailer,
-                            mailer_method: :participants_changed_email)
-  Notifier.subscribe_mailer(event_name: Notifier::REVIEWER_REMOVED, mailer_class: CollectionsMailer,
-                            mailer_method: :participants_changed_email)
+  Notifier.subscribe(event_name: Notifier::REVIEWER_ADDED) do |payload|
+    CollectionsMailer.with(**payload).review_access_granted_email.deliver_later
+  end
+  Notifier.subscribe(event_name: Notifier::REVIEWER_ADDED) do |payload|
+    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
+  end
+  Notifier.subscribe(event_name: Notifier::REVIEWER_REMOVED) do |payload|
+    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
+  end
 
   # Subscriptions for ReviewsMailer
-  Notifier.subscribe_mailer(event_name: Notifier::REVIEW_REQUESTED, mailer_class: ReviewsMailer,
-                            mailer_method: :submitted_email)
-  Notifier.subscribe_mailer(event_name: Notifier::REVIEW_REJECTED, mailer_class: ReviewsMailer,
-                            mailer_method: :rejected_email)
-  Notifier.subscribe_mailer(event_name: Notifier::REVIEW_APPROVED, mailer_class: ReviewsMailer,
-                            mailer_method: :approved_email)
-  Notifier.subscribe_action(event_name: Notifier::REVIEW_REQUESTED,
-                            action_class: ReviewRequestSubscriptionMailer)
+  Notifier.subscribe(event_name: Notifier::REVIEW_REQUESTED) do |payload|
+    ReviewsMailer.with(**payload).submitted_email.deliver_later
+  end
+  Notifier.subscribe(event_name: Notifier::REVIEW_REJECTED) do |payload|
+    ReviewsMailer.with(**payload).rejected_email.deliver_later
+  end
+  Notifier.subscribe(event_name: Notifier::REVIEW_APPROVED) do |payload|
+    ReviewsMailer.with(**payload).approved_email.deliver_later
+  end
+  Notifier.subscribe(event_name: Notifier::REVIEW_REQUESTED) do |payload|
+    ReviewRequestSubscriptionMailer.call(**payload)
+  end
 
   # Subscriptions for WorksMailer
-  Notifier.subscribe_action(event_name: Notifier::ACCESSIONING_STARTED,
-                            action_class: WorkAccessioningStartedSubscriptionMailer)
-  Notifier.subscribe_action(event_name: Notifier::ACCESSIONING_COMPLETE,
-                            action_class: WorkAccessioningCompletedSubscriptionMailer)
+  Notifier.subscribe(event_name: Notifier::ACCESSIONING_STARTED) do |payload|
+    WorkAccessioningStartedSubscriptionMailer.call(**payload)
+  end
+  Notifier.subscribe(event_name: Notifier::ACCESSIONING_COMPLETE) do |payload|
+    WorkAccessioningCompletedSubscriptionMailer.call(**payload)
+  end
 end


### PR DESCRIPTION
With this change, `Notifier.subscribe` takes an event name to subscribe to, and then yields event payloads to the block. This means the Notifier no longer needs to care about whether something is a mailer class or an "action," terminology we no longer use in H3. This change makes the Notifier class less coupled to implementation details and gives us more flexibility to accommodate new use cases going forward.
