### PR TITLE
Fix role lookup when mapping to cocina.

### DIFF
--- a/app/cocina_builders/contributor_role_cocina_builder.rb
+++ b/app/cocina_builders/contributor_role_cocina_builder.rb
@@ -189,6 +189,6 @@ class ContributorRoleCocinaBuilder # rubocop:disable Metrics/ClassLength
   attr_reader :role
 
   def role_key
-    role.sub(' ', '_').to_sym
+    role.tr(' ', '_').to_sym
   end
 end


### PR DESCRIPTION
A role may have more than one space, e.g., "degree granting institution".