### PR TITLE
Encode user-provided keyword strings before sending to FAST API

### DIFF
--- a/app/services/keyword_resolver.rb
+++ b/app/services/keyword_resolver.rb
@@ -61,7 +61,7 @@ class KeywordResolver
 
   def resolve(query) # rubocop:disable Metrics/AbcSize
     response = connection.get do |req|
-      req.params['query'] = query
+      req.params['query'] = ERB::Util.url_encode(query)
       req.params['queryIndex'] = 'suggestall'
       req.params['queryReturn'] = 'idroot,suggestall,tag'
       req.params['suggest'] = 'autoSubject'

--- a/spec/support/stub_fast_connection.rb
+++ b/spec/support/stub_fast_connection.rb
@@ -2,8 +2,15 @@
 
 RSpec.shared_context('with FAST connection') do
   before do
-    stub_request(:get, "#{Settings.autocomplete_lookup.url}?query=#{query}#{other_params}")
-      .with(headers: lookup_headers)
+    stub_request(:get, Settings.autocomplete_lookup.url)
+      .with(headers: lookup_headers, query: {
+              query:,
+              rows: 20,
+              sort: 'usage desc',
+              queryIndex: 'suggestall',
+              queryReturn: 'idroot,suggestall,tag',
+              suggest: 'autoSubject'
+            })
       .to_return(status: lookup_status, body: lookup_response_body, headers: {})
   end
 
@@ -14,9 +21,6 @@ RSpec.shared_context('with FAST connection') do
       'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
       'User-Agent' => 'Stanford Self-Deposit (Hungry Hungry Hippo)'
     }
-  end
-  let(:other_params) do
-    '&rows=20&sort=usage+desc&queryIndex=suggestall&queryReturn=idroot,suggestall,tag&suggest=autoSubject'
   end
   let(:lookup_response_body) do
     {


### PR DESCRIPTION
Do this because it is a best practice and because it eliminates HB exceptions about unhelpful 400 Bad Request responses from the FAST API when we send it improperly escaped query strings.
