### PR TITLE
Change user_versions param when closing version.

### DIFF
--- a/app/services/sdr/repository.rb
+++ b/app/services/sdr/repository.rb
@@ -53,8 +53,8 @@ module Sdr
     def self.accession(druid:)
       # Close the version, which will also start accessioning
       # user_versions = mode for handling user versioning.
-      # Setting to none (do nothing with user versioning) for now.
-      Dor::Services::Client.object(druid).version.close(user_versions: 'none')
+      # Setting to update_if_existing (the default in DSA) for now.
+      Dor::Services::Client.object(druid).version.close(user_versions: 'update_if_existing')
     rescue Dor::Services::Client::Error => e
       raise Error, "Initiating accession failed: #{e.message}"
     end

--- a/spec/services/sdr/repository_spec.rb
+++ b/spec/services/sdr/repository_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Sdr::Repository do
         described_class.accession(druid:)
 
         expect(Dor::Services::Client).to have_received(:object).with(druid)
-        expect(version_client).to have_received(:close).with(user_versions: 'none')
+        expect(version_client).to have_received(:close).with(user_versions: 'update_if_existing')
       end
     end
 


### PR DESCRIPTION
This allows updating H2 objects, since they use user versioning.