### PR TITLE
Switch left nav tabs to buttons for keyboard navigation

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -42,6 +42,7 @@ $enable-smooth-scroll: false;
 
       border-radius: unset;
       display: block flex;
+      text-align: left;
 
       &:not(:first-child) {
         border-top: var(--bs-border-width) var(--bs-border-style) rgba(var(--bs-white-rgb), 1);

--- a/app/components/edit/tab_form/tab_component.rb
+++ b/app/components/edit/tab_form/tab_component.rb
@@ -12,7 +12,7 @@ module Edit
       end
 
       def call
-        tag.div(
+        tag.button(
           class: classes,
           id:,
           data: {
@@ -24,7 +24,8 @@ module Edit
           type: 'button',
           'aria-controls': pane_id,
           'aria-selected': selected?,
-          'aria-labelledby': id
+          'aria-labelledby': id,
+          tabindex: '0'
         ) do
           label
         end

--- a/app/components/edit/tab_form/tab_list_component.html.erb
+++ b/app/components/edit/tab_form/tab_list_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div class: classes, 'data-controller': 'tab-error' do %>
   <div class="col-md-3">
-    <%= tag.div class: 'nav nav-pills d-flex flex-column rounded-top rounded-bottom', role: 'tablist', 'aria-orientation': 'vertical' do |component| %>
+    <%= tag.div class: 'nav nav-pills d-flex flex-column rounded-top rounded-bottom', role: 'tablist navigation', 'aria-orientation': 'vertical', tabindex: '0' do |component| %>
       <% tabs.each do |tab| %>
         <%= tab %>
       <% end %>

--- a/spec/components/edit/tab_form/tab_component_spec.rb
+++ b/spec/components/edit/tab_form/tab_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Edit::TabForm::TabComponent, type: :component do
     it 'renders a tab' do
       render_inline(described_class.new(label: 'Tab 1', tab_name: :tab_one, active_tab_name: :tab_one))
 
-      expect(page).to have_css('div.nav-link.active#tab_one-tab', text: 'Tab 1')
+      expect(page).to have_button('Tab 1', class: 'nav-link w-100 active')
     end
   end
 
@@ -15,7 +15,7 @@ RSpec.describe Edit::TabForm::TabComponent, type: :component do
     it 'renders a tab without active class' do
       render_inline(described_class.new(label: 'Tab 1', tab_name: :tab_one, active_tab_name: :tab_two))
 
-      expect(page).to have_css('div.nav-link#tab_one-tab:not(.active)', text: 'Tab 1')
+      expect(page).to have_button('Tab 1', class: 'nav-link w-100')
     end
   end
 end

--- a/spec/system/edit_work_spec.rb
+++ b/spec/system/edit_work_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe 'Edit a work' do
 
       find('.nav-link', text: 'Deposit', exact_text: true).click
       fill_in('What\'s changing?', with: 'Nothing')
-      click_link_or_button('Deposit')
+      find('.btn-primary', text: 'Deposit', exact_text: true).click
 
       expect(page).to have_current_path(edit_work_path(druid))
       expect(page).to have_css('.alert-warning', text: 'You have not made any changes to the form.')


### PR DESCRIPTION
Fixes #1060

Note, per @alundgard feedback in (https://stanfordlib.slack.com/archives/C07CQLENZGW/p1748893022298669?thread_ts=1748890325.891679&cid=C07CQLENZGW) these need to be `button` objects in order to use keyboard navigation.


https://github.com/user-attachments/assets/96314bda-2fac-43ef-b3d8-a594e1e3df7b

