### PR TITLE
Pass in event metadata when updating objects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
-    bigdecimal (3.2.1)
+    bigdecimal (3.2.2)
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
@@ -190,7 +190,7 @@ GEM
       activesupport (>= 4.2)
       bunny (~> 2.17)
       zeitwerk (~> 2.1)
-    dor-services-client (15.9.1)
+    dor-services-client (15.10.0)
       activesupport (>= 7.0.0)
       cocina-models (~> 0.103.2)
       deprecation
@@ -635,7 +635,7 @@ DEPENDENCIES
   debug
   dlss-capistrano
   dor-event-client
-  dor-services-client (>= 15.9.0)
+  dor-services-client
   dor-workflow-client (>= 7.6.1)
   druid-tools
   dry-monads

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
       activesupport (>= 4.2)
       bunny (~> 2.17)
       zeitwerk (~> 2.1)
-    dor-services-client (15.10.0)
+    dor-services-client (15.11.0)
       activesupport (>= 7.0.0)
       cocina-models (~> 0.103.2)
       deprecation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -635,7 +635,7 @@ DEPENDENCIES
   debug
   dlss-capistrano
   dor-event-client
-  dor-services-client
+  dor-services-client (>= 15.9.0)
   dor-workflow-client (>= 7.6.1)
   druid-tools
   dry-monads

--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -59,14 +59,16 @@ class DepositCollectionJob < ApplicationJob
     assign_contributors
   end
 
+  # rubocop:disable Metrics/AbcSize
   def perform_persist
     if !collection_form.persisted?
-      Sdr::Repository.register(cocina_object: mapped_cocina_object)
+      Sdr::Repository.register(cocina_object: mapped_cocina_object, user_name: Current.user.sunetid)
     elsif RoundtripSupport.changed?(cocina_object: mapped_cocina_object)
-      Sdr::Repository.open_if_needed(cocina_object: mapped_cocina_object)
-                     .then { |cocina_object| Sdr::Repository.update(cocina_object:) }
+      Sdr::Repository.open_if_needed(cocina_object: mapped_cocina_object, user_name: Current.user.sunetid)
+                     .then { |cocina_object| Sdr::Repository.update(cocina_object:, user_name: Current.user.sunetid) }
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   # @param [Symbol] role :managers or :depositors
   #

--- a/app/jobs/deposit_work_job.rb
+++ b/app/jobs/deposit_work_job.rb
@@ -45,6 +45,10 @@ class DepositWorkJob < ApplicationJob
 
   attr_reader :work_form, :work, :status
 
+  def user_name
+    Current.user.sunetid
+  end
+
   def content
     @content ||= Content.find(work_form.content_id)
   end
@@ -73,13 +77,13 @@ class DepositWorkJob < ApplicationJob
   # rubocop:disable Metrics/AbcSize
   def perform_persist
     if !work_form.persisted?
-      Sdr::Repository.register(cocina_object: cocina_object_for_persist, assign_doi:, user_name: Current.user.sunetid)
+      Sdr::Repository.register(cocina_object: cocina_object_for_persist, assign_doi:, user_name:)
     elsif changed?
       Sdr::Repository.open_if_needed(cocina_object: cocina_object_for_persist,
                                      version_description: work_form.whats_changing, status:,
-                                     user_name: Current.user.sunetid)
+                                     user_name:)
                      .then do |cocina_object|
-        Sdr::Repository.update(cocina_object:, user_name: Current.user.sunetid)
+        Sdr::Repository.update(cocina_object:, user_name:)
       end
     end
   end

--- a/app/jobs/deposit_work_job.rb
+++ b/app/jobs/deposit_work_job.rb
@@ -77,7 +77,7 @@ class DepositWorkJob < ApplicationJob
       Sdr::Repository.open_if_needed(cocina_object: cocina_object_for_persist,
                                      version_description: work_form.whats_changing, status:)
                      .then do |cocina_object|
-        Sdr::Repository.update(cocina_object:)
+        Sdr::Repository.update(cocina_object:, description: 'metadata and files updated')
       end
     end
   end

--- a/app/jobs/deposit_work_job.rb
+++ b/app/jobs/deposit_work_job.rb
@@ -70,17 +70,20 @@ class DepositWorkJob < ApplicationJob
     @changed = RoundtripSupport.changed?(cocina_object: mapped_cocina_object)
   end
 
+  # rubocop:disable Metrics/AbcSize
   def perform_persist
     if !work_form.persisted?
-      Sdr::Repository.register(cocina_object: cocina_object_for_persist, assign_doi:)
+      Sdr::Repository.register(cocina_object: cocina_object_for_persist, assign_doi:, user_name: Current.user.sunetid)
     elsif changed?
       Sdr::Repository.open_if_needed(cocina_object: cocina_object_for_persist,
-                                     version_description: work_form.whats_changing, status:)
+                                     version_description: work_form.whats_changing, status:,
+                                     user_name: Current.user.sunetid)
                      .then do |cocina_object|
-        Sdr::Repository.update(cocina_object:, description: 'metadata and files updated')
+        Sdr::Repository.update(cocina_object:, user_name: Current.user.sunetid)
       end
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   def assign_doi
     work_form.doi_option == 'yes'

--- a/app/services/sdr/repository.rb
+++ b/app/services/sdr/repository.rb
@@ -80,10 +80,14 @@ module Sdr
     end
 
     # @param [Cocina::Models::DRO] cocina_object
+    # @param [String] description the description of the update for DSA Event
     # @raise [Error] if there is an error updating the object
     # @return [Cocina::Models::DRO] the updated cocina object
-    def self.update(cocina_object:)
-      Dor::Services::Client.object(cocina_object.externalIdentifier).update(params: cocina_object)
+    def self.update(cocina_object:, description: nil)
+      Dor::Services::Client.object(cocina_object.externalIdentifier).update(params: cocina_object,
+                                                                            event_data: {
+                                                                              description:, who: Current.user.sunetid
+                                                                            })
     rescue Dor::Services::Client::Error => e
       raise Error, "Updating failed: #{e.message}"
     end

--- a/app/services/sdr/repository.rb
+++ b/app/services/sdr/repository.rb
@@ -85,9 +85,8 @@ module Sdr
     # @return [Cocina::Models::DRO] the updated cocina object
     def self.update(cocina_object:, description: nil)
       Dor::Services::Client.object(cocina_object.externalIdentifier).update(params: cocina_object,
-                                                                            event_data: {
-                                                                              description:, who: Current.user.sunetid
-                                                                            })
+                                                                            description:,
+                                                                            who: Current.user.sunetid)
     rescue Dor::Services::Client::Error => e
       raise Error, "Updating failed: #{e.message}"
     end

--- a/app/services/sdr/repository.rb
+++ b/app/services/sdr/repository.rb
@@ -39,7 +39,8 @@ module Sdr
     # @return [Cocina::Models::DRO] the registered cocina object
     # @raise [Error] if there is an error depositing the work
     def self.register(cocina_object:, assign_doi: false)
-      response_cocina_object = Dor::Services::Client.objects.register(params: cocina_object, assign_doi:)
+      response_cocina_object = Dor::Services::Client.objects.register(params: cocina_object, assign_doi:,
+                                                                      user_name: Current.user.sunetid)
 
       # Create workflow destroys existing steps if called again, so need to check if already created.
       Sdr::Workflow.create_unless_exists(response_cocina_object.externalIdentifier, 'registrationWF', version: 1)
@@ -72,7 +73,8 @@ module Sdr
       raise Error, 'Object cannot be opened' unless status.openable?
 
       open_cocina_object = Dor::Services::Client.object(cocina_object.externalIdentifier)
-                                                .version.open(description: version_description)
+                                                .version.open(description: version_description,
+                                                              opening_user_name: Current.user.sunetid)
       Cocina::VersionAndLockUpdater.call(cocina_object:, version: open_cocina_object.version,
                                          lock: open_cocina_object.lock)
     rescue Dor::Services::Client::Error => e
@@ -86,7 +88,7 @@ module Sdr
     def self.update(cocina_object:, description: nil)
       Dor::Services::Client.object(cocina_object.externalIdentifier).update(params: cocina_object,
                                                                             description:,
-                                                                            who: Current.user.sunetid)
+                                                                            user_name: Current.user.sunetid)
     rescue Dor::Services::Client::Error => e
       raise Error, "Updating failed: #{e.message}"
     end

--- a/spec/jobs/deposit_collection_job_spec.rb
+++ b/spec/jobs/deposit_collection_job_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DepositCollectionJob do
       expect(Cocina::CollectionMapper).to have_received(:call).with(collection_form:,
                                                                     source_id: "h3:collection-#{collection.id}")
       expect(Sdr::Repository).to have_received(:register)
-        .with(cocina_object: an_instance_of(Cocina::Models::RequestCollection))
+        .with(cocina_object: an_instance_of(Cocina::Models::RequestCollection), user_name: current_user.sunetid)
       expect(Sdr::Repository).to have_received(:accession).with(druid:)
 
       expect(collection.reload.accessioning?).to be true
@@ -118,8 +118,8 @@ RSpec.describe DepositCollectionJob do
       expect(Cocina::CollectionMapper).to have_received(:call).with(collection_form:,
                                                                     source_id: "h3:collection-#{collection.id}")
       expect(Sdr::Repository).to have_received(:open_if_needed)
-        .with(cocina_object: an_instance_of(Cocina::Models::CollectionWithMetadata))
-      expect(Sdr::Repository).to have_received(:update).with(cocina_object:)
+        .with(cocina_object: an_instance_of(Cocina::Models::CollectionWithMetadata), user_name: current_user.sunetid)
+      expect(Sdr::Repository).to have_received(:update).with(cocina_object:, user_name: current_user.sunetid)
       expect(Sdr::Repository).to have_received(:accession)
       expect(RoundtripSupport).to have_received(:changed?)
       expect(Notifier).not_to have_received(:publish).with(Notifier::DEPOSIT_PERSIST_COMPLETE)

--- a/spec/jobs/deposit_work_job_spec.rb
+++ b/spec/jobs/deposit_work_job_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe DepositWorkJob do
                 expect(event.type).to eq 'deposit'
                 expect(event.date.first.value).to eq '2024-01-01'
               end
-      expect(Sdr::Repository).to have_received(:update).with(cocina_object:)
+      expect(Sdr::Repository).to have_received(:update).with(cocina_object:, description: 'metadata and files updated')
       expect(Sdr::Repository).not_to have_received(:accession)
       expect(RoundtripSupport).to have_received(:changed?)
 
@@ -167,7 +167,7 @@ RSpec.describe DepositWorkJob do
                 expect(event.type).to eq 'deposit'
                 expect(event.date.first.value).to eq Time.zone.today.iso8601
               end
-      expect(Sdr::Repository).to have_received(:update).with(cocina_object:)
+      expect(Sdr::Repository).to have_received(:update).with(cocina_object:, description: 'metadata and files updated')
       expect(Sdr::Repository).to have_received(:accession)
     end
   end

--- a/spec/services/sdr/repository_spec.rb
+++ b/spec/services/sdr/repository_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Sdr::Repository do
       end
 
       it 'registers with SDR and creates registrationWF' do
-        expect(described_class.register(cocina_object:)).to eq(registered_cocina_object)
+        expect(described_class.register(cocina_object:, user_name:)).to eq(registered_cocina_object)
 
         expect(objects_client).to have_received(:register).with(params: cocina_object, assign_doi: false,
                                                                 user_name:)
@@ -41,7 +41,7 @@ RSpec.describe Sdr::Repository do
       end
 
       it 'raises' do
-        expect { described_class.register(cocina_object:) }.to raise_error(Sdr::Repository::Error)
+        expect { described_class.register(cocina_object:, user_name:) }.to raise_error(Sdr::Repository::Error)
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Sdr::Repository do
       end
 
       it 'raises' do
-        expect { described_class.register(cocina_object:) }.to raise_error(Sdr::Repository::Error)
+        expect { described_class.register(cocina_object:, user_name:) }.to raise_error(Sdr::Repository::Error)
       end
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe Sdr::Repository do
   end
 
   describe '#open_if_needed' do
-    subject(:open_cocina_object) { described_class.open_if_needed(cocina_object:, version_description:) }
+    subject(:open_cocina_object) { described_class.open_if_needed(cocina_object:, version_description:, user_name:) }
 
     let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
     let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, status: version_status) }
@@ -238,7 +238,7 @@ RSpec.describe Sdr::Repository do
 
     context 'when successful' do
       it 'updates with SDR' do
-        expect(described_class.update(cocina_object:, description:)).to eq(updated_cocina_object)
+        expect(described_class.update(cocina_object:, description:, user_name:)).to eq(updated_cocina_object)
 
         expect(object_client).to have_received(:update).with(params: cocina_object,
                                                              user_name:,
@@ -254,7 +254,7 @@ RSpec.describe Sdr::Repository do
       end
 
       it 'raises' do
-        expect { described_class.update(cocina_object:) }.to raise_error(Sdr::Repository::Error)
+        expect { described_class.update(cocina_object:, user_name:) }.to raise_error(Sdr::Repository::Error)
       end
     end
   end

--- a/spec/services/sdr/repository_spec.rb
+++ b/spec/services/sdr/repository_spec.rb
@@ -239,9 +239,8 @@ RSpec.describe Sdr::Repository do
         expect(described_class.update(cocina_object:, description:)).to eq(updated_cocina_object)
 
         expect(object_client).to have_received(:update).with(params: cocina_object,
-                                                             event_data: {
-                                                               description:, who: user_name
-                                                             })
+                                                             who: user_name,
+                                                             description:)
       end
     end
 

--- a/spec/services/sdr/repository_spec.rb
+++ b/spec/services/sdr/repository_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Sdr::Repository do
       it 'registers with SDR and creates registrationWF' do
         expect(described_class.register(cocina_object:)).to eq(registered_cocina_object)
 
-        expect(objects_client).to have_received(:register).with(params: cocina_object, assign_doi: false)
+        expect(objects_client).to have_received(:register).with(params: cocina_object, assign_doi: false,
+                                                                user_name:)
         expect(Sdr::Workflow).to have_received(:create_unless_exists).with(druid, 'registrationWF', version: 1)
       end
     end
@@ -207,7 +208,8 @@ RSpec.describe Sdr::Repository do
       it 'opens a new version' do
         expect(open_cocina_object.version).to eq(2)
         expect(open_cocina_object.lock).to eq('bcd234')
-        expect(version_client).to have_received(:open).with(description: version_description)
+        expect(version_client).to have_received(:open).with(description: version_description,
+                                                            opening_user_name: user_name)
       end
     end
 
@@ -239,7 +241,7 @@ RSpec.describe Sdr::Repository do
         expect(described_class.update(cocina_object:, description:)).to eq(updated_cocina_object)
 
         expect(object_client).to have_received(:update).with(params: cocina_object,
-                                                             who: user_name,
+                                                             user_name:,
                                                              description:)
       end
     end


### PR DESCRIPTION
Part of #1371 - add extra metadata to the object update event.

Tested in QA with this bug fix in DSA: https://github.com/sul-dlss/dor-services-app/pull/5366

Release strategy:
1. ~~https://github.com/sul-dlss/dor-services-app/pull/5364~~
2. ~~https://github.com/sul-dlss/dor-services-client/pull/525~~
3. ~~Create new release of dsa client~~
4. ~~Deploy dsa~~
5. ~~Update this PR to use the new release of dsa-client~~