### PR TITLE
Support setting message position for spinners, defaulting to right side.

### DIFF
--- a/app/components/edit/rosette_spinner_component.html.erb
+++ b/app/components/edit/rosette_spinner_component.html.erb
@@ -1,4 +1,5 @@
 <%= tag.div data: { controller: 'wait' }, id: 'rosette-spinner' do %>
     <%= render Elements::SpinnerComponent.new(image_path: image_path('rosette.png'), message: t('messages.wait_for_it'),
-                                              classes: 'my-5 text-center', height: 150, width: 150, message_classes: 'mt-3', speed: 3.0) %>
+                                              classes: 'my-5 align-items-center', height: 150, width: 150, message_classes: 'mt-3', speed: 3.0,
+                                              message_position: :bottom) %>
 <% end %>

--- a/app/components/elements/spinner_component.rb
+++ b/app/components/elements/spinner_component.rb
@@ -3,8 +3,9 @@
 module Elements
   # It spins.
   class SpinnerComponent < ApplicationComponent
-    def initialize(message: 'Loading...', image_path: nil, variant: nil, hide_message: false, classes: [], # rubocop:disable Metrics/ParameterLists
-                   height: nil, width: nil, message_classes: [], speed: 0.75, data: {}, id: nil)
+    def initialize(message: 'Loading...', message_classes: [], message_position: :right, hide_message: false, # rubocop:disable Metrics/ParameterLists
+                   image_path: nil, variant: nil, classes: [],
+                   height: nil, width: nil, speed: 0.75, data: {}, id: nil)
       @message = message
       @variant = variant
       @hide_message = hide_message
@@ -16,13 +17,14 @@ module Elements
       @speed = speed # In seconds, so a larger number is slower. The default (0.75) is the same as Bootstrap's default.
       @data = data
       @id = id
+      @message_position = message_position # :bottom or :right
       super()
     end
 
     attr_reader :message, :image_path, :data, :id
 
     def spinner_classes
-      merge_classes('spinner-border', variant_class, border_class)
+      merge_classes('spinner-border', variant_class, border_class, 'mx-2')
     end
 
     def message_classes
@@ -30,7 +32,7 @@ module Elements
     end
 
     def classes
-      merge_classes(@classes)
+      merge_classes(@classes, 'd-flex', message_position_classes)
     end
 
     def spinner_style
@@ -40,6 +42,19 @@ module Elements
     end
 
     private
+
+    def message_position_classes
+      case @message_position # rubocop:disable Metrics/HashLikeCase
+      when :bottom
+        'flex-column'
+      when :right
+        'align-items-center'
+      when :top
+        'flex-column-reverse'
+      when :left
+        'flex-row-reverse align-items-center justify-content-end'
+      end
+    end
 
     def variant_class
       return unless @variant

--- a/app/views/globuses/wait.html.erb
+++ b/app/views/globuses/wait.html.erb
@@ -3,7 +3,7 @@
     <div class="col">
       <%= turbo_stream_from 'globus', @content %>
       <%= render Elements::SpinnerComponent.new(message: 'Getting list of files from Globus') %>
-      <%= render Elements::ButtonFormComponent.new(label: 'Cancel',
+      <%= render Elements::ButtonFormComponent.new(label: 'Cancel', variant: 'outline-primary',
                                                    link: cancel_content_globuses_path(@content), data: { action: 'dropzone-files#enableDropzone' },
                                                    method: :post, top: false) %>
     </div>


### PR DESCRIPTION
closes #1367

```
<%= render Elements::SpinnerComponent.new %>

<%= render Elements::SpinnerComponent.new(message_position: :bottom, classes: 'mt-3') %>

<%= render Elements::SpinnerComponent.new(message_position: :top, classes: 'mt-3') %>

<%= render Elements::SpinnerComponent.new(message_position: :left, classes: 'mt-3') %>

<%= render Edit::RosetteSpinnerComponent.new %>
```

![image](https://github.com/user-attachments/assets/9c4de81d-f847-4bd8-ac22-ffe952db1f35)
