### PR TITLE
Display link to terms of use conditionally on work deposit pane.

### DIFF
--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -125,7 +125,14 @@
         <%= render Works::Edit::CitationComponent.new(form:) %>
       <% end %>
 
-      <% component.with_work_pane(tab_name: :deposit, label: t('works.edit.panes.deposit.label'), form_id:, discard_draft_form_id:, work_presenter: @work_presenter, help_text: t('works.edit.panes.deposit.help_text'), active_tab_name:, next_tab_btn: false) do |pane_component| %>
+      <% component.with_work_pane(tab_name: :deposit, label: t('works.edit.panes.deposit.label'), form_id:, discard_draft_form_id:, work_presenter: @work_presenter, active_tab_name:, next_tab_btn: false) do |pane_component| %>
+        <% pane_component.with_help do %>
+          <p class="mb-0">
+            <%= t('works.edit.panes.deposit.help_text') %>
+            <% if @work_form.agree_to_terms %>You have accepted the <a href="#" data-bs-toggle="modal" data-bs-target="#tod-modal">Terms of Deposit</a>.<% end %>
+          </p>
+        <% end %>
+
         <% if @work_presenter && !@work_presenter.first_draft? %>
           <div class="pane-section">
             <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :whats_changing, label: t('works.edit.fields.whats_changing.label'), tooltip: t('works.edit.fields.whats_changing.tooltip_html'), maxlength: 100) %>

--- a/spec/system/create_work_deposit_spec.rb
+++ b/spec/system/create_work_deposit_spec.rb
@@ -226,9 +226,8 @@ RSpec.describe 'Create a work deposit' do
 
       expect(page).to have_no_text('What\'s changing?')
 
-      within('#main-container') do
-        expect(page).to have_no_text('Terms of deposit')
-      end
+      expect(page).to have_text('You have accepted the Terms of Deposit')
+      expect(page).to have_no_text('I agree to the SDR Terms of Deposit')
 
       # Footer buttons
       expect(page).to have_button('Save as draft')

--- a/spec/system/validate_work_deposit_spec.rb
+++ b/spec/system/validate_work_deposit_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe 'Validate a work deposit' do
     # Terms of deposit is required, but skipping.
     find('.nav-link', text: 'Deposit', exact_text: true).click
     expect(page).to have_css('.nav-link.active', text: 'Deposit')
+    expect(page).to have_no_text('You have accepted the Terms of Deposit')
     expect(page).to have_field('I agree to the SDR Terms of Deposit', checked: false)
     expect(page).to have_text('In depositing content to the Stanford Digital Repository')
 


### PR DESCRIPTION
closes #1248

<img width="853" alt="image" src="https://github.com/user-attachments/assets/b8865cb7-04ac-40d2-bc09-4ee913721962" />
