### PR TITLE
Display pending review alert when item is pending review

### DIFF
--- a/app/components/elements/spinner_component.rb
+++ b/app/components/elements/spinner_component.rb
@@ -44,7 +44,7 @@ module Elements
     private
 
     def message_position_classes
-      case @message_position # rubocop:disable Metrics/HashLikeCase
+      case @message_position # rubocop:disable Style/HashLikeCase
       when :bottom
         'flex-column'
       when :right

--- a/app/components/works/show/depositing_component.html.erb
+++ b/app/components/works/show/depositing_component.html.erb
@@ -1,6 +1,6 @@
 <% if alert? %>
   <%= render Elements::AlertComponent.new(variant: :success, dismissible: true,
-                                          title: 'You have successfully submitted your work for deposit',
+                                          title: 'Work successfully deposited',
                                           data: { turbo_permanent: true }, id: 'depositing-alert') do %>
     <p class="mt-2 mb-1">Here's what to expect next:</p>
     <ul>

--- a/app/components/works/show/pending_review_component.html.erb
+++ b/app/components/works/show/pending_review_component.html.erb
@@ -1,0 +1,12 @@
+<%= render Elements::AlertComponent.new(variant: :success, dismissible: true,
+                                        title: 'Work successfully submitted for review',
+                                        data: { turbo_permanent: true }, id: 'pending-review-alert') do %>
+  <p class="mt-2 mb-1">Here's what to expect next:</p>
+  <ul>
+    <li>The managers and reviewers on this collection have received a notice that your deposit was submitted.</li>
+    <li>They will be prompted to review your deposit and either approve it or return it to you for changes.</li>
+    <li>You will receive an email notification when your deposit is either approved or returned to you for changes.</li>
+    <li>If you have questions about the review process for your deposit, please contact the managers or reviewers for this collection,
+      which can be found on the Collection information page.</li>
+  </ul>
+<% end %>

--- a/app/components/works/show/pending_review_component.rb
+++ b/app/components/works/show/pending_review_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Works
+  module Show
+    # Component for rendering an alert for a work pending review.
+    class PendingReviewComponent < ApplicationComponent
+      attr_reader :work_presenter
+
+      def initialize(work_presenter:)
+        @work_presenter = work_presenter
+        super()
+      end
+
+      def render?
+        work_presenter.pending_review?
+      end
+    end
+  end
+end

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -10,6 +10,7 @@
 
 <%= render Works::Show::ReviewComponent.new(work: @work, review_form: @review_form) %>
 <%= render Works::Show::ReviewRejectedComponent.new(work: @work) %>
+<%= render Works::Show::PendingReviewComponent.new(work_presenter: @work_presenter) %>
 <%= render Works::Show::DepositingComponent.new(work_presenter: @work_presenter) %>
 <%= render Works::Show::HeaderComponent.new(presenter: @work_presenter) %>
 

--- a/spec/components/works/show/depositing_component_spec.rb
+++ b/spec/components/works/show/depositing_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Works::Show::DepositingComponent, type: :component do
     it 'renders the alert' do
       render_inline(described_class.new(work_presenter:))
 
-      expect(page).to have_css('.alert', text: 'You have successfully submitted your work for deposit')
+      expect(page).to have_css('.alert', text: 'Work successfully deposited')
       expect(page).to have_css('#depositing-alert[data-turbo-permanent]')
     end
   end

--- a/spec/components/works/show/pending_review_component_spec.rb
+++ b/spec/components/works/show/pending_review_component_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Works::Show::PendingReviewComponent, type: :component do
+  let(:work) { instance_double(Work, pending_review?: pending_review) }
+  let(:work_presenter) do
+    WorkPresenter.new(work_form: WorkForm.new, work:, version_status: VersionStatus::NilStatus)
+  end
+
+  context 'with work pending review' do
+    let(:pending_review) { true }
+
+    it 'does not render the alert' do
+      render_inline(described_class.new(work_presenter:))
+
+      expect(page).to have_css('.alert', text: 'Work successfully submitted for review')
+    end
+  end
+
+  context 'with work not pending review' do
+    let(:pending_review) { false }
+
+    it 'does not render the alert' do
+      render_inline(described_class.new(work_presenter:))
+
+      expect(page).to have_no_css('.alert')
+    end
+  end
+end

--- a/spec/system/create_work_deposit_spec.rb
+++ b/spec/system/create_work_deposit_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe 'Create a work deposit' do
       # On show page
       expect(page).to have_css('h1', text: title_fixture)
       expect(page).to have_css('.status', text: 'Depositing')
-      expect(page).to have_css('.alert-success', text: 'You have successfully submitted your work')
+      expect(page).to have_css('.alert-success', text: 'Work successfully deposited')
       expect(page).to have_no_link('Edit or deposit')
 
       # Contributors

--- a/spec/system/create_work_draft_spec.rb
+++ b/spec/system/create_work_draft_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'Create a work draft' do
     # On show page
     expect(page).to have_css('h1', text: title_fixture)
     expect(page).to have_css('.status', text: 'Draft - Not deposited')
-    expect(page).to have_no_css('.alert-success', text: 'You have successfully submitted your work')
+    expect(page).to have_no_css('.alert-success', text: 'Work successfully deposited')
     expect(page).to have_link('Edit or deposit', href: edit_work_path(druid))
     expect(page).to have_no_css('#contributors-table td')
   end

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Show a work' do
       expect(page).to have_css('h1', text: work.title)
       expect(page).to have_css('.status', text: 'Deposited')
       expect(page).to have_link('Edit or deposit', href: edit_work_path(druid))
-      expect(page).to have_no_css('.alert-success', text: 'You have successfully submitted your work')
+      expect(page).to have_no_css('.alert-success', text: 'Work successfully deposited')
       expect(page).to have_no_content('Admin functions')
 
       # Files table


### PR DESCRIPTION
Fixes #1322

**NOTE**: After making the following screenshot, I changed the color & icon of the alert to match what's already displayed when depositing. I.e., the "green" success color and the check-mark icon instead of the info icon. This brings consistency with the depositing alert and parity with H2.

![Screenshot from 2025-06-10 10-46-57](https://github.com/user-attachments/assets/f99136cf-13b5-4927-a9bb-7810785e57dc)
