### PR TITLE
rename purl to public webpage

### DIFF
--- a/app/components/collections/edit/access_settings_component.html.erb
+++ b/app/components/collections/edit/access_settings_component.html.erb
@@ -27,7 +27,7 @@
 
   <p>
     Files that have been explicitly "hidden" in the file upload section
-    will not be listed on the public page for the item and will not be
+    will not be listed on the public webpage for the item and will not be
     downloadable by anyone, regardless of which option below is selected
     for the deposit. See "Can I restrict access to content deposited in
     the SDR?" near the bottom of our

--- a/app/components/emails/works/purl_component.rb
+++ b/app/components/emails/works/purl_component.rb
@@ -11,7 +11,7 @@ module Emails
 
       def call
         tag.p do
-          "The persistent URL (PURL) for this deposit is #{purl_link}. Please use this when citing your work.".html_safe # rubocop:disable Rails/OutputSafety
+          "The public webpage for this deposit is #{purl_link}. Please use this when citing your work.".html_safe # rubocop:disable Rails/OutputSafety
         end
       end
 

--- a/app/components/works/edit/access_settings_component.html.erb
+++ b/app/components/works/edit/access_settings_component.html.erb
@@ -6,7 +6,7 @@
   <% else %>
     <%= form.hidden_field :max_release_date %>
     <p>
-      Select when the files in your deposit will be downloadable from the PURL page.
+      Select when the files in your deposit will be downloadable from the public webpage.
       If you select "Immediately", your files will be available shortly after you
       deposit this item. Or you may specify a specific date in the future.
     </p>
@@ -37,7 +37,7 @@
 <div class="pane-section">
   <%= render Edit::LabelComponent.new(label_text: 'Individual file visibility') %>
   <p>
-    You can prevent individual files from being displayed on the PURL page,
+    You can prevent individual files from being displayed on the public webpage,
     meaning viewers of the page can neither see or download the files. All files
     are still preserved in the SDR, whether they are visible or not. If a file was
     available to viewers on a previous version of this work, it will continue to

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -23,7 +23,7 @@
   <%= component.with_pane(id: 'details-pane', tab_id: 'details-tab', active: !deposits_active) do %>
     <%= render Elements::Tables::TableComponent.new(id: 'info-table', classes: 'mb-5') do |component| %>
       <% component.with_caption do %><%= render Show::TableHeadingComponent.new(text: 'Collection information') %><% end %>
-      <% component.with_row(label: 'PURL', values: [@collection_presenter.purl_link]) %>
+      <% component.with_row(label: 'Public webpage', values: [@collection_presenter.purl_link]) %>
       <% component.with_row(label: 'Created by', values: [@collection_presenter.created_by]) %>
       <% component.with_row(label: 'Collection created', values: [@collection_presenter.created_datetime]) %>
     <% end %>

--- a/app/views/collections_mailer/invitation_to_deposit_email.html.erb
+++ b/app/views/collections_mailer/invitation_to_deposit_email.html.erb
@@ -3,9 +3,9 @@
 <p>You have been invited to deposit to the <%= @collection.title %> collection in the Stanford Digital Repository.
   Start your deposit at <%= link_to collection_url(@collection.druid), collection_url(@collection.druid, anchor: 'deposits') %>.</p>
 
-<p>SDR deposits can be discovered in the Stanford library catalog and can be accessed by others at a persistent link (PURL). <a href="https://purl.stanford.edu/wd068fv8349">Example of a PURL.</a>
+<p>SDR deposits can be discovered in the Stanford library catalog and can be accessed by others at a public webpage. <a href="https://purl.stanford.edu/wd068fv8349">Example of a public webpage.</a>
 
-<p>In some cases a deposit requires review and approval before the PURL is available. <a href="https://sdr.library.stanford.edu/documentation/sdr-submission-workflows">Read about the approval process.</a>
+<p>In some cases a deposit requires review and approval before the public webpage is available. <a href="https://sdr.library.stanford.edu/documentation/sdr-submission-workflows">Read about the approval process.</a>
 
 <p>Before you complete your deposit, you will need to accept the <%= link_to 'Terms of Deposit', Settings.terms_url %>.
 

--- a/app/views/reviews_mailer/approved_email.html.erb
+++ b/app/views/reviews_mailer/approved_email.html.erb
@@ -8,7 +8,7 @@
 <%= render Emails::Works::SubmitClarificationComponent.new %>
 
 <p>
-  The persistent URL (PURL) for this deposit, <%= link_to nil, Sdr::Purl.from_druid(druid: @work.druid) %>,
+  The public webpage for this deposit, <%= link_to nil, Sdr::Purl.from_druid(druid: @work.druid) %>,
   is now active and available for sharing.
 </p>
 

--- a/app/views/reviews_mailer/submitted_email.html.erb
+++ b/app/views/reviews_mailer/submitted_email.html.erb
@@ -11,7 +11,7 @@
   Upon review, you will receive another notification indicating if the deposit has been
   returned to you for changes or if it has been approved and published.
   <% if @work.druid %>
-    Once published, your deposit will be available at this persistent URL (PURL): <%= link_to nil, Sdr::Purl.from_druid(druid: @work.druid) %>
+    Once published, your deposit will be available at this public webpage: <%= link_to nil, Sdr::Purl.from_druid(druid: @work.druid) %>
   <% end %>
 </p>
 

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -15,7 +15,7 @@
 
 <%= render Elements::Tables::TableComponent.new(id: 'details-table', classes: 'mb-5') do |component| %>
   <% component.with_caption do %><%= render Show::TableHeadingComponent.new(text: 'Details') %><% end %>
-  <% component.with_row(label: 'Persistent Link', tooltip: t('sharing_link.tooltip_html'), values: [@work_presenter.purl_link]) %>
+  <% component.with_row(label: 'Public webpage', tooltip: t('sharing_link.tooltip_html'), values: [@work_presenter.purl_link]) %>
   <% component.with_row(label: 'DOI', values: [@work_presenter.doi_value]) %>
   <% component.with_row(label: 'Collection', values: [@work_presenter.collection_link]) %>
   <% component.with_row(label: 'Depositor', values: [@work_presenter.depositor]) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,10 +72,10 @@ en:
       fields:
         description:
           tooltip_html: >-
-            Enter a brief description (100 characters max) to help others understand what this file contains. This description will appear on the public page for your work next to the name of the file. This description is not required.
+            Enter a brief description (100 characters max) to help others understand what this file contains. This description will appear on the public webpage for your work next to the name of the file. This description is not required.
         hide:
           tooltip_html: >-
-            Check this box to prevent this file from being displayed on or downloaded from the public page for your work. The file will still be preserved in the SDR as part of your deposit. Hidden files should NOT contain any content the University classifies as <a href="https://uit.stanford.edu/guide/riskclassifications" target="_blank">High Risk</a>.
+            Check this box to prevent this file from being displayed on or downloaded from the public webpage for your work. The file will still be preserved in the SDR as part of your deposit. Hidden files should NOT contain any content the University classifies as <a href="https://uit.stanford.edu/guide/riskclassifications" target="_blank">High Risk</a>.
   contributors:
     edit:
       legend: 'Contributor'
@@ -148,7 +148,7 @@ en:
           label: 'Contact email (one per box)'
           collections:
             tooltip_html: >-
-              Enter one or more valid email addresses (one per box) where people can write to ask questions about this collection. Consider using a group address that will be active and monitored for a long time to ensure that questions are received. Email addresses will appear on the public page for the collection.
+              Enter one or more valid email addresses (one per box) where people can write to ask questions about this collection. Consider using a group address that will be active and monitored for a long time to ensure that questions are received. Email addresses will appear on the public webpage for the collection.
           works:
             tooltip_html: >-
               Enter one or more valid email addresses (one per box) where people can write to ask questions about this deposit. Email addresses will be publicly visible. Use an email address that you expect to be functional for many years, if possible.
@@ -173,7 +173,7 @@ en:
     edit:
       fields:
         label: 'License'
-      license_terms_of_use: In addition to the license, the following Terms of Use will also be displayed on the public page for your work.
+      license_terms_of_use: In addition to the license, the following Terms of Use will also be displayed on the public webpage for your work.
   managers:
     edit:
       legend: 'Managers'
@@ -182,7 +182,7 @@ en:
   sharing_link:
     label: 'Link for sharing'
     tooltip_html: >-
-      Use this link for sharing the public page for your deposit. Links become active when the deposit is completed.
+      Use this link for sharing the public webpage for your deposit. Links become active when the deposit is completed.
   publication_date:
     edit:
       legend: 'Publication date (optional)'
@@ -237,7 +237,7 @@ en:
   terms_of_deposit:
     faq: 'FAQs and download Terms of Deposit'
   terms_of_use:
-    default_use_statement_instructions: 'Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on the PURL page.'
+    default_use_statement_instructions: 'Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on the public webpage.'
   works:
     edit:
       breadcrumb: 'Edit'
@@ -278,7 +278,7 @@ en:
           help_text: >-
             A unique, descriptive title may improve discovery of your work in web searches.
           tooltip_html: >-
-            Serves as the title of the public page for your work and the title of web search results. Detailed titles similar to those used for scholarly publications will make it easier for users to find your work online. Avoid generic titles such as "Dataset for publication" or "My honors thesis."
+            Serves as the title of the public webpage for your work and the title of web search results. Detailed titles similar to those used for scholarly publications will make it easier for users to find your work online. Avoid generic titles such as "Dataset for publication" or "My honors thesis."
         license:
           help_text: 'Assigning a license may improve discovery of your work in web searches.'
           tooltip_html: >-
@@ -290,7 +290,7 @@ en:
         whats_changing:
           label: "What's changing?"
           tooltip_html: >-
-            Enter a brief description (200 characters max) indicating which fields were changed or what type of correction was made. This information is not displayed on the public page.
+            Enter a brief description (200 characters max) indicating which fields were changed or what type of correction was made. This information is not displayed on the public webpage.
         work_type:
           label: 'What type of content are you depositing?'
           tooltip_html: >-
@@ -323,9 +323,9 @@ en:
           label: 'Citation for this deposit (optional)'
           help_text: >-
             You may explicitly state how you would like your work to be cited.
-            Be sure to include the DOI if you're getting one or the link to the public page for your work that begins "https://purl.stanford.edu/..."
+            Be sure to include the DOI if you're getting one or the link to the public webpage for your work that begins "https://purl.stanford.edu/..."
           tooltip_html: >-
-            To find your PURL link and DOI (if you've elected to get one), click "Save as draft" at the bottom of this screen. The PURL and DOI are listed on the display page for this item. Copy these links, then re-edit this work to add them to the citation below.
+            To find your public webpage link and DOI (if you've elected to get one), click "Save as draft" at the bottom of this screen. The public webpage and DOI are listed on the display page for this item. Copy these links, then re-edit this work to add them to the citation below.
         contributors:
           tab_label: 'Authors / Contributors'
           label: 'Authors / Contributors'
@@ -338,7 +338,7 @@ en:
           tab_label: 'Dates (optional)'
           label: 'Enter dates related to your deposit (optional)'
           tooltip_html: >-
-            This application will automatically record the date that your content is made available on the public page for your work. The date fields below are optional.
+            This application will automatically record the date that your content is made available on the public webpage for your work. The date fields below are optional.
         doi:
           tab_label: 'DOI'
           label: 'DOI assignment'
@@ -386,11 +386,11 @@ en:
           help_text: >-
             A unique, descriptive name may improve discovery of your collection in web searches.
           tooltip_html: >-
-            Enter a name for your collection. This name will serve as the title on the public page for the collection and the title of web search results, as well as in the Stanford University Libraries' catalog. Please do not use the word "Collection" at the end of the title.
+            Enter a name for your collection. This name will serve as the title on the public webpage for the collection and the title of web search results, as well as in the Stanford University Libraries' catalog. Please do not use the word "Collection" at the end of the title.
         release_option:
           label: 'When will files on deposits to this collection be downloadable?'
           tooltip_html: >-
-            As the collection manager, you can decide whether 1) Depositors to this collection are required to make the files on their deposits downloadable as soon as the deposit is completed ("Immediately"), or 2) if Depositors can decide for themselves when downloading of their content will be available ("Depositor selects…"). Note that for both options the public page is always visible as soon as the deposit is complete and all descriptive information on the page is visible to anyone at any time.
+            As the collection manager, you can decide whether 1) Depositors to this collection are required to make the files on their deposits downloadable as soon as the deposit is completed ("Immediately"), or 2) if Depositors can decide for themselves when downloading of their content will be available ("Depositor selects…"). Note that for both options the public webpage is always visible as soon as the deposit is complete and all descriptive information on the page is visible to anyone at any time.
           options:
             immediate: 'Immediately'
             depositor_selects: 'Depositor selects a date up to'
@@ -455,7 +455,7 @@ en:
           tab_label: 'Terms of use'
           label: 'Terms of use'
           tooltip_html: >-
-            As the collection manager, you can decide whether additional terms of use can be added to a deposit and displayed on the public page along with the Standard Terms of Use shown below. You have three options: 1) Leave the custom terms off. No additional terms will be added. 2) Provide custom terms that will appear on every deposit. The depositor will not be able to modify this text. 3) Allow the depositor to type in their own custom terms. With this option, you can choose to display to the depositor the default instructions we have written, or write your own instructions.
+            As the collection manager, you can decide whether additional terms of use can be added to a deposit and displayed on the public webpage along with the Standard Terms of Use shown below. You have three options: 1) Leave the custom terms off. No additional terms will be added. 2) Provide custom terms that will appear on every deposit. The depositor will not be able to modify this text. 3) Allow the depositor to type in their own custom terms. With this option, you can choose to display to the depositor the default instructions we have written, or write your own instructions.
           use_statement_label: 'Include a custom use statement?'
           use_statement_options:
             nope: 'No, do not include a custom use statement.'

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -140,7 +140,7 @@ namespace :import do
   end
 
   desc 'Test import works from json'
-  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Layout/LineLength
   # IMPORTANT: Enable merge_stanford_and_organization and document_type feature flags in H2.
   # For example: SETTINGS__MERGE_STANFORD_AND_ORGANIZATION=true SETTINGS__DOCUMENT_TYPE=true SETTINGS__NO_CITATION_STATUS_NOTE=true bin/rails c -e p
   # works_cocina.jsonl can be generated in H2 for some set of works with:
@@ -152,7 +152,7 @@ namespace :import do
   #     end
   #   end
   # It will raise an error if the work cannot be roundtripped or the collection cannot be found.
-  # rubocop:enable Metrics/LineLength
+  # rubocop:enable Layout/LineLength
   task :test_works, %i[cocina_filename] => :environment do |_t, args|
     Parallel.each_with_index(File.open(args[:cocina_filename] || 'works_cocina.jsonl'),
                              in_processes: 6) do |line, index|

--- a/spec/components/emails/works/purl_component_spec.rb
+++ b/spec/components/emails/works/purl_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Emails::Works::PurlComponent, type: :component do
   it 'renders the PURL text' do
     render_inline(described_class.new(work:))
 
-    expect(page).to have_css('p', text: 'The persistent URL (PURL) for this deposit is https://sul-purl-stage.stanford.edu/bc123df4567')
+    expect(page).to have_css('p', text: 'The public webpage for this deposit is https://sul-purl-stage.stanford.edu/bc123df4567')
     expect(page).to have_link('https://sul-purl-stage.stanford.edu/bc123df4567', href: 'https://sul-purl-stage.stanford.edu/bc123df4567')
   end
 end

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Show a collection' do
       # Collection information
       within('table#info-table') do
         expect(page).to have_css('caption', text: 'Collection information')
-        expect(page).to have_css('th', text: 'PURL')
+        expect(page).to have_css('th', text: 'Public webpage')
         expect(page).to have_link("https://sul-purl-stage.stanford.edu/#{bare_druid}", href: "https://sul-purl-stage.stanford.edu/#{bare_druid}")
         expect(page).to have_css('th', text: 'Created by')
         expect(page).to have_css('td', text: collection.user.name)

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe 'Show a work' do
         expect(page).to have_css('caption', text: 'Details')
         expect(page).to have_css('tr', text: 'DOI')
         expect(page).to have_css('td', text: Doi.url(druid:))
-        expect(page).to have_css('tr', text: 'Persistent Link')
+        expect(page).to have_css('tr', text: 'Public webpage')
         expect(page).to have_css('td', text: Sdr::Purl.from_druid(druid:))
         expect(page).to have_css('tr', text: 'Collection')
         expect(page).to have_css('td', text: collection.title)


### PR DESCRIPTION
Fixes #1394 - rename `PURL` and `public page` to `public webpage` (except in https://github.com/sul-dlss/hungry-hungry-hippo/blob/main/config/locales/en.yml#L213 as requested in the ticket)