### PR TITLE
do not allow home page message alert to be dismissed

### DIFF
--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -10,7 +10,7 @@
     <%= render Elements::ButtonLinkComponent.new(link: admin_dashboard_path, label: 'Admin') if allowed_to?(:show?, with: AdminPolicy) %>
   </div>
 </div>
-<%= render Elements::AlertComponent.new(value: t('banner.dashboard_html'), dismissible: true) %>
+<%= render Elements::AlertComponent.new(value: t('banner.dashboard_html'), dismissible: false) %>
 
 <% if @draft_works.present? %>
   <div class="mb-5">


### PR DESCRIPTION
Fixes #777 - do not allow home page message to be dismissed

![Screenshot 2025-06-10 at 2 53 00 PM](https://github.com/user-attachments/assets/3b65b45d-11e6-48c7-aca2-8aafa8cd4b9b)
