### PR TITLE
Allow skipping of roundtripping when importing some collections.

### DIFF
--- a/app/importers/collection_importer.rb
+++ b/app/importers/collection_importer.rb
@@ -6,14 +6,15 @@ class CollectionImporter
     new(...).call
   end
 
-  def initialize(collection_hash:, cocina_object:)
+  def initialize(collection_hash:, cocina_object:, skip_roundtrip: false)
     @collection_hash = collection_hash
     @cocina_object = cocina_object
+    @skip_roundtrip = skip_roundtrip
   end
 
   def call
     ::Collection.transaction do
-      unless CollectionRoundtripper.call(collection_form:, cocina_object:)
+      if !skip_roundtrip && !CollectionRoundtripper.call(collection_form:, cocina_object:)
         raise ImportError, "Collection #{druid} cannot be roundtripped"
       end
 
@@ -24,7 +25,7 @@ class CollectionImporter
 
   private
 
-  attr_reader :collection_hash, :cocina_object
+  attr_reader :collection_hash, :cocina_object, :skip_roundtrip
 
   def collection # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     @collection ||= ::Collection.find_or_create_by!(druid:) do |collection|

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -48,6 +48,13 @@ NO_MIGRATE_COLLECTIONS = [
   'druid:db160pg5444'
 ].freeze
 
+# These collections will be imported, but will not be editable.
+SKIP_ROUNDTRIP_COLLECTIONS = [
+  'druid:md001qd8892',
+  'druid:xf974wp1364',
+  'druid:db700wz4340'
+].freeze
+
 namespace :import do
   desc 'Import collections from json'
   # collections.json can be generated in H2 for some set of collections with:
@@ -83,7 +90,8 @@ namespace :import do
                       else
                         Sdr::Repository.find(druid:)
                       end
-      CollectionImporter.call(collection_hash:, cocina_object:)
+      CollectionImporter.call(collection_hash:, cocina_object:,
+                              skip_roundtrip: SKIP_ROUNDTRIP_COLLECTIONS.include?(druid))
     end
   end
 

--- a/spec/importers/collection_importer_spec.rb
+++ b/spec/importers/collection_importer_spec.rb
@@ -134,6 +134,17 @@ RSpec.describe CollectionImporter do
     end
   end
 
+  context 'when roundtrip is skipped' do
+    let(:cocina_object) { collection_with_metadata_fixture.new(type: Cocina::Models::ObjectType.curated_collection) }
+
+    it 'raises an error and does not create a new collection' do
+      expect { described_class.call(collection_hash:, cocina_object:, skip_roundtrip: true) }
+        .to change(Collection, :count).by(1)
+
+      expect(tags_client).to have_received(:create).with(tags: ['Project : H3'])
+    end
+  end
+
   context 'when license is not required' do
     it 'sets the license to the default license' do
       collection_hash['license_option'] = 'depositor_selects'


### PR DESCRIPTION
This is to support collections which have been updated outside H2, but still need to be imported into H3. These collections will be in H3, but not editable.