### PR TITLE
Show user version in show page instead of system version

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -39,7 +39,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
 
     unless editable?
       flash[:warning] = helpers.t('works.edit.messages.cannot_be_edited_html', support_email: Settings.support_email)
-      return redirect_to work_path(params[:druid]), status: :see_other
+      return redirect_to work_path(druid), status: :see_other
     end
 
     # This updates the Work with the latest metadata from the Cocina object.
@@ -142,6 +142,10 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
 
   private
 
+  def druid
+    params[:druid]
+  end
+
   def work_params
     params.expect(work: WorkForm.user_editable_attributes + [WorkForm.nested_attributes])
   end
@@ -151,11 +155,11 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def update_work_params
-    work_params.merge(druid: params[:druid])
+    work_params.merge(druid:)
   end
 
   def set_work_and_collection
-    @work = Work.find_by!(druid: params[:druid])
+    @work = Work.find_by!(druid:)
     @collection = @work.collection
   end
 
@@ -164,7 +168,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def set_work_form_from_cocina
-    @cocina_object = Sdr::Repository.find(druid: params[:druid])
+    @cocina_object = Sdr::Repository.find(druid:)
     version_description = @version_status.open? ? @version_status.version_description : nil
     @work_form = Form::WorkMapper.call(cocina_object: @cocina_object, doi_assigned: doi_assigned?,
                                        agree_to_terms: current_user.agree_to_terms?,
@@ -176,7 +180,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def set_status
-    @version_status = Sdr::Repository.status(druid: params[:druid])
+    @version_status = Sdr::Repository.status(druid:)
   end
 
   def set_content
@@ -196,7 +200,8 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def set_presenter
-    @work_presenter = WorkPresenter.new(work: @work, work_form: @work_form, version_status: @version_status)
+    @work_presenter = WorkPresenter.new(work: @work, work_form: @work_form, version_status: @version_status,
+                                        user_version: Sdr::Repository.latest_user_version(druid:))
   end
 
   def set_license_presenter

--- a/app/presenters/work_presenter.rb
+++ b/app/presenters/work_presenter.rb
@@ -4,12 +4,13 @@
 class WorkPresenter < FormPresenter
   include ActionPolicy::Behaviour
 
-  def initialize(work:, work_form:, version_status:)
+  def initialize(work:, work_form:, version_status:, user_version: 1)
     @work = work
+    @user_version = user_version
     super(form: work_form, version_status:)
   end
 
-  attr_reader :work, :version_status
+  attr_reader :work, :version_status, :user_version
 
   def purl_link
     # No druid yet, so there's no PURL link yet either. Work is likely still depositing.

--- a/app/services/sdr/repository.rb
+++ b/app/services/sdr/repository.rb
@@ -24,6 +24,14 @@ module Sdr
       raise NotFoundResponse, "Object not found: #{druid}"
     end
 
+    # @param [String] druid the druid of the object
+    # @return [Integer] the head user version or 1 as default
+    def self.latest_user_version(druid:)
+      Dor::Services::Client.object(druid).user_version.inventory.find(&:head)&.userVersion || 1
+    rescue Dor::Services::Client::NotFoundResponse
+      raise NotFoundResponse, "Object not found: #{druid}"
+    end
+
     # @param [Array<String>] druids the druids of the objects
     # @return [Hash<String,VersionStatus>] map of druid to status
     def self.statuses(druids:)

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -20,7 +20,7 @@
   <% component.with_row(label: 'DOI', values: [@work_presenter.doi_value]) %>
   <% component.with_row(label: 'Collection', values: [@work_presenter.collection_link]) %>
   <% component.with_row(label: 'Depositor', values: [@work_presenter.depositor]) %>
-  <% component.with_row(label: 'Version details', values: [@work_presenter.version]) %>
+  <% component.with_row(label: 'Version', values: [@work_presenter.user_version]) %>
   <% component.with_row(label: 'Total number of files', values: [@work_presenter.number_of_files_in_deposit]) %>
   <% component.with_row(label: 'Size', values: [number_to_human_size(@work_presenter.size_of_deposit)]) %>
   <% component.with_row(label: 'Deposit created', values: [@work_presenter.deposited_at]) %>

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Edit work' do
       allow(Sdr::Repository).to receive(:find).with(druid:).and_return(dro_with_metadata_fixture)
       allow(Sdr::Repository).to receive(:status)
         .with(druid:).and_return(build(:version_status))
-
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
       create(:work, druid:, collection: create(:collection, druid: collection_druid_fixture))
       sign_in(create(:user))
     end
@@ -36,6 +36,7 @@ RSpec.describe 'Edit work' do
     before do
       allow(Sdr::Repository).to receive(:find).with(druid:).and_return(dro_with_metadata_fixture)
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
       create(:work, druid:, collection: create(:collection, druid: collection_druid_fixture))
       sign_in(admin_user, groups:)
     end
@@ -72,6 +73,7 @@ RSpec.describe 'Edit work' do
     before do
       allow(Sdr::Repository).to receive(:find).with(druid: work.druid).and_return(cocina_object)
       allow(Sdr::Repository).to receive(:status).with(druid: work.druid).and_return(version_status)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
       allow(WorkRoundtripper).to receive(:call)
     end
 
@@ -102,6 +104,7 @@ RSpec.describe 'Edit work' do
     before do
       allow(Sdr::Repository).to receive(:find).with(druid: work.druid).and_return(cocina_object)
       allow(Sdr::Repository).to receive(:status).with(druid: work.druid).and_return(version_status)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
       allow(WorkRoundtripper).to receive(:call).and_call_original
 
       sign_in(user)
@@ -129,6 +132,7 @@ RSpec.describe 'Edit work' do
     before do
       allow(Sdr::Repository).to receive(:find).with(druid: work.druid).and_return(cocina_object)
       allow(Sdr::Repository).to receive(:status).with(druid: work.druid).and_return(version_status)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
       allow(WorkRoundtripper).to receive(:call)
 
       sign_in(user)
@@ -156,6 +160,7 @@ RSpec.describe 'Edit work' do
     before do
       allow(Sdr::Repository).to receive(:find).with(druid: work.druid).and_return(cocina_object)
       allow(Sdr::Repository).to receive(:status).with(druid: work.druid).and_return(version_status)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
       allow(WorkRoundtripper).to receive(:call)
 
       sign_in(user)

--- a/spec/requests/review_work_spec.rb
+++ b/spec/requests/review_work_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Review work' do
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(dro_with_metadata_fixture)
     allow(Sdr::Repository).to receive(:status)
       .with(druid:).and_return(build(:version_status))
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
 
     collection = create(:collection, druid: collection_druid_fixture, managers: [manager], reviewers: [reviewer])
     create(:work, druid:, collection:)

--- a/spec/requests/show_work_spec.rb
+++ b/spec/requests/show_work_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Show work' do
     before do
       allow(Sdr::Repository).to receive(:find).with(druid:).and_return(dro_with_metadata_fixture)
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(build(:version_status))
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     end
 
     context 'when just some user' do
@@ -51,6 +52,7 @@ RSpec.describe 'Show work' do
       create(:work, druid:)
       allow(Sdr::Repository).to receive(:find).with(druid:).and_return(dro_with_metadata_fixture)
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(build(:openable_version_status))
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
 
       sign_in(admin_user, groups:)
     end
@@ -87,6 +89,7 @@ RSpec.describe 'Show work' do
     before do
       allow(Sdr::Repository).to receive(:find).with(druid:).and_return(dro_with_metadata_fixture)
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(build(:version_status))
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
 
       sign_in(user)
     end
@@ -112,6 +115,7 @@ RSpec.describe 'Show work' do
     before do
       allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(build(:version_status))
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
 
       sign_in(user)
     end
@@ -133,6 +137,8 @@ RSpec.describe 'Show work' do
     before do
       allow(Sdr::Repository).to receive(:find).with(druid:).and_return(dro_with_metadata_fixture)
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(build(:first_draft_version_status))
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
+
       allow(Doi).to receive(:assigned?).and_return(false)
 
       sign_in(user)

--- a/spec/system/admin/delete_work_spec.rb
+++ b/spec/system/admin/delete_work_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Delete a work' do
   before do
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     allow(Sdr::Repository).to receive(:open_if_needed) { |args| args[:cocina_object] }
     allow(Sdr::Event).to receive(:list).and_return([])
 

--- a/spec/system/admin/druid_search_spec.rb
+++ b/spec/system/admin/druid_search_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Search for a collection or work by druid' do
   before do
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     allow(Sdr::Event).to receive(:list).and_return([])
 
     sign_in(create(:user), groups: ['dlss:hydrus-app-administrators'])

--- a/spec/system/admin/move_spec.rb
+++ b/spec/system/admin/move_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'Move a work' do
   before do
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     allow(Sdr::Repository).to receive(:open_if_needed) { |args| args[:cocina_object] }
     allow(Sdr::Repository).to receive(:update) do |args|
       @updated_cocina_object = args[:cocina_object]

--- a/spec/system/admin/show_user_spec.rb
+++ b/spec/system/admin/show_user_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Search for and show a user' do
   before do
     allow(Sdr::Repository).to receive(:statuses).with(druids: [owned_work.druid])
                                                 .and_return({ owned_work.druid => build(:version_status) })
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid: owned_work.druid).and_return(1)
     sign_in(create(:user), groups: ['dlss:hydrus-app-administrators'])
   end
 

--- a/spec/system/create_work_deposit_spec.rb
+++ b/spec/system/create_work_deposit_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Create a work deposit' do
       # Stubbing out for show page
       allow(Sdr::Repository).to receive(:find).with(druid:).and_invoke(->(_arg) { @registered_cocina_object })
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
       allow(Sdr::Event).to receive(:list).and_return([])
     end
 
@@ -289,6 +290,7 @@ RSpec.describe 'Create a work deposit' do
                                               )
       allow(Sdr::Repository).to receive(:status).with(druid:)
                                                 .and_return(draft_version_status)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
       allow(Sdr::Event).to receive(:list).and_return([])
     end
 

--- a/spec/system/create_work_draft_spec.rb
+++ b/spec/system/create_work_draft_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Create a work draft' do
     # Stubbing out for show page
     allow(Sdr::Repository).to receive(:find).with(druid:).and_invoke(->(_arg) { @registered_cocina_object })
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     allow(Sdr::Event).to receive(:list).and_return([])
 
     create(:collection, user:, title: collection_title_fixture, druid: collection_druid_fixture, managers: [user])

--- a/spec/system/create_work_review_spec.rb
+++ b/spec/system/create_work_review_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Create a work that requires review' do
     # Stubbing out for show page
     allow(Sdr::Repository).to receive(:find).with(druid:).and_invoke(->(_arg) { @registered_cocina_object })
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
 
     allow(Settings.notifications).to receive(:enabled).and_return(true)
     allow(Sdr::Event).to receive(:create)

--- a/spec/system/edit_discard_work_spec.rb
+++ b/spec/system/edit_discard_work_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'Discard a work' do
   before do
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     allow(Sdr::Repository).to receive(:discard_draft)
     allow(Sdr::Event).to receive(:list).and_return([])
 

--- a/spec/system/edit_work_review_spec.rb
+++ b/spec/system/edit_work_review_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Submit a work for review without changes' do
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
     allow(RoundtripSupport).to receive(:changed?).and_return(false)
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     allow(Sdr::Event).to receive(:list).and_return([])
 
     sign_in(user)

--- a/spec/system/edit_work_spec.rb
+++ b/spec/system/edit_work_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe 'Edit a work' do
       ->(_arg) { @updated_cocina_object } # show after update
     )
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     # It is already open.
     allow(Sdr::Repository).to receive(:open_if_needed) { |args| args[:cocina_object] }
     allow(Sdr::Repository).to receive(:update) do |args|

--- a/spec/system/manage_contributors_spec.rb
+++ b/spec/system/manage_contributors_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Manage contributors for a work deposit' do
     # Stubbing out for show page
     allow(Sdr::Repository).to receive(:find).with(druid:).and_invoke(->(_arg) { @registered_cocina_object })
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     allow(Doi).to receive(:assigned?).with(druid:).and_return(false)
     allow(Sdr::Event).to receive(:list).and_return([])
 

--- a/spec/system/manage_dates_spec.rb
+++ b/spec/system/manage_dates_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Manage dates for a work deposit' do
     # Stubbing out for show page
     allow(Sdr::Repository).to receive(:find).with(druid:).and_invoke(->(_arg) { @registered_cocina_object })
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     allow(Doi).to receive(:assigned?).with(druid:).and_return(false)
     allow(Sdr::Event).to receive(:list).and_return([])
 

--- a/spec/system/review_accept_work_spec.rb
+++ b/spec/system/review_accept_work_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Review and accept a work' do
 
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status, deposit_version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
 
     allow(Settings.notifications).to receive(:enabled).and_return(true)
     allow(Sdr::Event).to receive(:create)

--- a/spec/system/review_reject_work_spec.rb
+++ b/spec/system/review_reject_work_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Review and reject a work' do
   before do
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
 
     allow(Settings.notifications).to receive(:enabled).and_return(true)
     allow(Sdr::Event).to receive(:create)

--- a/spec/system/show_discard_work_draft_spec.rb
+++ b/spec/system/show_discard_work_draft_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Discard a work draft' do
     before do
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status_discardable,
                                                                          version_status_openable)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(2)
     end
 
     it 'discards a draft' do
@@ -55,6 +56,7 @@ RSpec.describe 'Discard a work draft' do
     before do
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
       allow(Sdr::Repository).to receive(:status).with(druid: collection.druid).and_return(version_status)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
       allow(Sdr::Repository).to receive(:find).with(druid: collection.druid).and_return(collection_cocina_object)
     end
 

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe 'Show a work' do
   before do
     allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
     allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     # File doesn't matter; it just needs to exist.
     allow(StagingSupport).to receive(:staging_filepath).and_call_original
     allow(StagingSupport).to receive(:staging_filepath).with(druid: work.druid, filepath: 'my_file1.txt')
@@ -174,7 +175,7 @@ RSpec.describe 'Show a work' do
         expect(page).to have_css('td', text: collection.title)
         expect(page).to have_css('tr', text: 'Depositor')
         expect(page).to have_css('td', text: user.name)
-        expect(page).to have_css('tr', text: 'Version details')
+        expect(page).to have_css('tr', text: 'Version')
         expect(page).to have_css('td', text: '1')
         expect(page).to have_css('tr', text: 'Total number of files')
         expect(page).to have_css('td', text: '3')

--- a/spec/system/unsaved_work_changes_spec.rb
+++ b/spec/system/unsaved_work_changes_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe 'Notifies unsaved changes' do
       create(:work, druid:, user:, collection:)
       allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     end
 
     it 'asks user to confirm leaving page' do
@@ -90,6 +91,7 @@ RSpec.describe 'Notifies unsaved changes' do
       create(:work, druid:, user:, collection:)
       allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     end
 
     it 'asks user to confirm leaving page' do
@@ -120,6 +122,7 @@ RSpec.describe 'Notifies unsaved changes' do
       create(:work, druid:, user:, collection:)
       allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
       allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+      allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     end
 
     it 'asks user to confirm leaving page' do


### PR DESCRIPTION
Fixes #1420 - fetch the current head user version for display and change the label in the show page (used to be system version from cocina object)

tested in QA, see https://argo-qa.stanford.edu/view/druid:jx716kz1859 for an example (https://sul-h3-qa.stanford.edu/works/druid:jx716kz1859)

Note that currently any existing H3 objects do not have a default user version, and the first time a user creates one (by changing files), User Version 1 will then be created.  The result is that the display will continue to show "Version 1" (the default) until they create a *second* change to the files, at which point it will become Version 2