### PR TITLE
add link next to role label

### DIFF
--- a/app/components/edit/contributor_component.html.erb
+++ b/app/components/edit/contributor_component.html.erb
@@ -40,7 +40,8 @@
     <%# Contributor person name/orcid fields %>
     <%= render Elements::Forms::FieldsetComponent.new(label: 'Person', hidden_label: true, data: { contributors_target: 'personSection' }) do %>
       <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :person_role, label_classes: 'fw-bold', tooltip: helpers.t('works.edit.fields.contributors.role.tooltip_html'),
-                                                           options: PERSON_ROLES, label: role_label, container_classes: 'mb-4') %>
+                                                           options: PERSON_ROLES, label: role_label, container_classes: 'mb-4',
+                                                           caption: helpers.t('works.edit.fields.contributors.role.definitions_link_label_html')) %>
 
       <%= render Elements::Forms::ToggleComponent.new(form:, field_name: :with_orcid, label_classes: 'fw-bold', tooltip: helpers.t('works.edit.fields.contributors.with_orcid.tooltip_html'),
                                                       label: helpers.t('works.edit.fields.contributors.with_orcid.label'), container_classes: 'orcid-section mb-4') do |component| %>

--- a/app/components/edit/contributor_component.rb
+++ b/app/components/edit/contributor_component.rb
@@ -36,11 +36,11 @@ module Edit
     end
 
     def role_label
-      'Role'
+      t('works.edit.fields.contributors.role.label')
     end
 
     def organization_label
-      'Organization name'
+      t('works.edit.fields.contributors.organization_name.label')
     end
 
     def orcid_name_input_disabled?

--- a/app/components/elements/forms/field_component.rb
+++ b/app/components/elements/forms/field_component.rb
@@ -6,8 +6,8 @@ module Elements
     class FieldComponent < ApplicationComponent
       def initialize(form:, field_name:, required: false, hidden_label: false, label: nil, help_text: nil, # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength, Metrics/AbcSize
                      disabled: false, hidden: false, data: {}, input_data: {}, placeholder: nil, width: nil,
-                     label_classes: [], container_classes: [], input_classes: [], tooltip: nil, error_classes: [],
-                     readonly: false, mark_required: false)
+                     label_classes: [], container_classes: [], input_classes: [], tooltip: nil, caption: nil,
+                     error_classes: [], readonly: false, mark_required: false)
         @form = form
         @field_name = field_name
         @required = required
@@ -25,13 +25,14 @@ module Elements
         @container_classes = container_classes
         @input_classes = input_classes
         @tooltip = tooltip
+        @caption = caption
         @error_classes = error_classes
         @readonly = readonly
         super()
       end
 
       attr_reader :form, :field_name, :required, :help_text, :hidden_label, :label, :hidden, :disabled, :data,
-                  :placeholder, :width, :label_classes, :input_data, :tooltip, :readonly
+                  :placeholder, :width, :label_classes, :input_data, :tooltip, :caption, :readonly
 
       def help_text_id
         @help_text_id ||= form.field_id(field_name, 'help')

--- a/app/components/elements/forms/label_component.html.erb
+++ b/app/components/elements/forms/label_component.html.erb
@@ -3,3 +3,4 @@
 <% end %>
 <%# This is outside the label so that clicking on it doesn't toggle some inputs like checkboxes. %>
 <%= render Elements::TooltipComponent.new(target_label: label_text, tooltip:) %>
+<%= tag.span { caption } if caption %>

--- a/app/components/elements/forms/label_component.rb
+++ b/app/components/elements/forms/label_component.rb
@@ -5,7 +5,7 @@ module Elements
     # Component for rendering a form label.
     class LabelComponent < ApplicationComponent
       def initialize(form:, field_name:, label_text: nil, default_label_class: 'form-label', hidden_label: false, # rubocop:disable Metrics/ParameterLists
-                     classes: [], tooltip: nil)
+                     classes: [], tooltip: nil, caption: nil)
         @form = form
         @label_text = label_text
         @field_name = field_name
@@ -13,10 +13,11 @@ module Elements
         @default_label_class = default_label_class
         @classes = classes
         @tooltip = tooltip
+        @caption = caption
         super()
       end
 
-      attr_reader :field_name, :form, :tooltip
+      attr_reader :field_name, :form, :tooltip, :caption
 
       def label_text
         return field_name if @label_text.blank?

--- a/app/components/elements/forms/select_field_component.html.erb
+++ b/app/components/elements/forms/select_field_component.html.erb
@@ -1,5 +1,5 @@
 <%= tag.div class: container_classes, data: do %>
-  <%= render Elements::Forms::LabelComponent.new(form:, field_name:, label_text: label, hidden_label:, classes: label_classes, tooltip:) %>
+  <%= render Elements::Forms::LabelComponent.new(form:, field_name:, label_text: label, hidden_label:, classes: label_classes, tooltip:, caption:) %>
   <%= render Elements::Forms::HelpTextComponent.new(id: help_text_id, help_text:) %>
   <%= form.select field_name, options, { prompt: }, { class: 'form-select', aria: field_aria, style: styles, data: input_data, required: } %>
   <%= render Elements::Forms::InvalidFeedbackComponent.new(form:, field_name:) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,12 +251,15 @@ en:
           label: 'Enter preferred citation'
         contributors:
           role:
+            label: Role
+            definitions_link_label_html: <a href="https://sdr.library.stanford.edu/documentation/author-contributor-role-term-definitions" target="_blank">See role definitions</a>
             tooltip_html: >-
               Choose one role for each individual or organization that best describes their contribution to the work you are depositing.
           first_name:
             tooltip_html: >-
               For individuals, use whatever capitalization the individual would normally use for their name. Middle names or initials may be included after the first name in the same box. Both first and last name fields are required.
           organization_name:
+            label: Organization name
             tooltip_html: >-
               Enter the full name of the organization.
           with_orcid:


### PR DESCRIPTION
Fixes #1249 - add a link next to role label

This makes it generic enough to easily extend adding these sorts of captions for any other label as needed.

![Screenshot 2025-06-11 at 1 43 14 PM](https://github.com/user-attachments/assets/b25077f4-7528-4a93-9497-9714d4569c51)
