### PR TITLE
Sanitize requests to replace bogus characters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'kaminari' # For pagination
 gem 'kicks' # Background processing of rabbitMQ messages. (Formerly sneakers.)
 gem 'marcel' # For MIME type detection
 gem 'okcomputer'
+gem 'rack-sanitizer'
 gem 'state_machines-activerecord'
 gem 'validate_url'
 gem 'view_component'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,6 +418,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.16)
+    rack-sanitizer (2.0.4)
+      rack (>= 1.0, < 4.0)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -677,6 +679,7 @@ DEPENDENCIES
   pg
   propshaft
   puma (>= 5.0)
+  rack-sanitizer
   rails (~> 8.0.0)
   rspec-rails
   rspec_junit_formatter

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,9 @@ module HungryHungryHippo
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    # Sanitize malformed characters in requests to prevent alerts like https://app.honeybadger.io/projects/77112/faults/118640601
+    config.middleware.insert 0, Rack::Sanitizer
+
     # Add timestamps to all loggers (both Rack-based ones and e.g. Sidekiq's)
     config.log_formatter = proc do |severity, datetime, _progname, msg|
       "[#{datetime.to_fs(:iso8601)}] [#{severity}] #{msg}\n"


### PR DESCRIPTION
This reduces the # of uninformative alerts.
