### PR TITLE
add total files and file size to item report

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -7,7 +7,13 @@ class Work < ApplicationRecord
 
   belongs_to :user
   belongs_to :collection
-  # This association isn't useful from this direction, so don't try to use it.
+  # The association below isn't useful from this direction, so don't try to use it.
+  # This is because the content model object is refreshed from cocina before it is
+  # accessed (see the `set_content` method in the WorksController), which generates
+  # a new content object reach time it is done.  We therefore can have many content
+  # objects for a single work, only one of which is relevant.  It should be the
+  # latest one, but there is no guarantee that is up to date unless it has just
+  # been refreshed.
   has_many :content, dependent: :destroy
 
   state_machine :review_state, initial: :review_not_in_progress do

--- a/app/services/admin/work_report.rb
+++ b/app/services/admin/work_report.rb
@@ -161,7 +161,9 @@ module Admin
           next unless druids.include?(druid)
 
           work_model = Work.find_by(druid:)
-          content_files = work_model.content.last.content_files
+          cocina_object = Sdr::Repository.find(druid:)
+          content = Contents::Builder.call(cocina_object:, user: work_model.user, work: work_model)
+          content_files = content.content_files
           row = [work_form.title,
                  work_model.id,
                  work_form.druid,

--- a/app/services/admin/work_report.rb
+++ b/app/services/admin/work_report.rb
@@ -149,8 +149,9 @@ module Admin
     def create_csv
       headers = ['item title', 'work_id', 'druid', 'deposit state', 'review state', 'version number', 'owner',
                  'date created', 'date last modified', 'date last deposited', 'release', 'visibility',
-                 'license', 'custom rights', 'DOI', 'work type', 'work subtypes', 'collection title',
-                 'collection id', 'collection_druid']
+                 'license', 'custom rights', 'DOI', 'work type', 'work subtypes',
+                 'total number of files', 'total file size (kb)',
+                 'collection title', 'collection id', 'collection_druid']
 
       CSV.generate(headers: true) do |csv|
         csv << headers
@@ -160,6 +161,7 @@ module Admin
           next unless druids.include?(druid)
 
           work_model = Work.find_by(druid:)
+          content_files = work_model.content.last.content_files
           row = [work_form.title,
                  work_model.id,
                  work_form.druid,
@@ -177,6 +179,8 @@ module Admin
                  work_model.doi_assigned? ? Doi.url(druid:) : nil,
                  work_form.work_type,
                  work_form.work_subtypes.present? ? work_form.work_subtypes.join('; ') : nil,
+                 content_files.count,
+                 content_files.sum(&:size) / 1000.0, # size is in bytes, convert to kb (decimal)
                  work_model.collection.title,
                  work_model.collection_id,
                  work_model.collection.druid]


### PR DESCRIPTION
Fixes #1430 - add files count and size to admin item report

Tested on localhost and QA

Example report attached from QA: 
[item_report.csv](https://github.com/user-attachments/files/20730960/item_report.csv)
