### PR TITLE
Download file from staging, stacks or preservation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'kaminari' # For pagination
 gem 'kicks' # Background processing of rabbitMQ messages. (Formerly sneakers.)
 gem 'marcel' # For MIME type detection
 gem 'okcomputer'
+gem 'preservation-client'
 gem 'rack-sanitizer'
 gem 'state_machines-activerecord'
 gem 'validate_url'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,10 +346,6 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
-    mime-types (3.7.0)
-      logger
-      mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0610)
     mini_mime (1.1.5)
     minitest (5.25.5)
     mission_control-jobs (1.0.2)
@@ -362,6 +358,11 @@ GEM
       railties (>= 7.1)
       stimulus-rails
       turbo-rails
+    moab-versioning (6.1.0)
+      druid-tools (>= 1.0.0)
+      json
+      nokogiri
+      nokogiri-happymapper
     msgpack (1.8.0)
     multi_json (1.15.0)
     net-http (0.6.0)
@@ -385,6 +386,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
+    nokogiri-happymapper (0.10.0)
+      nokogiri (~> 1.5)
     okcomputer (1.19.0)
     openapi_parser (1.0.0)
     optimist (3.2.1)
@@ -400,6 +403,11 @@ GEM
     pg (1.5.9)
     pp (0.6.2)
       prettyprint
+    preservation-client (7.1.0)
+      activesupport (>= 4.2)
+      faraday (~> 2.0)
+      moab-versioning (>= 5.0.0, < 7)
+      zeitwerk (~> 2.1)
     prettyprint (0.2.0)
     prism (1.4.0)
     propshaft (1.1.0)
@@ -676,6 +684,7 @@ DEPENDENCIES
   overmind
   parallel
   pg
+  preservation-client
   propshaft
   puma (>= 5.0)
   rack-sanitizer

--- a/app/components/works/show/content_file_download_button_component.rb
+++ b/app/components/works/show/content_file_download_button_component.rb
@@ -19,11 +19,6 @@ module Works
                                                      link: download_content_file_path(content_file),
                                                      data:, **opts)
       end
-
-      def render?
-        File.exist?(StagingSupport.staging_filepath(druid: content_file.content.work.druid,
-                                                    filepath: content_file.filepath))
-      end
     end
   end
 end

--- a/app/controllers/content_files_controller.rb
+++ b/app/controllers/content_files_controller.rb
@@ -32,14 +32,74 @@ class ContentFilesController < ApplicationController
   def download
     authorize! @content_file
 
-    staging_filepath = StagingSupport.staging_filepath(druid: @content_file.content.work.druid,
-                                                       filepath: @content_file.filepath)
-    return head :bad_request unless File.exist?(staging_filepath)
+    status = Sdr::Repository.status(druid:)
 
-    send_file staging_filepath, filename: @content_file.filename, type: @content_file.mime_type
+    # if the object is accessioned and the file is not hidden, get it from the stacks
+    if status.openable? && !@content_file.hide
+      download_from_stacks
+    # if the object is accessioned, get it from preservation
+    elsif status.openable?
+      download_from_preservation(status.version)
+    # otherwise, get it from the staging area
+    else
+      download_from_staging
+    end
   end
 
   private
+
+  # rubocop:disable Metrics/AbcSize
+  # this was borrowed from Argo without permission
+  def download_from_preservation(version)
+    # Set headers on the response before writing to the response stream
+    send_file_headers!(
+      type: 'application/octet-stream',
+      disposition: 'attachment',
+      filename: CGI.escape(filepath.split('/').last)
+    )
+    response.headers['Last-Modified'] = Time.now.utc.rfc2822 # HTTP requires GMT date/time
+
+    Preservation::Client.objects.content(
+      druid:,
+      filepath:,
+      version:,
+      on_data: proc { |data, _count| response.stream.write data }
+    )
+  rescue Preservation::Client::NotFoundError => e
+    # Undo the header setting above for the streaming response. Not relevant here.
+    response.headers.delete('Last-Modified')
+    response.headers.delete('Content-Disposition')
+
+    render status: :not_found, plain: "Preserved file not found: #{e}"
+  rescue Preservation::Client::Error => e
+    message = "Preservation client error getting content of #{filepath} for #{druid}: #{e}"
+    logger.error(message)
+    Honeybadger.notify(message)
+    render status: :internal_server_error, plain: message
+  ensure
+    response.stream.close
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def download_from_stacks
+    redirect_to "#{Settings.stacks.file_url}/#{druid}/#{filepath}", allow_other_host: true
+  end
+
+  def download_from_staging
+    staging_filepath = StagingSupport.staging_filepath(druid:, filepath:)
+
+    return head :bad_request unless File.exist?(staging_filepath)
+
+    send_file staging_filepath, filename: filepath, type: @content_file.mime_type
+  end
+
+  def druid
+    @content_file.work.druid
+  end
+
+  def filepath
+    @content_file.filepath
+  end
 
   def set_content_file
     @content_file = ContentFile.includes(:content).find(params[:id])

--- a/app/controllers/content_files_controller.rb
+++ b/app/controllers/content_files_controller.rb
@@ -45,6 +45,7 @@ class ContentFilesController < ApplicationController
   private
 
   # rubocop:disable Metrics/AbcSize
+  # Note: for streaming to work, you need the include at the top of the controller
   def download_from_preservation
     # Set headers on the response before writing to the response stream
     send_file_headers!(

--- a/app/controllers/content_files_controller.rb
+++ b/app/controllers/content_files_controller.rb
@@ -32,66 +32,39 @@ class ContentFilesController < ApplicationController
   def download
     authorize! @content_file
 
-    status = Sdr::Repository.status(druid:)
-
-    # if the object is accessioned and the file is not hidden, get it from the stacks
-    if status.openable? && !@content_file.hide
-      download_from_stacks
-    # if the object is accessioned, get it from preservation
-    elsif status.openable?
-      download_from_preservation(status.version)
-    # otherwise, get it from the staging area
-    else
-      download_from_staging
+    # if the file is on the staging path, get it from there
+    if File.exist?(@content_file.staging_filepath)
+      send_file @content_file.staging_filepath, filename: filepath, type: @content_file.mime_type
+    else # if not, get it from preservation
+      download_from_preservation
     end
   end
 
   private
 
   # rubocop:disable Metrics/AbcSize
-  # this was borrowed from Argo without permission
-  def download_from_preservation(version)
+  def download_from_preservation
     # Set headers on the response before writing to the response stream
     send_file_headers!(
       type: 'application/octet-stream',
       disposition: 'attachment',
-      filename: CGI.escape(filepath.split('/').last)
+      filename: @content_file.filename
     )
     response.headers['Last-Modified'] = Time.now.utc.rfc2822 # HTTP requires GMT date/time
 
     Preservation::Client.objects.content(
       druid:,
       filepath:,
-      version:,
       on_data: proc { |data, _count| response.stream.write data }
     )
-  rescue Preservation::Client::NotFoundError => e
-    # Undo the header setting above for the streaming response. Not relevant here.
-    response.headers.delete('Last-Modified')
-    response.headers.delete('Content-Disposition')
-
-    render status: :not_found, plain: "Preserved file not found: #{e}"
-  rescue Preservation::Client::Error => e
+  rescue Preservation::Client::NotFoundError, Preservation::Client::Error => e
     message = "Preservation client error getting content of #{filepath} for #{druid}: #{e}"
-    logger.error(message)
     Honeybadger.notify(message)
-    render status: :internal_server_error, plain: message
+    render status: :bad_request, plain: 'There was a problem downloading your file.  Please try again later.'
   ensure
     response.stream.close
   end
   # rubocop:enable Metrics/AbcSize
-
-  def download_from_stacks
-    redirect_to "#{Settings.stacks.file_url}/#{druid}/#{filepath}", allow_other_host: true
-  end
-
-  def download_from_staging
-    staging_filepath = StagingSupport.staging_filepath(druid:, filepath:)
-
-    return head :bad_request unless File.exist?(staging_filepath)
-
-    send_file staging_filepath, filename: filepath, type: @content_file.mime_type
-  end
 
   def druid
     @content_file.work.druid

--- a/app/controllers/content_files_controller.rb
+++ b/app/controllers/content_files_controller.rb
@@ -2,6 +2,8 @@
 
 # Controller for a Work content file
 class ContentFilesController < ApplicationController
+  include ActionController::Live # required for streaming
+
   before_action :set_content_file
 
   def show

--- a/app/models/content_file.rb
+++ b/app/models/content_file.rb
@@ -23,6 +23,12 @@ class ContentFile < ApplicationRecord
     self.extname = FilenameSupport.extname(filepath:)
   end
 
+  # the path on the local staging filesystem
+  # note: depending on status of the object (ie draft vs deposited), there is no guarantee the file will still be there
+  def staging_filepath
+    StagingSupport.staging_filepath(druid: content.work.druid, filepath:)
+  end
+
   def filename
     FilenameSupport.filename(filepath:)
   end

--- a/config/initializers/preservation_client.rb
+++ b/config/initializers/preservation_client.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Configure preservation-client to use preservation catalog URL
+Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.token)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,9 +14,6 @@ purl:
 
 staging_location: '/sdr-deposit-staging'
 
-stacks:
-  file_url: 'https://sul-stacks-stage.stanford.edu/file'
-
 preservation_catalog:
   url: 'https://preservation-catalog-stage.stanford.edu'
   token: 'mint-token-with-target-preservation-catalog-rake-generate-token'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,13 @@ purl:
 
 staging_location: '/sdr-deposit-staging'
 
+stacks:
+  file_url: 'https://sul-stacks-stage.stanford.edu/file'
+
+preservation_catalog:
+  url: 'https://preservation-catalog-stage.stanford.edu'
+  token: 'mint-token-with-target-preservation-catalog-rake-generate-token'
+
 # mappings from authorization role to workgroup name
 authorization_workgroup_names:
   administrators: 'dlss:hydrus-app-administrators'

--- a/spec/components/works/show/content_file_download_button_component_spec.rb
+++ b/spec/components/works/show/content_file_download_button_component_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe Works::Show::ContentFileDownloadButtonComponent, type: :component
   let(:content) { create(:content, work:) }
 
   context 'when content file not available for download' do
-    it 'does not render' do
+    it 'renders link (will go to preservation)' do
       render_inline(described_class.new(content_file:))
 
-      expect(page).to have_no_css('a')
+      expect(page).to have_link('Download file', href: "/content_files/#{content_file.id}/download")
+      expect(page).to have_css('a[data-turbo="false"]')
     end
   end
 
@@ -22,7 +23,7 @@ RSpec.describe Works::Show::ContentFileDownloadButtonComponent, type: :component
       allow(File).to receive(:exist?).with('tmp/workspace/bc/123/df/4567/bc123df4567/content/test.txt').and_return(true)
     end
 
-    it 'renders link' do
+    it 'renders link (will download file from staging)' do
       render_inline(described_class.new(content_file:))
 
       expect(page).to have_link('Download file', href: "/content_files/#{content_file.id}/download")

--- a/spec/models/content_file_spec.rb
+++ b/spec/models/content_file_spec.rb
@@ -29,4 +29,15 @@ RSpec.describe ContentFile do
       end
     end
   end
+
+  describe '.staging_filepath' do
+    let(:work) { create(:work, :with_druid) }
+    let(:content) { create(:content, :with_content_files, work:) }
+    let(:content_file) { content.content_files.first }
+
+    it 'returns the path in the staging area' do
+      expect(content_file.staging_filepath).to eq StagingSupport.staging_filepath(druid: work.druid,
+                                                                                  filepath: content_file.filepath)
+    end
+  end
 end

--- a/spec/requests/download_content_file_spec.rb
+++ b/spec/requests/download_content_file_spec.rb
@@ -3,10 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Download content file' do
-  let(:content_file) { create(:content_file, content:, mime_type: 'text/plain') }
+  let(:content_file) { create(:content_file, content:, mime_type: 'text/plain', hide:) }
   let(:user) { create(:user) }
   let(:work) { create(:work, :with_druid) }
   let(:content) { create(:content, work:, user:) }
+  let(:version_status) { build(:version_status) }
+  let(:hide) { false }
+  let(:druid) { work.druid }
+
+  before do
+    allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
+    sign_in(:user)
+    sign_in(user)
+  end
 
   context 'when the user is not authorized' do
     before do
@@ -20,31 +29,58 @@ RSpec.describe 'Download content file' do
     end
   end
 
-  context 'when the file is not available for download' do
-    before do
-      sign_in(user)
+  context 'when the user is authorized' do
+    context 'when the file is not available for download' do
+      it 'returns a bad request' do
+        get "/content_files/#{content_file.id}/download"
+
+        expect(response).to have_http_status(:bad_request)
+      end
     end
 
-    it 'returns a bad request' do
-      get "/content_files/#{content_file.id}/download"
+    context 'when the file is available for download and is not yet accessioned' do
+      let(:version_status) { build(:first_draft_version_status) }
 
-      expect(response).to have_http_status(:bad_request)
+      before do
+        allow(StagingSupport).to receive(:staging_filepath).and_return('spec/fixtures/files/hippo.txt')
+      end
+
+      it 'returns the file from staging' do
+        get "/content_files/#{content_file.id}/download"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.header['Content-Disposition']).to include('attachment')
+        expect(response.header['Content-Type']).to eq('text/plain')
+        expect(response.body).to eq(File.read('spec/fixtures/files/hippo.txt'))
+      end
     end
-  end
 
-  context 'when the file is available for download' do
-    before do
-      allow(StagingSupport).to receive(:staging_filepath).and_return('spec/fixtures/files/hippo.txt')
-      sign_in(user)
+    context 'when the file is available for download, is already accessioned and is not hidden' do
+      let(:version_status) { build(:openable_version_status) }
+
+      it 'returns the file from the stacks' do
+        get "/content_files/#{content_file.id}/download"
+        expect(response.location).to eq "#{Settings.stacks.file_url}/#{druid}/#{content_file.filepath}"
+      end
     end
 
-    it 'returns the file' do
-      get "/content_files/#{content_file.id}/download"
+    context 'when the file is available for download, is already accessioned and is hidden' do
+      let(:version_status) { build(:openable_version_status) }
+      let(:hide) { true }
 
-      expect(response).to have_http_status(:ok)
-      expect(response.header['Content-Disposition']).to include('attachment')
-      expect(response.header['Content-Type']).to eq('text/plain')
-      expect(response.body).to eq(File.read('spec/fixtures/files/hippo.txt'))
+      before do
+        allow(Preservation::Client.objects).to receive(:content)
+      end
+
+      it 'returns the file from preservation' do
+        get "/content_files/#{content_file.id}/download"
+        expect(Preservation::Client.objects).to have_received(:content).with(
+          druid:,
+          filepath: content_file.filepath,
+          version: version_status.version,
+          on_data: Proc
+        )
+      end
     end
   end
 end

--- a/spec/requests/download_content_file_spec.rb
+++ b/spec/requests/download_content_file_spec.rb
@@ -7,15 +7,8 @@ RSpec.describe 'Download content file' do
   let(:user) { create(:user) }
   let(:work) { create(:work, :with_druid) }
   let(:content) { create(:content, work:, user:) }
-  let(:version_status) { build(:version_status) }
   let(:hide) { false }
   let(:druid) { work.druid }
-
-  before do
-    allow(Sdr::Repository).to receive(:status).with(druid:).and_return(version_status)
-    sign_in(:user)
-    sign_in(user)
-  end
 
   context 'when the user is not authorized' do
     before do
@@ -30,7 +23,15 @@ RSpec.describe 'Download content file' do
   end
 
   context 'when the user is authorized' do
-    context 'when the file is not available for download' do
+    before do
+      sign_in(user)
+    end
+
+    context 'when the file is not available on the staging path or from preservation' do
+      before do
+        allow(Preservation::Client.objects).to receive(:content).and_raise(Preservation::Client::NotFoundError)
+      end
+
       it 'returns a bad request' do
         get "/content_files/#{content_file.id}/download"
 
@@ -38,9 +39,7 @@ RSpec.describe 'Download content file' do
       end
     end
 
-    context 'when the file is available for download and is not yet accessioned' do
-      let(:version_status) { build(:first_draft_version_status) }
-
+    context 'when the file is on the staging filesystem' do
       before do
         allow(StagingSupport).to receive(:staging_filepath).and_return('spec/fixtures/files/hippo.txt')
       end
@@ -55,29 +54,18 @@ RSpec.describe 'Download content file' do
       end
     end
 
-    context 'when the file is available for download, is already accessioned and is not hidden' do
-      let(:version_status) { build(:openable_version_status) }
-
-      it 'returns the file from the stacks' do
-        get "/content_files/#{content_file.id}/download"
-        expect(response.location).to eq "#{Settings.stacks.file_url}/#{druid}/#{content_file.filepath}"
-      end
-    end
-
-    context 'when the file is available for download, is already accessioned and is hidden' do
-      let(:version_status) { build(:openable_version_status) }
+    context 'when the file is not on the staging filesystem' do
       let(:hide) { true }
 
       before do
         allow(Preservation::Client.objects).to receive(:content)
       end
 
-      it 'returns the file from preservation' do
+      it 'returns the latest file from preservation' do
         get "/content_files/#{content_file.id}/download"
         expect(Preservation::Client.objects).to have_received(:content).with(
           druid:,
           filepath: content_file.filepath,
-          version: version_status.version,
           on_data: Proc
         )
       end


### PR DESCRIPTION
Fixes #1341 - download files from staging, stacks or preservation based on logic

Tested in QA 

~~Requires new configuration in shared_configs, puppet and vault.~~ DONE
~~Preservation catalog tokens are already minted and placed into vault.~~ DONE

pre-reqs:
-  [x] QA: https://github.com/sul-dlss/shared_configs/pull/2359
- [x] Stage: https://github.com/sul-dlss/shared_configs/pull/2360
- [x] Prod: https://github.com/sul-dlss/shared_configs/pull/2361
- [x] Puppet: https://github.com/sul-dlss/puppet/pull/12519/ 
- [x] Puppet v2: https://github.com/sul-dlss/puppet/pull/12532/ 


