### PR TITLE
adjust sort order to match display

### DIFF
--- a/app/components/collections/show/deposits_component.rb
+++ b/app/components/collections/show/deposits_component.rb
@@ -19,7 +19,7 @@ module Collections
       end
 
       def collection_deposits
-        @collection_deposits ||= presenters.map do |presenter|
+        presenters.map do |presenter|
           {
             id: dom_id(presenter),
             values: values_for(presenter)

--- a/app/views/collections/works.html.erb
+++ b/app/views/collections/works.html.erb
@@ -22,8 +22,8 @@
         <% component.with_sort_option(label: 'Owner (descending)', link: works_collection_path(@collection, sort_by: 'users.name desc', q: @search_term)) %>
         <% component.with_sort_option(label: 'Status (ascending)', link: works_collection_path(@collection, sort_by: 'status asc', q: @search_term)) %>
         <% component.with_sort_option(label: 'Status (descending)', link: works_collection_path(@collection, sort_by: 'status desc', q: @search_term)) %>
-        <% component.with_sort_option(label: 'Date modified (Newest first)', link: works_collection_path(@collection, sort_by: 'works.updated_at desc', q: @search_term)) %>
-        <% component.with_sort_option(label: 'Date modified (Oldest first)', link: works_collection_path(@collection, sort_by: 'works.updated_at asc', q: @search_term)) %>
+        <% component.with_sort_option(label: 'Date modified (Newest first)', link: works_collection_path(@collection, sort_by: 'works.object_updated_at desc', q: @search_term)) %>
+        <% component.with_sort_option(label: 'Date modified (Oldest first)', link: works_collection_path(@collection, sort_by: 'works.object_updated_at asc', q: @search_term)) %>
       <% end %>
     </div>
   </div>

--- a/spec/components/collections/show/sort_dropdown_component_spec.rb
+++ b/spec/components/collections/show/sort_dropdown_component_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Collections::Show::SortDropdownComponent, type: :component do
       component.with_sort_option(label: 'Status (descending)',
                                  link: "/collections/#{druid_fixture}/works?sort_by=status%20desc")
       component.with_sort_option(label: 'Date modified (ascending)',
-                                 link: "/collections/#{druid_fixture}/works?sort_by=works.updated_at%20asc")
+                                 link: "/collections/#{druid_fixture}/works?sort_by=works.object_updated_at%20asc")
       component.with_sort_option(label: 'Date modified (descending)',
-                                 link: "/collections/#{druid_fixture}/works?sort_by=works.updated_at%20desc")
+                                 link: "/collections/#{druid_fixture}/works?sort_by=works.object_updated_at%20desc")
     end
   end
 

--- a/spec/services/work_sort_service_spec.rb
+++ b/spec/services/work_sort_service_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe WorkSortService do
     end
 
     context 'when sorting by date modified ascending' do
-      let(:sort_by) { 'works.updated_at asc' }
+      let(:sort_by) { 'works.object_updated_at asc' }
 
       it 'orders by updated_at ascending' do
         presenters = described_class.call(works:, sort_by:)
@@ -111,7 +111,7 @@ RSpec.describe WorkSortService do
     end
 
     context 'when sorting by date modified descending' do
-      let(:sort_by) { 'works.updated_at desc' }
+      let(:sort_by) { 'works.object_updated_at desc' }
 
       it 'orders by updated_at descending' do
         presenters = described_class.call(works:, sort_by:)


### PR DESCRIPTION
(hopefully) fixes #1498 

1. We display `object_updated_at` in the table, but currently sort on `updated-at`.  This makes the sort match the display.
2. We are (I think) unnecessarily memoizing the collections list, it's only used once in the component anyway.  Speculation it may be causing old cached info to show somehow?