### PR TITLE
Create a new job to send reminder emails about terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ A "nested" field is one that is not "simple" (see prior section).
 1. Test the triggering of the notification.
 1. Test the email.
 
+Preview mailers at http://localhost:3000/rails/mailers
+Add new previews at spec/mailers/previews
+
 ## Analytics
 
 First-party analytics is implemented using [Ahoy](https://github.com/ankane/ahoy). See `Ahoy::Event` for a list of implemented events.

--- a/app/jobs/terms_reminder_email_job.rb
+++ b/app/jobs/terms_reminder_email_job.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-# Send an email to every depositor who agreed to the terms of acceptance > 1 year ago
+# Send an email to every depositor who agreed to the terms of acceptance or received an email > 1 year ago
 # This job is run each day automatically via a cron job setup via whenever gem in schedule.rb
 # Running daily means there should not be too many emails sent at a time (i.e. since users agree to
 # the terms of deposit over time as they first start using H3, the number of users surpassing a
 # year on any given day should be small).
 class TermsReminderEmailJob < ApplicationJob
   def perform
-    users = User.where(agreed_to_terms_at: ...1.year.ago)
+    users = User.where(terms_reminder_email_last_sent_at: ...1.year.ago)
+                .or(User.where(agreed_to_terms_at: ...1.year.ago, terms_reminder_email_last_sent_at: nil))
     users.each do |user|
       TermsMailer.with(user:).reminder_email.deliver_now
+      user.update(terms_reminder_email_last_sent_at: Time.zone.now)
     end
   end
 end

--- a/app/jobs/terms_reminder_email_job.rb
+++ b/app/jobs/terms_reminder_email_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Send an email to every depositor who agreed to the terms of acceptance > 1 year ago
+# This job is run each day automatically via a cron job setup via whenever gem in schedule.rb
+# Running daily means there should not be too many emails sent at a time (i.e. since users agree to
+# the terms of deposit over time as they first start using H3, the number of users surpassing a
+# year on any given day should be small).
+class TermsReminderEmailJob < ApplicationJob
+  def perform
+    users = User.where(agreed_to_terms_at: ...1.year.ago)
+    users.each do |user|
+      TermsMailer.with(user:).reminder_email.deliver_now
+    end
+  end
+end

--- a/app/mailers/terms_mailer.rb
+++ b/app/mailers/terms_mailer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Sends email notifications about having agreed to the terms of deposit
+class TermsMailer < ApplicationMailer
+  def reminder_email
+    @user = params[:user]
+    mail(to: @user.email_address, subject: 'Annual Notice of the Stanford Digital Repository (SDR) Terms of Deposit')
+  end
+end

--- a/app/views/terms_mailer/reminder_email.html.erb
+++ b/app/views/terms_mailer/reminder_email.html.erb
@@ -1,6 +1,6 @@
 <%= render Emails::SalutationComponent.new(user: @user) %>
 
-<p>You are receiving this email as a current or past user of the Stanford Digital Repository (SDR) self-deposit application at https://sdr.stanford.edu.</p>
+<p>You are receiving this email as a current or past user of the Stanford Digital Repository (SDR) self-deposit application at <a href="https://sdr.stanford.edu">https://sdr.stanford.edu</a>.</p>
 
 <p>All SDR depositors must agree to our Terms of Deposit, which assert that you have the right to deposit the content and assign Stanford University Libraries the necessary license to preserve the content and make it available online for others to access.</p>
 

--- a/app/views/terms_mailer/reminder_email.html.erb
+++ b/app/views/terms_mailer/reminder_email.html.erb
@@ -1,0 +1,15 @@
+<%= render Emails::SalutationComponent.new(user: @user) %>
+
+<p>You are receiving this email as a current or past user of the Stanford Digital Repository (SDR) self-deposit application at https://sdr.stanford.edu.</p>
+
+<p>All SDR depositors must agree to our Terms of Deposit, which assert that you have the right to deposit the content and assign Stanford University Libraries the necessary license to preserve the content and make it available online for others to access.</p>
+
+<p>If you have deposited content in the SDR, you most likely agreed to the Terms of Deposit when you completed your first deposit. Your agreement to the Terms applies to all the deposits you make in the SDR, even though you may not be required to attest to the Terms every time you deposit content.</p>
+
+<h3>What should you do?</h3>
+
+<p>We ask that all SDR depositors review the Terms of Deposit on an annual basis. Learn more about the Terms of Deposit or contact the SDR team with any questions.</p>
+
+<p>Thank you for using the Stanford Digital Repository!</p>
+
+<%= render Emails::SignatureComponent.new %>

--- a/app/views/terms_mailer/reminder_email.html.erb
+++ b/app/views/terms_mailer/reminder_email.html.erb
@@ -8,7 +8,7 @@
 
 <span><strong>What should you do?</strong></span>
 
-<p>We ask that all SDR depositors review the Terms of Deposit on an annual basis. <a href="https://sdr.library.stanford.edu/documentation/understanding-sdr-terms-deposit">Learn more about the Terms of Deposit</a> or <a href="mailto:sdr-support@lists.stanford.edu">contact the SDR team</a> with any questions.</p>
+<p>We ask that all SDR depositors review the Terms of Deposit on an annual basis. <a href="https://sdr.library.stanford.edu/documentation/understanding-sdr-terms-deposit">Learn more about the Terms of Deposit</a> or <a href="mailto:<%= Settings.support_email %>">contact the SDR team</a> with any questions.</p>
 
 <p>Thank you for using the Stanford Digital Repository!</p>
 

--- a/app/views/terms_mailer/reminder_email.html.erb
+++ b/app/views/terms_mailer/reminder_email.html.erb
@@ -2,13 +2,13 @@
 
 <p>You are receiving this email as a current or past user of the Stanford Digital Repository (SDR) self-deposit application at <a href="https://sdr.stanford.edu">https://sdr.stanford.edu</a>.</p>
 
-<p>All SDR depositors must agree to our Terms of Deposit, which assert that you have the right to deposit the content and assign Stanford University Libraries the necessary license to preserve the content and make it available online for others to access.</p>
+<p>All SDR depositors must agree to our <a href="https://sdr.library.stanford.edu/documentation/understanding-sdr-terms-deposit">Terms of Deposit</a>, which assert that you have the right to deposit the content and assign Stanford University Libraries the necessary license to preserve the content and make it available online for others to access.</p>
 
 <p>If you have deposited content in the SDR, you most likely agreed to the Terms of Deposit when you completed your first deposit. Your agreement to the Terms applies to all the deposits you make in the SDR, even though you may not be required to attest to the Terms every time you deposit content.</p>
 
 <span><strong>What should you do?</strong></span>
 
-<p>We ask that all SDR depositors review the Terms of Deposit on an annual basis. Learn more about the Terms of Deposit or contact the SDR team with any questions.</p>
+<p>We ask that all SDR depositors review the Terms of Deposit on an annual basis. <a href="https://sdr.library.stanford.edu/documentation/understanding-sdr-terms-deposit">Learn more about the Terms of Deposit</a> or <a href="mailto:sdr-support@lists.stanford.edu">contact the SDR team</a> with any questions.</p>
 
 <p>Thank you for using the Stanford Digital Repository!</p>
 

--- a/app/views/terms_mailer/reminder_email.html.erb
+++ b/app/views/terms_mailer/reminder_email.html.erb
@@ -6,7 +6,7 @@
 
 <p>If you have deposited content in the SDR, you most likely agreed to the Terms of Deposit when you completed your first deposit. Your agreement to the Terms applies to all the deposits you make in the SDR, even though you may not be required to attest to the Terms every time you deposit content.</p>
 
-<h3>What should you do?</h3>
+<span><strong>What should you do?</strong></span>
 
 <p>We ask that all SDR depositors review the Terms of Deposit on an annual basis. Learn more about the Terms of Deposit or contact the SDR team with any questions.</p>
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,3 +23,8 @@
 every 1.day do
   runner 'Content.where("created_at < ?", 3.days.ago).destroy_all', output: { standard: '/dev/null' }
 end
+
+# people are more likely to read their emails first thing in the morning?
+every 1.day, at: '8:30 am' do
+  runner 'TermsReminderEmailJob.perform_later'
+end

--- a/db/migrate/20250619163206_last_email_sent.rb
+++ b/db/migrate/20250619163206_last_email_sent.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class LastEmailSent < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :terms_reminder_email_last_sent_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -466,7 +466,8 @@ CREATE TABLE public.users (
     first_name character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    agreed_to_terms_at timestamp(6) without time zone
+    agreed_to_terms_at timestamp(6) without time zone,
+    terms_reminder_email_last_sent_at timestamp(6) without time zone
 );
 
 
@@ -1045,6 +1046,7 @@ ALTER TABLE ONLY public.shares
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250619163206'),
 ('20250616125424'),
 ('20250610120209'),
 ('20250604121142'),

--- a/spec/jobs/terms_reminder_email_job_spec.rb
+++ b/spec/jobs/terms_reminder_email_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TermsReminderEmailJob, :active_job_test_adapter do
+  include ActionMailer::TestHelper
+
+  subject(:job) { described_class.new }
+
+  let!(:new_user) { create(:user, agreed_to_terms_at: nil) } # has not agreed yet, no email
+  let!(:recent_user) { create(:user, agreed_to_terms_at: Time.zone.today - 1.day) } # agreed recently, no email
+  let!(:old_user_1_year_ago) { create(:user, agreed_to_terms_at: Time.zone.today - 366.days) } # agreed over a year ago
+  let!(:old_user_2_years_ago) { create(:user, agreed_to_terms_at: Time.zone.today - 2.years) } # agreed over a year ago
+
+  let(:mailer) { instance_double(TermsMailer, reminder_email: delivery_object) }
+  let(:delivery_object) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
+
+  describe '#perform' do
+    before do
+      allow(TermsMailer).to receive(:with).with(user: User).and_return(mailer)
+      allow(mailer).to receive(:with).and_return(mailer)
+      allow(delivery_object).to receive(:deliver_now)
+    end
+
+    it 'sends an email to just the users who agreed to terms over a year ago' do
+      described_class.perform_now
+      expect(TermsMailer).to have_received(:with).with(user: old_user_1_year_ago)
+      expect(TermsMailer).to have_received(:with).with(user: old_user_2_years_ago)
+      expect(TermsMailer).not_to have_received(:with).with(user: new_user)
+      expect(TermsMailer).not_to have_received(:with).with(user: recent_user)
+      expect(mailer).to have_received(:reminder_email).twice
+    end
+  end
+end

--- a/spec/jobs/terms_reminder_email_job_spec.rb
+++ b/spec/jobs/terms_reminder_email_job_spec.rb
@@ -7,13 +7,39 @@ RSpec.describe TermsReminderEmailJob, :active_job_test_adapter do
 
   subject(:job) { described_class.new }
 
-  let!(:new_user) { create(:user, agreed_to_terms_at: nil) } # has not agreed yet, no email
-  let!(:recent_user) { create(:user, agreed_to_terms_at: Time.zone.today - 1.day) } # agreed recently, no email
-  let!(:old_user_1_year_ago) { create(:user, agreed_to_terms_at: Time.zone.today - 366.days) } # agreed over a year ago
-  let!(:old_user_2_years_ago) { create(:user, agreed_to_terms_at: Time.zone.today - 2.years) } # agreed over a year ago
+  let(:yesterday) { Time.zone.today - 1.day }
+  let(:just_over_one_year_ago) { Time.zone.today - 366.days }
+  let(:two_years_ago) { Time.zone.today - 2.years }
+
+  # has not agreed yet, do not send email
+  let!(:new_user) { create(:user, agreed_to_terms_at: nil, terms_reminder_email_last_sent_at: nil) }
+  # agreed recently, do not send email
+  let!(:recent_user) { create(:user, agreed_to_terms_at: yesterday, terms_reminder_email_last_sent_at: nil) }
+
+  # agreed over a year ago, never received reminder email, should get email
+  let!(:old_user_1_year_ago) do
+    create(:user, agreed_to_terms_at: just_over_one_year_ago, terms_reminder_email_last_sent_at: nil)
+  end
+  # agreed two years ago, never received reminder email, should get email
+  let!(:old_user_2_years_ago) do
+    create(:user, agreed_to_terms_at: two_years_ago, terms_reminder_email_last_sent_at: nil)
+  end
+
+  # agreed over one year ago, received reminder email less one year ago, do not send email
+  let!(:old_user_1_year_ago_not_ready_for_email) do
+    create(:user, agreed_to_terms_at: just_over_one_year_ago, terms_reminder_email_last_sent_at: yesterday)
+  end
+
+  # agreed two years ago, received reminder email over one year ago, should get email
+  let!(:old_user_2_years_ago_ready_for_email) do
+    create(:user, agreed_to_terms_at: two_years_ago, terms_reminder_email_last_sent_at: just_over_one_year_ago)
+  end
 
   let(:mailer) { instance_double(TermsMailer, reminder_email: delivery_object) }
   let(:delivery_object) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
+
+  let(:users_to_receive_email) { [old_user_1_year_ago, old_user_2_years_ago, old_user_2_years_ago_ready_for_email] }
+  let(:users_to_not_receive_email) { [new_user, recent_user, old_user_1_year_ago_not_ready_for_email] }
 
   describe '#perform' do
     before do
@@ -22,13 +48,31 @@ RSpec.describe TermsReminderEmailJob, :active_job_test_adapter do
       allow(delivery_object).to receive(:deliver_now)
     end
 
-    it 'sends an email to just the users who agreed to terms over a year ago' do
+    it 'sends email to users who agreed to terms over a year ago and have not received an email since then' do
       described_class.perform_now
+
+      # three user should get emails
       expect(TermsMailer).to have_received(:with).with(user: old_user_1_year_ago)
       expect(TermsMailer).to have_received(:with).with(user: old_user_2_years_ago)
+      expect(TermsMailer).to have_received(:with).with(user: old_user_2_years_ago_ready_for_email)
+
+      # three users should should NOT get emails
       expect(TermsMailer).not_to have_received(:with).with(user: new_user)
       expect(TermsMailer).not_to have_received(:with).with(user: recent_user)
-      expect(mailer).to have_received(:reminder_email).twice
+      expect(TermsMailer).not_to have_received(:with).with(user: old_user_1_year_ago_not_ready_for_email)
+
+      # exactly three emails went out
+      expect(mailer).to have_received(:reminder_email).exactly(3).times # three emails should go out
+
+      # we have recorded the date that the users received the email
+      users_to_receive_email.each do |user|
+        expect(user.reload.terms_reminder_email_last_sent_at.to_date).to eq(Date.current)
+      end
+
+      # users who have not received an email have not been updated
+      users_to_not_receive_email.each do |user|
+        expect(user.reload.terms_reminder_email_last_sent_at).not_to eq(Date.current)
+      end
     end
   end
 end

--- a/spec/mailers/previews/terms_mailer_preview.rb
+++ b/spec/mailers/previews/terms_mailer_preview.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Preview with http://localhost:3000/rails/mailers/terms_mailer/
+class TermsMailerPreview < ActionMailer::Preview
+  def reminder_email
+    TermsMailer.with(user: User.first).reminder_email
+  end
+end

--- a/spec/mailers/terms_mailer_spec.rb
+++ b/spec/mailers/terms_mailer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TermsMailer do
+  let(:user) { create(:user, name: 'Howard', first_name: 'Moe') }
+
+  describe '.reminder_email' do
+    let(:mail) { described_class.with(user:).reminder_email }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq 'Annual Notice of the Stanford Digital Repository (SDR) Terms of Deposit'
+      expect(mail.to).to eq [user.email_address]
+      expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'renders the body' do
+      # not checking the full body but a couple parts
+      expect(mail.body.encoded).to include('Dear Moe,')
+      expect(mail.body.encoded).to include('You are receiving this email as a current or past user')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1496 

~~Spam~~ Email users once a year to remind them that they agreed to the SDR terms of deposit.

- [x] add tests
- [x] check email format for real
- [x] record when email sent to user and do not need again until 1 year has passed

<img width="1428" alt="Screenshot 2025-06-19 at 2 00 20 PM" src="https://github.com/user-attachments/assets/9c0b313f-e6cb-4ba8-8c72-cdf630a4756b" />


