### PR TITLE
user selection of days should be kept

### DIFF
--- a/app/controllers/admin/recent_activity_collections_controller.rb
+++ b/app/controllers/admin/recent_activity_collections_controller.rb
@@ -13,11 +13,11 @@ module Admin
     private
 
     def days_limit
-      params.fetch(:admin_recent_activity, {}).fetch(:days_limit, 7).to_i
+      recent_activity_params.fetch(:days_limit, Admin::RecentActivityForm.new.days_limit).to_i
     end
 
     def recent_activity_params
-      params.permit(:days_limit)
+      params.fetch(:admin_recent_activity, {}).permit(:days_limit)
     end
 
     def rows


### PR DESCRIPTION
Fixes #1503 - user selection of "days ago" should stick in admin collection recent activity report