### PR TITLE
search files in edit view when paginating

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,6 @@ AllCops:
     - 'config/environments/*.rb'
     - 'db/**/*'
     - 'vendor/**/*'
-    - 'tmp/**/*'
 
 Layout/LineLength:
   Max: 120

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,7 @@ AllCops:
     - 'config/environments/*.rb'
     - 'db/**/*'
     - 'vendor/**/*'
+    - 'tmp/**/*'
 
 Layout/LineLength:
   Max: 120

--- a/app/components/works/edit/content_hierarchy_component.rb
+++ b/app/components/works/edit/content_hierarchy_component.rb
@@ -4,15 +4,12 @@ module Works
   module Edit
     # Component for rendering an editable file hierarchy table for a Content.
     class ContentHierarchyComponent < ApplicationComponent
-      # NOTE: content is a reserved word in a view component, so using content_obj instead.
-      def initialize(content_obj:)
-        @content_obj = content_obj
+      def initialize(content_files:)
+        @content_files = content_files
         super()
       end
 
-      def content_files
-        @content_obj.content_files.path_order
-      end
+      attr_reader :content_files
     end
   end
 end

--- a/app/components/works/edit/content_non_hierarchy_component.html.erb
+++ b/app/components/works/edit/content_non_hierarchy_component.html.erb
@@ -9,16 +9,16 @@
     <% content_files.each do |content_file| %>
         <% component.with_row do |row_component| %>
             <% row_component.with_cell do %>
-            <%= content_file.filepath %>
+                <%= content_file.filepath %>
             <% end %>
             <% row_component.with_cell do %>
-            <%= render Works::Edit::ContentFileDescriptionComponent.new(content_file:) %>
+                <%= render Works::Edit::ContentFileDescriptionComponent.new(content_file:) %>
             <% end %>
             <% row_component.with_cell do %>
-            <%= render Works::Edit::ContentFileHideComponent.new(content_file:) %>
+                <%= render Works::Edit::ContentFileHideComponent.new(content_file:) %>
             <% end %>
             <% row_component.with_cell do %>
-            <%= render Works::Edit::ContentFileDeleteComponent.new(content_file:) %>
+                <%= render Works::Edit::ContentFileDeleteComponent.new(content_file:) %>
             <% end %>
         <% end %>
     <% end %>

--- a/app/components/works/edit/content_non_hierarchy_component.html.erb
+++ b/app/components/works/edit/content_non_hierarchy_component.html.erb
@@ -1,0 +1,26 @@
+<%= render Elements::Tables::TableComponent.new(id: 'content-table', label: 'Files', show_label: false) do |component| %>
+    <%# These headers are duplicated in app/components/works/edit/content_hierarchy_component.html.erb %>
+    <% component.with_headers([
+                                { label: 'File Name' },
+                                { label: 'Description', tooltip: t('content_files.edit.fields.description.tooltip_html'), style: 'width: 180px;' },
+                                { label: 'Hide', tooltip: t('content_files.edit.fields.hide.tooltip_html'), style: 'width: 85px;' },
+                                { label: 'Action', style: 'width: 85px;' }
+                              ]) %>
+    <% content_files.each do |content_file| %>
+        <% component.with_row do |row_component| %>
+            <% row_component.with_cell do %>
+            <%= content_file.filepath %>
+            <% end %>
+            <% row_component.with_cell do %>
+            <%= render Works::Edit::ContentFileDescriptionComponent.new(content_file:) %>
+            <% end %>
+            <% row_component.with_cell do %>
+            <%= render Works::Edit::ContentFileHideComponent.new(content_file:) %>
+            <% end %>
+            <% row_component.with_cell do %>
+            <%= render Works::Edit::ContentFileDeleteComponent.new(content_file:) %>
+            <% end %>
+        <% end %>
+    <% end %>
+<% end %>
+<%= paginate content_files, params: { controller: 'contents', action: 'show', id: content_obj.id } %>

--- a/app/components/works/edit/content_non_hierarchy_component.rb
+++ b/app/components/works/edit/content_non_hierarchy_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Works
+  module Edit
+    # Component for rendering an editable file flat table for a Content.
+    class ContentNonHierarchyComponent < ApplicationComponent
+      # NOTE: content is a reserved word in a view component, so using content_obj instead.
+      def initialize(content_obj:, content_files:)
+        @content_files = content_files
+        @content_obj = content_obj
+        super()
+      end
+
+      attr_reader :content_files, :content_obj
+    end
+  end
+end

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -8,6 +8,12 @@ class ContentsController < ApplicationController
   # Called from work edit/update form.
   def show
     authorize! @content
+
+    # since the user can search by filename when pagination is occurring, this can result in @content_files
+    # query having 0 results or fewer than the max number for pagination ... we want to know how many
+    # files the object has before a search to properly render the "no files" messages or search box
+    @total_files = @content.content_files.count
+    @search_term = search_term
   end
 
   # Called from work show page.
@@ -34,7 +40,13 @@ class ContentsController < ApplicationController
   end
 
   def set_content_files
-    @content_files = @content.content_files.path_order.page(params[:page])
+    @content_files = @content.content_files
+    @content_files = @content_files.where('filepath like ?', "%#{search_term}%") if search_term
+    @content_files = @content_files.path_order.page(params[:page])
+  end
+
+  def search_term
+    params[:q]
   end
 
   def update_files

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -12,7 +12,7 @@ class ContentsController < ApplicationController
     # since the user can search by filename when pagination is occurring, this can result in @content_files
     # query having 0 results even when the object itself has files ... and we want to know how many files the
     # object has before a search to properly render the "no files" or "no search results" message as appropriate
-    @total_files = @content.content_files.count
+    @total_files = total_files
     @search_term = search_term
   end
 
@@ -42,11 +42,18 @@ class ContentsController < ApplicationController
   def set_content_files
     @content_files = @content.content_files
     @content_files = @content_files.where('filepath like ?', "%#{search_term}%") if search_term
-    @content_files = @content_files.path_order.page(params[:page])
+    @content_files = @content_files.path_order
+    # if we have more than the configured number of files that will work with a hiearchical view, we will do a flat list with paging instead
+    @content_files = @content_files.page(params[:page]) if total_files > Settings.file_upload.hierarchical_files_limit
   end
 
   def search_term
     params[:q]
+  end
+
+  # the total number of files in an object before any search filters are applied
+  def total_files
+    @content.content_files.count
   end
 
   def update_files

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -43,7 +43,8 @@ class ContentsController < ApplicationController
     @content_files = @content.content_files
     @content_files = @content_files.where('filepath like ?', "%#{search_term}%") if search_term
     @content_files = @content_files.path_order
-    # if we have more than the configured number of files that will work with a hiearchical view, we will do a flat list with paging instead
+    # if we have more than the configured number of files that will work with a hiearchical view,
+    # we will do a flat list with paging instead
     @content_files = @content_files.page(params[:page]) if total_files > Settings.file_upload.hierarchical_files_limit
   end
 

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -44,7 +44,7 @@ class ContentsController < ApplicationController
     @content_files = @content_files.where('filepath like ?', "%#{search_term}%") if search_term
     @content_files = @content_files.path_order
     # if we have more than the configured number of files that will work with a hiearchical view,
-    # we will do a flat list with paging instead
+    # we will do a flat list with paging, so add the page method and current page param to the query
     @content_files = @content_files.page(params[:page]) if total_files > Settings.file_upload.hierarchical_files_limit
   end
 

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -10,8 +10,8 @@ class ContentsController < ApplicationController
     authorize! @content
 
     # since the user can search by filename when pagination is occurring, this can result in @content_files
-    # query having 0 results or fewer than the max number for pagination ... we want to know how many
-    # files the object has before a search to properly render the "no files" messages or search box
+    # query having 0 results even when the object itself has files ... and we want to know how many files the
+    # object has before a search to properly render the "no files" or "no search results" message as appropriate
     @total_files = @content.content_files.count
     @search_term = search_term
   end

--- a/app/views/contents/_show.html.erb
+++ b/app/views/contents/_show.html.erb
@@ -1,11 +1,9 @@
 <%= turbo_frame_tag content, 'show' do %>
   <%= turbo_stream_from 'show', content %>
-  <% content_files ||= content.content_files.path_order.page(1) %>
-  <% if total_files > Kaminari.config.default_per_page # there is more than one page of results, show search bar with section header %>
+  <% if total_files > Settings.search.file_search_box_min # there is at least this files in the object, so show search bar with section header %>
       <div class="row">
         <div class="col-3">
           <%= render Edit::SectionHeaderComponent.new(title: t('works.edit.panes.files.list')) %>
-          <%= "(#{total_files})" %>
         </div>
         <div class="col-5 ms-auto">
           <%# Not using TextFieldComponent because field-container conflicts with input-group. %>
@@ -29,37 +27,12 @@
       <%= render Edit::SectionHeaderComponent.new(title: t('works.edit.panes.files.list')) %>
     <% end %>
 
-  <% if total_files.zero? # there are no files at all in the object %>
+  <% if total_files.zero? # there are no files at all in the object, show the appropriate message to the user %>
     <p>Your files will appear here once they have been uploaded.</p>
-  <% else # there are files in the object %>
-      <% if total_files > Settings.file_upload.hierarchical_files_limit # we have too many files, and the hierarchy would not work well, show flat list with paging %>
-        <%= render Elements::Tables::TableComponent.new(id: 'content-table', label: 'Files', show_label: false) do |component| %>
-          <%# These headers are duplicated in app/components/works/edit/content_hierarchy_component.html.erb %>
-          <% component.with_headers([
-                                      { label: 'File Name' },
-                                      { label: 'Description', tooltip: t('content_files.edit.fields.description.tooltip_html'), style: 'width: 180px;' },
-                                      { label: 'Hide', tooltip: t('content_files.edit.fields.hide.tooltip_html'), style: 'width: 85px;' },
-                                      { label: 'Action', style: 'width: 85px;' }
-                                    ]) %>
-          <% content_files.each do |content_file| %>
-            <% component.with_row do |row_component| %>
-              <% row_component.with_cell do %>
-                <%= content_file.filepath %>
-              <% end %>
-              <% row_component.with_cell do %>
-                <%= render Works::Edit::ContentFileDescriptionComponent.new(content_file:) %>
-              <% end %>
-              <% row_component.with_cell do %>
-                <%= render Works::Edit::ContentFileHideComponent.new(content_file:) %>
-              <% end %>
-              <% row_component.with_cell do %>
-                <%= render Works::Edit::ContentFileDeleteComponent.new(content_file:) %>
-              <% end %>
-            <% end %>
-          <% end %>
-        <% end %>
-        <%= paginate content_files, params: { controller: 'contents', action: 'show', id: content.id } %>
-      <% else # hierarchy will work fine with less than the configured number of files, show it with paging %>
+  <% else # there is at lesat one file in the object, now decide if we show the hierarchical view without paging or the flat list view with paging %>
+      <% if total_files > Settings.file_upload.hierarchical_files_limit # lots of files, and the hierarchy would not work well, show flat list with paging %>
+        <%= render Works::Edit::ContentNonHierarchyComponent.new(content_obj: content, content_files:) %>
+      <% else # fewer files,  hierarchy will work fine, show hierarchy view without paging %>
         <%= render Works::Edit::ContentHierarchyComponent.new(content_files:) %>
       <% end %>
   <% end %>

--- a/app/views/contents/_show.html.erb
+++ b/app/views/contents/_show.html.erb
@@ -12,7 +12,7 @@
               <%= render Elements::Forms::LabelComponent.new(form:, field_name: :q, default_label_class: 'input-group-text', classes: 'bg-white border-end-0') do %>
                 <%= search_icon %><span class="visually-hidden">Search files</span>
               <% end %>
-              <%= form.text_field :q, class: 'form-control border-start-0', value: search_term, placeholder: 'Search ...' %>
+              <%= form.text_field :q, id: 'content-files-search', class: 'form-control border-start-0', value: search_term, placeholder: 'Search ...' %>
               <div class="input-group-text bg-white" style="padding: 0.3rem;">
                 <%= render Elements::Forms::SubmitComponent.new(label: 'Search', classes: 'btn-sm py-1') %>
               </div>

--- a/app/views/contents/_show.html.erb
+++ b/app/views/contents/_show.html.erb
@@ -1,36 +1,66 @@
 <%= turbo_frame_tag content, 'show' do %>
   <%= turbo_stream_from 'show', content %>
   <% content_files ||= content.content_files.path_order.page(1) %>
-  <% if content_files.empty? %>
+  <% if total_files > Kaminari.config.default_per_page # show search bar with section header %>
+      <div class="row">
+        <div class="col-3">
+          <%= render Edit::SectionHeaderComponent.new(title: t('works.edit.panes.files.list')) %>
+        </div>
+        <div class="col-5 ms-auto">
+          <%# Not using TextFieldComponent because field-container conflicts with input-group. %>
+          <%= form_with url: content_path(content), method: :get do |form| %>
+            <div class="input-group">
+              <%= render Elements::Forms::LabelComponent.new(form:, field_name: :q, default_label_class: 'input-group-text', classes: 'bg-white border-end-0') do %>
+                <%= search_icon %><span class="visually-hidden">Search files</span>
+              <% end %>
+              <%= form.text_field :q, class: 'form-control border-start-0', value: search_term, placeholder: 'Search ...' %>
+              <div class="input-group-text bg-white" style="padding: 0.3rem;">
+                <%= render Elements::Forms::SubmitComponent.new(label: 'Search', classes: 'btn-sm py-1') %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <% if content_files.empty? %>
+        <p>There are no results matching "<%= search_term %>".</p>
+      <% end %>
+    <% else # just show section header %>
+      <%= render Edit::SectionHeaderComponent.new(title: t('works.edit.panes.files.list')) %>
+    <% end %>
+
+  <% if total_files.zero? %>
     <p>Your files will appear here once they have been uploaded.</p>
-  <% elsif content.content_files.count > Settings.file_upload.hierarchical_files_limit %>
-    <%= render Elements::Tables::TableComponent.new(id: 'content-table', label: 'Files', show_label: false) do |component| %>
-      <%# These headers are duplicated in app/components/works/edit/content_hierarchy_component.html.erb %>
-      <% component.with_headers([
-                                  { label: 'File Name' },
-                                  { label: 'Description', tooltip: t('content_files.edit.fields.description.tooltip_html'), style: 'width: 180px;' },
-                                  { label: 'Hide', tooltip: t('content_files.edit.fields.hide.tooltip_html'), style: 'width: 85px;' },
-                                  { label: 'Action', style: 'width: 85px;' }
-                                ]) %>
-      <% content_files.each do |content_file| %>
-        <% component.with_row do |row_component| %>
-          <% row_component.with_cell do %>
-            <%= content_file.filepath %>
-          <% end %>
-          <% row_component.with_cell do %>
-            <%= render Works::Edit::ContentFileDescriptionComponent.new(content_file:) %>
-          <% end %>
-          <% row_component.with_cell do %>
-            <%= render Works::Edit::ContentFileHideComponent.new(content_file:) %>
-          <% end %>
-          <% row_component.with_cell do %>
-            <%= render Works::Edit::ContentFileDeleteComponent.new(content_file:) %>
+  <% else %>
+      <% if total_files > Settings.file_upload.hierarchical_files_limit %>
+        <%= render Elements::Tables::TableComponent.new(id: 'content-table', label: 'Files', show_label: false) do |component| %>
+          <%# These headers are duplicated in app/components/works/edit/content_hierarchy_component.html.erb %>
+          <% component.with_headers([
+                                      { label: 'File Name' },
+                                      { label: 'Description', tooltip: t('content_files.edit.fields.description.tooltip_html'), style: 'width: 180px;' },
+                                      { label: 'Hide', tooltip: t('content_files.edit.fields.hide.tooltip_html'), style: 'width: 85px;' },
+                                      { label: 'Action', style: 'width: 85px;' }
+                                    ]) %>
+          <% content_files.each do |content_file| %>
+            <% component.with_row do |row_component| %>
+              <% row_component.with_cell do %>
+                <%= content_file.filepath %>
+              <% end %>
+              <% row_component.with_cell do %>
+                <%= render Works::Edit::ContentFileDescriptionComponent.new(content_file:) %>
+              <% end %>
+              <% row_component.with_cell do %>
+                <%= render Works::Edit::ContentFileHideComponent.new(content_file:) %>
+              <% end %>
+              <% row_component.with_cell do %>
+                <%= render Works::Edit::ContentFileDeleteComponent.new(content_file:) %>
+              <% end %>
+            <% end %>
           <% end %>
         <% end %>
+        <%= paginate content_files, params: { controller: 'contents', action: 'show', id: content.id } %>
+      <% else %>
+        <%= render Works::Edit::ContentHierarchyComponent.new(content_files:) %>
+        <%= paginate content_files, params: { controller: 'contents', action: 'show', id: content.id } %>
       <% end %>
-    <% end %>
-    <%= paginate content_files, params: { controller: 'contents', action: 'show', id: content.id } %>
-  <% else %>
-    <%= render Works::Edit::ContentHierarchyComponent.new(content_obj: content) %>
   <% end %>
 <% end %>

--- a/app/views/contents/_show.html.erb
+++ b/app/views/contents/_show.html.erb
@@ -1,10 +1,11 @@
 <%= turbo_frame_tag content, 'show' do %>
   <%= turbo_stream_from 'show', content %>
   <% content_files ||= content.content_files.path_order.page(1) %>
-  <% if total_files > Kaminari.config.default_per_page # show search bar with section header %>
+  <% if total_files > Kaminari.config.default_per_page # there is more than one page of results, show search bar with section header %>
       <div class="row">
         <div class="col-3">
           <%= render Edit::SectionHeaderComponent.new(title: t('works.edit.panes.files.list')) %>
+          <%= "(#{total_files})" %>
         </div>
         <div class="col-5 ms-auto">
           <%# Not using TextFieldComponent because field-container conflicts with input-group. %>
@@ -21,17 +22,17 @@
           <% end %>
         </div>
       </div>
-      <% if content_files.empty? %>
+      <% if content_files.empty? # user has executed a search but there were no results %>
         <p>There are no results matching "<%= search_term %>".</p>
       <% end %>
     <% else # just show section header %>
       <%= render Edit::SectionHeaderComponent.new(title: t('works.edit.panes.files.list')) %>
     <% end %>
 
-  <% if total_files.zero? %>
+  <% if total_files.zero? # there are no files at all in the object %>
     <p>Your files will appear here once they have been uploaded.</p>
-  <% else %>
-      <% if total_files > Settings.file_upload.hierarchical_files_limit %>
+  <% else # there are files in the object %>
+      <% if total_files > Settings.file_upload.hierarchical_files_limit # we have too many files, and the hierarchy would not work well, show flat list with paging %>
         <%= render Elements::Tables::TableComponent.new(id: 'content-table', label: 'Files', show_label: false) do |component| %>
           <%# These headers are duplicated in app/components/works/edit/content_hierarchy_component.html.erb %>
           <% component.with_headers([
@@ -58,9 +59,9 @@
           <% end %>
         <% end %>
         <%= paginate content_files, params: { controller: 'contents', action: 'show', id: content.id } %>
-      <% else %>
+      <% else # hierarchy will work fine with less than the configured number of files, show it with paging %>
         <%= render Works::Edit::ContentHierarchyComponent.new(content_files:) %>
-        <%= paginate content_files, params: { controller: 'contents', action: 'show', id: content.id } %>
+        <%#= paginate content_files, params: { controller: 'contents', action: 'show', id: content.id } %>
       <% end %>
   <% end %>
 <% end %>

--- a/app/views/contents/_show.html.erb
+++ b/app/views/contents/_show.html.erb
@@ -61,7 +61,6 @@
         <%= paginate content_files, params: { controller: 'contents', action: 'show', id: content.id } %>
       <% else # hierarchy will work fine with less than the configured number of files, show it with paging %>
         <%= render Works::Edit::ContentHierarchyComponent.new(content_files:) %>
-        <%#= paginate content_files, params: { controller: 'contents', action: 'show', id: content.id } %>
       <% end %>
   <% end %>
 <% end %>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'show', locals: { content: @content, content_files: @content_files } %>
+<%= render partial: 'show', locals: { content: @content, content_files: @content_files, search_term: @search_term, total_files: @total_files } %>

--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -53,7 +53,6 @@
           <%= render Elements::HorizontalRuleComponent.new(classes: 'my-3') %>
         <% end %>
 
-        <%= render Edit::SectionHeaderComponent.new(title: t('works.edit.panes.files.list')) %>
         <div id="content-files" class="pane-section">
           <%= turbo_frame_tag @content, 'show', src: content_path(@content), data: { controller: 'dropzone-files' }, class: 'dropzone-files' do %>
             <%= render Elements::SpinnerComponent.new %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,6 +45,9 @@ file_upload:
   max_filesize: 10000 # 10GB
   max_files: 25000
 
+search:
+  file_search_box_min: 50 # only show search bar above file list in edit page if there are more than this many files in the object
+
 datacite:
   prefix: '10.80343'
   host: api.test.datacite.org


### PR DESCRIPTION
HOLD for PO approval on QA

Fixes #402 - allow users to search for files by filename, only in the edit view and only when the object has more than a specified number of files (set to 50, but could be any value we want).  

The search works for both hierarchical file display and flat file display (i.e. will be shown for either view as long as the total number of files in the object is greater than the specified number, which is independent of both the page size and the limit that triggers the shift from hierarchical display with no paging to flat list with paging).

Note: the "x" to cancel the current search is not in this PR, it is also not in the collection deposits search view that is merged, and doesn't not appear to be in the component library used.

Here are the possible variants of file displays in this PR:

1. An object with no files - **shows a message** indicating there are no files (identical to current)

![Screenshot 2025-06-23 at 1 49 58 PM](https://github.com/user-attachments/assets/7cf97e90-7582-4f72-9d4a-ad784c16648a)

2. An object with fewer than the hierarchical file display limit (set to 1000) and fewer than the minimum needed for search bar (set to 50) - **shows a hierarchical display of files with no search box, no pagination** (identical to current).  Two screenshots below, one actually has hierarchy, the other doesn't, but it's the same view generating both under the hood.

![Screenshot 2025-06-23 at 1 51 15 PM](https://github.com/user-attachments/assets/b92c346a-5fa5-45fe-99a8-1b1a6cfe231b)

![Screenshot 2025-06-23 at 1 52 10 PM](https://github.com/user-attachments/assets/ca03e3c3-db93-4408-8d50-cdcced1454f3)

3. An object with fewer than the hierarchical file display limit (set to 1000) but more than the minimum needed for search bar (set to 50) - **shows a hierarchical display of files and includes a search box, no pagination**.    Two screenshots below, one is shown with no search term showing the full list, the second shows a search term applied (smaller list):

No search:
![Screenshot 2025-06-23 at 1 54 42 PM](https://github.com/user-attachments/assets/7a1af486-529a-48e4-bc2e-329d68a53d51)

With search:
![Screenshot 2025-06-23 at 1 55 46 PM](https://github.com/user-attachments/assets/f6f575c0-91c5-4d36-a8bd-d5862b720919)

4. An object with more than the hierarchical file display limit (set to 1000) and more than the minimum needed for search bar (set to 50) - **shows a flat display of files and includes a search box, with pagination**.    If the number of search results exceed the page size, paging will work as normal. Two screenshots below, one is shown with no search term showing the paginated list, the second shows a search term applied (smaller list):

No search, full list with paging:
![Screenshot 2025-06-23 at 1 57 35 PM](https://github.com/user-attachments/assets/3fb18606-9297-4c53-b635-770b2615d046)
![Screenshot 2025-06-23 at 1 58 16 PM](https://github.com/user-attachments/assets/2ec54bbb-4a38-454c-a4e8-8d84ca21c6d7)

With search, smaller list (no paging needed):
![Screenshot 2025-06-23 at 1 57 40 PM](https://github.com/user-attachments/assets/615afe81-82a2-47b4-9e17-f360423f3d7e)

5. Any object with more than the minimum needed for the search bar (set to 50), when the user searches for something that can't be found - show a message:

![Screenshot 2025-06-23 at 2 00 48 PM](https://github.com/user-attachments/assets/91c205d3-d4d3-45ad-8f47-a9ac5dc34d07)

6. _Edge case that is theoretically possible if you adjust the settings in an odd way_ - An object with more than the hierarchical file display limit but less than the minimum needed for search bar  - **shows a flat display of files with no search box, with pagination**.    We don't expect this to happen, given that the number that triggers a flat view with paging is likely to always be bigger than the number needed to show the search bar, but it would work as you'd expect it to.

To do:
- [x] tests
