### PR TITLE
skip tmp folder when running rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,7 @@ AllCops:
     - 'config/environments/*.rb'
     - 'db/**/*'
     - 'vendor/**/*'
+    - 'tmp/**/*'
 
 Layout/LineLength:
   Max: 120


### PR DESCRIPTION
If you upload a bunch of files with code in them to a test object in localhost, these files end up in a subfolder in the "tmp" folder.  You do not want rubocop thinking it is new code to run on.