### PR TITLE
show link on dashboard to open contact form with request a collection selected

### DIFF
--- a/app/components/structure/contact_form_modal_component.html.erb
+++ b/app/components/structure/contact_form_modal_component.html.erb
@@ -3,7 +3,7 @@
     <h1><%= contact_sdr %></h1>
   <% end %>
   <% component.with_body do %>
-    <%= tag.turbo_frame id: 'contact-form', src: new_contacts_path(modal: true), loading: do %>
+    <%= tag.turbo_frame id: 'contact-form', src: new_contacts_path(modal: true), loading:, data: { 'help-how-target': 'frame' } do %>
       <%= render Elements::SpinnerComponent.new %>
     <% end %>
   <% end %>

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -8,6 +8,7 @@ class ContactsController < ApplicationController
 
   def new
     @contact_form = ContactForm.new
+    @contact_form.help_how = 'Request access to another collection' if params[:show_collections] == 'true'
 
     render :new
   end

--- a/app/javascript/controllers/contact_controller.js
+++ b/app/javascript/controllers/contact_controller.js
@@ -1,14 +1,14 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['collectionSection']
+  static targets = ['collectionSection', 'helpHow']
 
   connect () {
-    this.toggleCollectionCheckboxes({ target: { value: '' } })
+    this.toggleCollectionCheckboxes()
   }
 
-  toggleCollectionCheckboxes (event) {
-    const disabled = event.target.value !== 'Request access to another collection'
+  toggleCollectionCheckboxes () {
+    const disabled = this.helpHowTarget.value !== 'Request access to another collection'
     this.collectionSectionTarget.classList.toggle('d-none', disabled)
     this.collectionSectionTarget.querySelectorAll('input').forEach(input => {
       input.disabled = disabled

--- a/app/javascript/controllers/help_how_controller.js
+++ b/app/javascript/controllers/help_how_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['frame']
+
+  connect () {
+    this.origSource = this.frameTarget.src
+    // Dynamically change the help turbo-frame source to show "Request access to another collection" by default.
+    this.element.addEventListener('show.bs.modal', event => {
+      const button = event.relatedTarget
+      if (!button) return
+      const showCollections = button.getAttribute('data-bs-showcollections') === 'true'
+      if (showCollections) {
+        this.frameTarget.src = this.origSource + '&show_collections=true'
+      } else {
+        this.frameTarget.src = this.origSource
+      }
+    })
+  }
+}

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -13,6 +13,7 @@
                                                      container_classes: 'mb-3', required: true) %>
 
   <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :help_how,
+                                                       input_data: { 'contact-target': 'helpHow' },
                                                        label: 'How can we help you? *', options: ContactForm::HELP_HOW_CHOICES,
                                                        container_classes: 'mb-3', required: true,
                                                        data: { action: 'change->contact#toggleCollectionCheckboxes' }) %>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -46,3 +46,13 @@
     <%= render Elements::ButtonLinkComponent.new(link: new_work_path(collection_druid: collection.druid), label: 'Deposit to this collection', variant: :primary, classes: 'mt-4') %>
   </div>
 <% end %>
+
+<div class="mb-5">
+    <%= link_to('Looking for a different collection?', '#',
+                data: {
+                  bs_toggle: 'modal',
+                  bs_target: '#contact-form-modal',
+                  bs_showCollections: 'true'
+                }) %>
+</a>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
     <%= stylesheet_link_tag 'component_library_overrides' %>
     <%= javascript_importmap_tags %>
   </head>
-  <body>
+  <body data-controller="help-how">
     <% if Settings.google_analytics.enabled %>
       <!-- Google Tag Manager (noscript) -->
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P6SX5MBG"


### PR DESCRIPTION
Fixes #1352

Alternative implementation in #1530 

Borrow how it's done from H2 (mostly)

New link at bottom of dashboard

![Screenshot 2025-06-25 at 12 10 22 PM](https://github.com/user-attachments/assets/513d4247-9543-418a-9261-f34dbd7df282)

when clicked, opens  modal with appropriate option pre-selected

![Screenshot 2025-06-25 at 12 09 23 PM](https://github.com/user-attachments/assets/c7e410bc-6747-41e1-b24e-bfbdc774a63a)

