### PR TITLE
use two modals instead of stimulus to trigger request collection form

### DIFF
--- a/app/components/structure/contact_form_modal_component.html.erb
+++ b/app/components/structure/contact_form_modal_component.html.erb
@@ -1,9 +1,9 @@
-<%= render Elements::ModalComponent.new(id: 'contact-form-modal') do |component| %>
+<%= render Elements::ModalComponent.new(id: form_id) do |component| %>
   <% component.with_header do %>
     <h1><%= contact_sdr %></h1>
   <% end %>
   <% component.with_body do %>
-    <%= tag.turbo_frame id: 'contact-form', src: new_contacts_path(modal: true), loading: do %>
+    <%= tag.turbo_frame id: 'contact-form', src: path, loading: do %>
       <%= render Elements::SpinnerComponent.new %>
     <% end %>
   <% end %>

--- a/app/components/structure/contact_form_modal_component.rb
+++ b/app/components/structure/contact_form_modal_component.rb
@@ -3,6 +3,14 @@
 module Structure
   # Component for rendering a contact form modal.
   class ContactFormModalComponent < ApplicationComponent
+    def initialize(form_id:, path:)
+      @form_id = form_id
+      @path = path
+      super()
+    end
+
+    attr_reader :form_id, :path
+
     def contact_sdr
       I18n.t('contact_sdr')
     end

--- a/app/components/structure/header_component.html.erb
+++ b/app/components/structure/header_component.html.erb
@@ -73,4 +73,4 @@
 <%= render Structure::TermsOfDepositModalComponent.new %>
 <%# there are two contact us modals; the first is the regular one; the second pre-selects requesting a collection %>
 <%= render Structure::ContactFormModalComponent.new(form_id: 'contact-form-modal', path: new_contacts_path(modal: true)) %>
-<%= render Structure::ContactFormModalComponent.new(form_id: 'request-collection-form-modal', path: request_collection_contacts_path(modal: true)) %>
+<%= render Structure::ContactFormModalComponent.new(form_id: 'request-collection-form-modal', path: new_contacts_path(help_how: 'Request access to another collection', modal: true)) %>

--- a/app/components/structure/header_component.html.erb
+++ b/app/components/structure/header_component.html.erb
@@ -71,4 +71,6 @@
   </div>
 </header>
 <%= render Structure::TermsOfDepositModalComponent.new %>
-<%= render Structure::ContactFormModalComponent.new %>
+<%# there are two contact us modals; the first is the regular one; the second pre-selects requesting a collection %>
+<%= render Structure::ContactFormModalComponent.new(form_id: 'contact-form-modal', path: new_contacts_path(modal: true)) %>
+<%= render Structure::ContactFormModalComponent.new(form_id: 'request-collection-form-modal', path: request_collection_contacts_path(modal: true)) %>

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -6,8 +6,17 @@ class ContactsController < ApplicationController
 
   before_action :set_contact_form_conditions
 
+  # the regular contact form
   def new
     @contact_form = ContactForm.new
+
+    render :new
+  end
+
+  # the contact form for a user looking for a different collection
+  def request_collection
+    @contact_form = ContactForm.new
+    @contact_form.help_how = 'Request access to another collection'
 
     render :new
   end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -6,17 +6,9 @@ class ContactsController < ApplicationController
 
   before_action :set_contact_form_conditions
 
-  # the regular contact form
   def new
     @contact_form = ContactForm.new
-
-    render :new
-  end
-
-  # the contact form for a user looking for a different collection
-  def request_collection
-    @contact_form = ContactForm.new
-    @contact_form.help_how = 'Request access to another collection'
+    @contact_form.help_how = params[:help_how]
 
     render :new
   end

--- a/app/javascript/controllers/contact_controller.js
+++ b/app/javascript/controllers/contact_controller.js
@@ -1,14 +1,14 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['collectionSection']
+  static targets = ['collectionSection', 'helpHow']
 
   connect () {
-    this.toggleCollectionCheckboxes({ target: { value: '' } })
+    this.toggleCollectionCheckboxes()
   }
 
-  toggleCollectionCheckboxes (event) {
-    const disabled = event.target.value !== 'Request access to another collection'
+  toggleCollectionCheckboxes () {
+    const disabled = this.helpHowTarget.value !== 'Request access to another collection'
     this.collectionSectionTarget.classList.toggle('d-none', disabled)
     this.collectionSectionTarget.querySelectorAll('input').forEach(input => {
       input.disabled = disabled

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -13,6 +13,7 @@
                                                      container_classes: 'mb-3', required: true) %>
 
   <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :help_how,
+                                                       input_data: { 'contact-target': 'helpHow' },
                                                        label: 'How can we help you? *', options: ContactForm::HELP_HOW_CHOICES,
                                                        container_classes: 'mb-3', required: true,
                                                        data: { action: 'change->contact#toggleCollectionCheckboxes' }) %>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -46,3 +46,12 @@
     <%= render Elements::ButtonLinkComponent.new(link: new_work_path(collection_druid: collection.druid), label: 'Deposit to this collection', variant: :primary, classes: 'mt-4') %>
   </div>
 <% end %>
+
+<div class="mb-5">
+    <%= link_to('Looking for a different collection?', '#',
+                data: {
+                  bs_toggle: 'modal',
+                  bs_target: '#request-collection-form-modal'
+                }) %>
+</a>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,11 +89,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   resource :terms, only: :show
 
-  resource :contacts, only: %i[new create] do
-    member do
-      get 'request_collection', to: 'contacts#request_collection'
-    end
-  end
+  resource :contacts, only: %i[new create]
 
   get 'accounts/search', to: 'accounts#search'
   get 'accounts/search_user', to: 'accounts#search_user'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,7 +89,11 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   resource :terms, only: :show
 
-  resource :contacts, only: %i[new create]
+  resource :contacts, only: %i[new create] do
+    member do
+      get 'request_collection', to: 'contacts#request_collection'
+    end
+  end
 
   get 'accounts/search', to: 'accounts#search'
   get 'accounts/search_user', to: 'accounts#search_user'


### PR DESCRIPTION
Alternative implementation of #1528 which uses two modals instead of stimulus to show the two possible contact us forms

Fixes #1352