### PR TITLE
show tooltips on click for all browsers

### DIFF
--- a/app/components/elements/tooltip_component.rb
+++ b/app/components/elements/tooltip_component.rb
@@ -22,7 +22,7 @@ module Elements
         bs_html: true,
         bs_toggle: 'tooltip',
         bs_title: tooltip,
-        bs_trigger: 'focus',
+        bs_trigger: 'click',
         tooltips_target: 'icon'
       }.tap do |data|
         if Settings.ahoy.tooltip


### PR DESCRIPTION
Fixes #1519  - `focus` does not appear to work in safari, but `click` does, and continues to work as expected in Chrome and Firefox.

Note that the current behavior in Firefox and Chrome is that you need to click to see the tooltip.  If this is what we want, then this change will make it work that way in Safari too.

If instead we want it to appear on hover, we can simply use the `hover` event instead of `click` here, which will change it in all browsers.