### PR TITLE
import last published date from h2

### DIFF
--- a/app/importers/work_importer.rb
+++ b/app/importers/work_importer.rb
@@ -26,6 +26,7 @@ class WorkImporter
 
   attr_reader :work_hash, :cocina_object
 
+  # rubocop:disable Metrics/AbcSize
   def create_work
     ::Work.find_or_create_by!(druid:) do |work|
       work.user = user
@@ -33,8 +34,10 @@ class WorkImporter
       work.object_updated_at = cocina_object.modified
       work.version = Cocina::Parser.version_for(cocina_object:)
       work.collection = collection
+      work.last_deposited_at = work_hash['head']['published_at']
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   def collection
     @collection ||= Collection.find_by!(druid: Cocina::Parser.collection_druid_for(cocina_object:))

--- a/spec/importers/work_importer_spec.rb
+++ b/spec/importers/work_importer_spec.rb
@@ -48,6 +48,31 @@ RSpec.describe WorkImporter do
         allow_custom_rights_statement: false,
         provided_custom_rights_statement: nil,
         custom_rights_statement_custom_instructions: nil
+      },
+      head: {
+        id: 4386,
+        version: 1,
+        title: 'My Icon Collection for Green Cardamom Green Pepper Integration Test',
+        work_type: 'image',
+        created_edtf: nil,
+        abstract: 'An abstract for Green Cardamom Green Pepper Integration Test logo',
+        citation: 'Scully, D. (2023). My Icon Collection for Green Cardamom Green Pepper',
+        access: 'world',
+        embargo_dat: nil,
+        license: 'CC0-1.0',
+        created_at: '2023-09-28T19:17:35.582Z',
+        updated_at: '2024-05-13T16:14:55.160Z',
+        state: 'deposited',
+        published_edtf: nil,
+        subtype: [],
+        work_id: 4382,
+        version_description: nil,
+        published_at: '2023-09-28T19:17:49.092Z',
+        upload_type: 'browser',
+        globus_endpoint: 'integration_test/work388/version2',
+        globus_origin: nil,
+        custom_rights: nil,
+        user_version: 1
       }
     }.deep_stringify_keys
   end
@@ -70,7 +95,9 @@ RSpec.describe WorkImporter do
       expect(work.user).to eq(user)
       expect(work.collection).to eq(collection)
       expect(work.title).to eq(title_fixture)
-      expect(work.version).to eq(2)
+      expect(work.version).to eq(2) # NOTE: this comes from cocina, not the work_version from H2
+      expect(work.last_deposited_at.class).to be ActiveSupport::TimeWithZone
+      expect(work.last_deposited_at).to eq('2023-09-28T19:17:49.092Z')
 
       expect(tags_client).to have_received(:create).with(tags: ['Project : H3'])
     end


### PR DESCRIPTION
Fixes #1520 

The wiki was updated here to add `:head` so we can export the head version into the work.json file:

```
works_json = works.map {|work| work.as_json(include: [:owner, :collection, :head])}
```

This export was tested with a single work on H2 QA to make sure it works.