### PR TITLE
allow first value to be different weight from label

### DIFF
--- a/app/components/elements/tables/row_component.html.erb
+++ b/app/components/elements/tables/row_component.html.erb
@@ -5,6 +5,11 @@
       <%= render Elements::TooltipComponent.new(target_label: label, tooltip:) %>
     </th>
   <% end %>
+  <% if first_value.present? %>
+    <td class="col-3" scope="row">
+      <%= first_value %>
+    </td>
+  <% end %>
   <% values.each do |value| %>
     <td><%= value %></td>
   <% end %>

--- a/app/components/elements/tables/row_component.rb
+++ b/app/components/elements/tables/row_component.rb
@@ -6,16 +6,17 @@ module Elements
     class RowComponent < ApplicationComponent
       renders_many :cells
 
-      def initialize(label: nil, values: [], id: nil, tooltip: nil)
+      def initialize(label: nil, first_value: nil, values: [], id: nil, tooltip: nil)
         @label = label
         # Provide either values or cells (e.g. for content files).
         @values = values
+        @first_value = first_value
         @id = id
         @tooltip = tooltip
         super()
       end
 
-      attr_reader :label, :values, :id, :tooltip
+      attr_reader :label, :values, :id, :tooltip, :first_value
 
       def empty_cell?
         label.present? && values.empty? && !cells?

--- a/app/components/elements/tables/row_component.rb
+++ b/app/components/elements/tables/row_component.rb
@@ -7,12 +7,17 @@ module Elements
       renders_many :cells
 
       def initialize(label: nil, first_value: nil, values: [], id: nil, tooltip: nil)
+        # Provide either label or first_value but not both; these are rendered in the first column
+        # label renders with <th> (bold), first_value is a normal <td>
         @label = label
+        @first_value = first_value
         # Provide either values or cells (e.g. for content files).
         @values = values
-        @first_value = first_value
         @id = id
         @tooltip = tooltip
+
+        raise ArgumentError if label.present? && first_value.present?
+
         super()
       end
 

--- a/app/views/works/history.html.erb
+++ b/app/views/works/history.html.erb
@@ -6,7 +6,7 @@
     <% component.with_header(label: 'Last modified') %>
     <% component.with_header(label: 'Description of changes') %>
     <% @events.each do |event| %>
-      <% component.with_row(label: event.label, values: [event.who, event.timestamp, event.description]) %>
+      <% component.with_row(first_value: event.label, values: [event.who, event.timestamp, event.description]) %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Fixes #1541 

Note: this component is used throughout the page for all the tables were we have a `label : value` approach, e.g. 

<img width="652" alt="Screenshot 2025-06-27 at 11 53 54 AM" src="https://github.com/user-attachments/assets/a64a2dbb-3bf4-40f9-97eb-03a85c6983fa" />

So this gives us some flexibility to allow the history table (this view is shared between works and collections) to indicate that first value is not a label, but is instead a normal value that should not be styled as a table header.

History looks like this now, all others remain the same.

<img width="1217" alt="Screenshot 2025-06-27 at 11 51 43 AM" src="https://github.com/user-attachments/assets/35767052-52db-4f14-8289-cf6d219dce37" />

<img width="652" alt="Screenshot 2025-06-27 at 11 53 54 AM" src="https://github.com/user-attachments/assets/28237059-bc50-4164-9b9a-d6e3a09dd3d7" />





