### PR TITLE
adjust help text for work report

### DIFF
--- a/app/components/elements/forms/help_text_component.html.erb
+++ b/app/components/elements/forms/help_text_component.html.erb
@@ -1,3 +1,3 @@
 <div>
-    <%= tag.p id:, class: 'form-text' do %><%= help_text %><% end %>
+    <%= tag.p id:, class: 'form-text' do %><%= help_text || content %><% end %>
 </div>

--- a/app/components/elements/forms/help_text_component.rb
+++ b/app/components/elements/forms/help_text_component.rb
@@ -5,7 +5,9 @@ module Elements
   module Forms
     # Component for rendering help text for form fields.
     class HelpTextComponent < ApplicationComponent
-      def initialize(help_text:, id:)
+      # this component can take plain text via 'help_text' or a block (which can contain html)
+      # it will render the help_text if provided, else it will render the block content
+      def initialize(id:, help_text: nil)
         @help_text = help_text
         @id = id
         super()
@@ -14,7 +16,7 @@ module Elements
       attr_reader :help_text, :id
 
       def render?
-        help_text.present?
+        help_text.present? || content.present?
       end
     end
   end

--- a/app/views/admin/work_report/new.html.erb
+++ b/app/views/admin/work_report/new.html.erb
@@ -32,11 +32,15 @@
     to
     <%= render Elements::Forms::DatepickerComponent.new(form:, field_name: :last_deposited_end, label: 'Date last deposited end', hidden_label: true, container_classes: 'col-md-5 ms-2') %>
   </div>
-  <%= render Elements::Forms::LabelComponent.new(form:, field_name: :collection_ids, label_text: 'Collection', classes: 'mb-2') %>
+  <%= render Elements::Forms::LabelComponent.new(form:, field_name: :collection_ids, label_text: 'Collection(s)', classes: 'mb-2') %>
+  <%= render Elements::Forms::HelpTextComponent.new(id: 'collection-ids-help') do %>
+    <ul>
+      <li>To include all collections in the report, do not make any selections from this list.</li>
+      <li>To select multiple collections, hold down the command button for Mac, or hold down the control button for Windows.</li>
+    </ul>
+  <% end %>
   <div class='mb-4'>
   <%= form.collection_select :collection_ids, @collections, :id, :title, { multiple: true }, class: 'form-select' %>
-  <%= render Elements::Forms::HelpTextComponent.new(help_text: 'For Mac: Hold down the command button to select multiple collections.
-                                                                For Windows: Hold down the control button to select multiple collections.', id: 'collection-ids-help') %>
   </div>
   <div class="row">
     <div class="col-md-6">


### PR DESCRIPTION
Fixes #1551 

Note: in order to style this as shown and use the existing component, have to use `html_safe`.  Since we control the use of this component, I think this is fine.