### PR TITLE
Change method for removing invalid indicators.

### DIFF
--- a/app/components/edit/tab_form/tab_list_component.html.erb
+++ b/app/components/edit/tab_form/tab_list_component.html.erb
@@ -11,7 +11,7 @@
       <% before_form_panes.each do |pane| %>
         <%= pane %>
       <% end %>
-      <%= form_with(model:, id: form_id, data: { action: 'change->ahoy-form-changes#changed change->unsaved-changes#changed' }) do |form| %>
+      <%= form_with(model:, id: form_id, data: { action: 'change->ahoy-form-changes#changed change->unsaved-changes#changed change->tab-error#changed' }) do |form| %>
         <% hidden_fields.each do |field| %>
           <%= form.hidden_field field %>
         <% end %>

--- a/app/javascript/controllers/tab_error_controller.js
+++ b/app/javascript/controllers/tab_error_controller.js
@@ -12,24 +12,6 @@ export default class extends Controller {
       const paneElement = this.paneTargets[index]
       const invalidElements = paneElement.querySelectorAll('.is-invalid')
       if (invalidElements.length > 0) {
-        invalidElements.forEach(invalidElement => {
-          invalidElement.addEventListener('change', event => {
-            // Mark the invalid target that was changed as no longer invalid, *and* mark any other invalid field
-            // with the same ID as no longer invalid. We think this is both harmless and it marks as valid the
-            // first name and last name fields in the contributor form, which are duplicated due to their being
-            // names in both the ORCID section and the non-ORCID section.
-            const invalidFieldElements = paneElement.querySelectorAll(`#${event.currentTarget.id}`)
-            if (invalidFieldElements) invalidFieldElements.forEach(element => element.classList.remove('is-invalid'))
-
-            // Remove the invalid feedback divs corresponding to invalid fields that are changed.
-            const invalidFeedbackElements = paneElement.querySelectorAll(`#${event.currentTarget.id}_error`)
-            if (invalidFeedbackElements) invalidFeedbackElements.forEach(element => element.remove())
-
-            // If the current pane no longer has fields marked as invalid, mark the tab as no longer
-            // being invalid.
-            if (!paneElement.querySelector('.is-invalid')) tabEl.classList.remove('is-invalid')
-          })
-        })
         tabEl.classList.add('is-invalid')
         const currentLabelledBy = tabEl.getAttribute('aria-labelledby')
         const newLabelledBy = `${currentLabelledBy} ${this.invalidDescriptionTarget.id}`
@@ -42,6 +24,27 @@ export default class extends Controller {
     if (firstErrorTabEl) {
       bootstrap.Tab.getOrCreateInstance(firstErrorTabEl).show() // eslint-disable-line no-undef
     }
+  }
+
+  changed (event) {
+    const target = event.target
+    if (!target.classList.contains('is-invalid')) return
+    const paneElement = target.closest('.tab-pane')
+    // Mark the invalid target that was changed as no longer invalid, *and* mark any other invalid field
+    // with the same ID as no longer invalid. We think this is both harmless and it marks as valid the
+    // first name and last name fields in the contributor form, which are duplicated due to their being
+    // names in both the ORCID section and the non-ORCID section.
+    const invalidFieldElements = paneElement.querySelectorAll(`#${target.id}`)
+    if (invalidFieldElements) invalidFieldElements.forEach(element => element.classList.remove('is-invalid'))
+
+    // Remove the invalid feedback divs corresponding to invalid fields that are changed.
+    const invalidFeedbackElements = paneElement.querySelectorAll(`#${target.id}_error`)
+    if (invalidFeedbackElements) invalidFeedbackElements.forEach(element => element.remove())
+
+    // If the current pane no longer has fields marked as invalid, mark the tab as no longer
+    // being invalid.
+    const tabEl = this.tabElementFromId(paneElement.id.replace('-pane', ''))
+    if (!paneElement.querySelector('.is-invalid')) tabEl.classList.remove('is-invalid')
   }
 
   // Clear all invalid feedbacks on a pane and removes invalid from the tab.

--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -142,7 +142,13 @@
         <% if @work_presenter && !@work_presenter.first_draft? %>
           <%= render Elements::AlertComponent.new(variant: :info, value: t('works.edit.panes.deposit.version_text')) %>
           <div class="pane-section">
-            <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :whats_changing, label: t('works.edit.fields.whats_changing.label'), tooltip: t('works.edit.fields.whats_changing.tooltip_html'), maxlength: 100) %>
+            <%#
+              When what's changing textarea is invalid and the user provides a value and then clicks Deposit / Save as draft,
+              the change event is triggered first. The changes made to the DOM cause the form submit to be blocked.
+              By calling tab-error#changed on the input event, the DOM is updated sooner than the change event,
+              allowing the form to be submitted without blocking.
+            %>
+            <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :whats_changing, label: t('works.edit.fields.whats_changing.label'), tooltip: t('works.edit.fields.whats_changing.tooltip_html'), maxlength: 100, data: { action: 'input->tab-error#changed' }) %>
           </div>
         <% else %>
           <%# This is a dummy value that is needed for validation, but won't be used for the version description. %>

--- a/spec/system/create_work_deposit_spec.rb
+++ b/spec/system/create_work_deposit_spec.rb
@@ -366,9 +366,6 @@ RSpec.describe 'Create a work deposit' do
 
       fill_in('What\'s changing?', with: 'Hiding a file.')
 
-      # Can be removed once https://github.com/sul-dlss/hungry-hungry-hippo/issues/1618 is fixed.
-      find_field('What\'s changing?').send_keys(:tab)
-
       click_link_or_button('Deposit', class: 'btn-primary')
 
       # Waiting page may be too fast to catch so not testing.


### PR DESCRIPTION
closes #1618

The problem is that the change event handler was interfering with the form submission. This uses a different event for updating the invalid indicators.