### PR TITLE
Indicate there are changes if they are only file changes

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -298,7 +298,11 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def invalid_for_whats_changing_only?
-    @work_form.errors.one? && @work_form.errors.first.attribute == :whats_changing
+    @work_form.errors.one? && @work_form.errors.first.attribute == :whats_changing && !attached_files_changed?
+  end
+
+  def attached_files_changed?
+    @content.content_files.any? { |content_file| content_file.file_type == 'attached' }
   end
 
   def handle_no_changes

--- a/spec/system/edit_work_spec.rb
+++ b/spec/system/edit_work_spec.rb
@@ -281,6 +281,29 @@ RSpec.describe 'Edit a work' do
     end
   end
 
+  context 'when files have changed, not providing whats changing, and saving as draft' do
+    let(:version_status) { build(:openable_version_status, version: cocina_object.version, version_description: nil) }
+
+    before do
+      allow(RoundtripSupport).to receive(:changed?).and_return(true)
+    end
+
+    it 'notifies user the user that whats changing is required' do
+      visit edit_work_path(druid)
+
+      expect(page).to have_css('h1', text: title_fixture)
+
+      # Add a file
+      find('.dropzone').drop('spec/fixtures/files/hippo.png')
+
+      expect(page).to have_css('table#content-table td', text: 'hippo.png')
+
+      click_link_or_button('Save as draft')
+
+      expect(page).to have_css('.alert-danger', text: 'Required fields have not been filled out.')
+    end
+  end
+
   context 'when nothing changed and depositing' do
     let(:version_status) { build(:openable_version_status, version: cocina_object.version) }
 


### PR DESCRIPTION
Fixes #1629 

This fixes the bug that if the only changes to a work on deposit or save draft is uploading files but the "what's changing" isn't filled out the form indicates as such instead of "no changes"