### PR TITLE
Remove left/right padding from icon buttons

### DIFF
--- a/app/components/elements/delete_button_component.rb
+++ b/app/components/elements/delete_button_component.rb
@@ -4,7 +4,7 @@ module Elements
   # Component for a delete button
   class DeleteButtonComponent < IconButtonComponent
     def initialize(label: 'Clear', **args)
-      super(icon: :delete, label:, **args)
+      super(icon: :delete, label:, classes: Array(classes) + ['px-0'], **args)
     end
   end
 end


### PR DESCRIPTION
Fixes #335

This commit effectively reduces the amount of horizontal padding between icon buttons and adjacent fields, having the desired effect of bringing the field delete button and the text field for repeatable components (e.g., contact email) closer. It also removes the horizontal padding of the move up and move down buttons, which I checked out in the work edit screen for authors, and it does not meaningfully impact that part of the UI as the delete and move buttons are arranged vertically there.

<img width="1178" height="434" alt="Image" src="https://github.com/user-attachments/assets/049f399d-138f-4fec-aadc-360b5bfce32e" />
