### PR TITLE
Add contributor affiliation updates to work form

### DIFF
--- a/app/cocina_builders/contributor_affiliation_cocina_builder.rb
+++ b/app/cocina_builders/contributor_affiliation_cocina_builder.rb
@@ -16,15 +16,14 @@ class ContributorAffiliationCocinaBuilder
 
   def call
     {
-      type: 'affiliation',
       structuredValue: [
-        generate_descriptive_value,
+        institution_params,
         ({ value: department } if department.present?)
       ].compact
     }
   end
 
-  def generate_descriptive_value
+  def institution_params
     {
       value: institution,
       identifier: [

--- a/app/cocina_builders/person_contributor_cocina_builder.rb
+++ b/app/cocina_builders/person_contributor_cocina_builder.rb
@@ -35,7 +35,7 @@ class PersonContributorCocinaBuilder
       role: role_params,
       identifier: identifier_params,
       status: ('primary' if primary),
-      note: note_params
+      affiliation: affiliation_params
     }.compact
   end
 
@@ -50,15 +50,15 @@ class PersonContributorCocinaBuilder
     [cocina_role]
   end
 
-  def note_params
+  def affiliation_params
     return if affiliations.empty?
 
     affiliations.map do |affiliation|
-      ContributorAffiliationCocinaBuilder.call(**affiliation_params(affiliation))
-    end
+      ContributorAffiliationCocinaBuilder.call(**form_affiliation_params(affiliation))
+    end.presence
   end
 
-  def affiliation_params(affiliation)
+  def form_affiliation_params(affiliation)
     return affiliation if affiliation.is_a?(Hash)
 
     # return the attributes as a hash with symbolized keys if it's an AffiliationForm object

--- a/app/components/edit/affiliation_component.html.erb
+++ b/app/components/edit/affiliation_component.html.erb
@@ -1,0 +1,22 @@
+<div class="row mb-3">
+  <div class="col">
+    <%= tag.div data: { controller: 'autocomplete', autocomplete_url_value: affiliations_search_path, autocomplete_query_param_value: 'query', autocomplete_min_length_value: '3' } do %>
+      <%= render Elements::Forms::TextFieldComponent.new(form:,
+                                                         field_name: :institution,
+                                                         label: helpers.t('works.edit.fields.affiliations.institution.label'),
+                                                         tooltip: helpers.t('works.edit.fields.affiliations.institution.tooltip_html'),
+                                                         input_data: { autocomplete_target: 'input' }) %>
+      <ul class="list-group" data-autocomplete-target="results" style="overflow-y: scroll; max-height: 425px;"></ul>
+      <%= form.hidden_field :uri, { data: { autocomplete_target: 'hidden' } } %>
+    <% end %>
+  </div>
+  <div class="col">
+    <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :department, label: helpers.t('works.edit.fields.affiliations.department.label'), tooltip: helpers.t('works.edit.fields.affiliations.department.tooltip_html'), container_classes: 'mb-4') %>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <div data-controller="invalid-feedback" data-invalid-feedback-tab-error-outlet=".tab-error" data-invalid-feedback-tab-value="affiliations"></div>
+    <%= render Elements::Forms::InvalidFeedbackComponent.new(form:, field_name: :uri, data: { invalid_feedback_target: 'feedback' }, classes: 'mb-2') %>
+  </div>
+</div>

--- a/app/components/edit/affiliation_component.rb
+++ b/app/components/edit/affiliation_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Edit
+  # Component for editing contributor affiliation
+  class AffiliationComponent < ApplicationComponent
+    def initialize(form:)
+      @form = form
+      super()
+    end
+
+    attr_reader :form
+  end
+end

--- a/app/components/edit/contributor_component.html.erb
+++ b/app/components/edit/contributor_component.html.erb
@@ -105,6 +105,13 @@
           </div>
         </div>
       </div>
+
+      <% if Settings.affiliations.enabled %>
+        <%= render Elements::HorizontalRuleComponent.new %>
+        <div class="mb-3 p-3">
+          <%= render NestedComponentPresenter.for(form:, field_name: :affiliations, model_class: AffiliationForm, form_component: Edit::AffiliationComponent, bordered: false, fieldset_classes: 'pane-section') %>
+        </div>
+      <% end %>
     <% end %>
 
     <%# Contributor organization name field %>

--- a/app/components/elements/forms/repeatable_nested_component.html.erb
+++ b/app/components/elements/forms/repeatable_nested_component.html.erb
@@ -28,7 +28,7 @@
     </template>
     <%= form.fields_for field_name do |nested_form| %>
       <%# Note that this div is duplicated above. If making a change here, also make the change above. %>
-      <%= tag.div(class: row_classes, data: { index: nested_form.options[:child_index], nested_form_target: 'instance', nested_form_reorder_target: 'instance' }) do %>
+      <%= tag.div(class: row_classes, data: { index: nested_form.options[:child_index], nested_form_target: 'instance' }) do %>
         <% form_component_instance = form_component.new(form: nested_form) %>
         <%= tag.div(class: column_classes) do %>
           <%= render form_component_instance %>

--- a/app/components/show/contributors_show_component.html.erb
+++ b/app/components/show/contributors_show_component.html.erb
@@ -3,7 +3,8 @@
   <% component.with_headers([
                               { label: 'Contributor' },
                               { label: 'ORCID' },
-                              { label: 'Role' }
+                              { label: 'Role' },
+                              { label: 'Affiliation' }
                             ]) %>
   <% contributors.each do |contributor| %>
     <% component.with_row(values: values_for(contributor)) %>

--- a/app/components/show/contributors_show_component.rb
+++ b/app/components/show/contributors_show_component.rb
@@ -16,7 +16,8 @@ module Show
       values = [
         contributor_name(contributor).presence,
         orcid_link(contributor),
-        contributor_role_label(contributor)
+        contributor_role_label(contributor),
+        contributor_affiliations(contributor)
       ]
 
       return [] if values.all?(&:blank?)
@@ -57,6 +58,12 @@ module Show
       return contributor.person_role if contributor.role_type == 'person'
 
       contributor.organization_role
+    end
+
+    def contributor_affiliations(contributor)
+      return if contributor.affiliations.empty?
+
+      contributor.affiliations.filter_map(&:institution).join(', ')
     end
   end
 end

--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Looks up data for organizations from the ROR service
+class AffiliationsController < ApplicationController
+  skip_verify_authorized only: %i[search]
+
+  def search
+    @organizations = lookup_organization
+    return head :not_found if @organizations.empty?
+
+    render layout: false
+  end
+
+  private
+
+  def lookup_organization
+    RorService.call(search: params[:query])
+  end
+end

--- a/app/forms/affiliation_form.rb
+++ b/app/forms/affiliation_form.rb
@@ -5,14 +5,22 @@
 # It includes fields for the institution, department, and ROR identifier
 class AffiliationForm < ApplicationForm
   attribute :institution, :string
-  validates :institution, presence: true
+  validates :institution, presence: true, if: -> { department.present? }
+  validate :validate_institution
 
   attribute :uri, :string
-  validates :uri, presence: true, if: ->(affiliation) { affiliation.institution.present? }
-
   attribute :department, :string
 
   def empty?
-    institution.blank? && uri.blank?
+    institution.blank? && uri.blank? && department.blank?
+  end
+
+  def validate_institution
+    # uri must be present if institution is present.
+    # However, error should be reported for institution, not uri.
+    # This happens when the user types in the autocomplete field but does not select an item.
+    return unless institution.present? && uri.blank?
+
+    errors.add(:institution, 'must be selected from the list')
   end
 end

--- a/app/javascript/controllers/nested_form_reorder_controller.js
+++ b/app/javascript/controllers/nested_form_reorder_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['instance', 'container']
+  static targets = ['container']
 
   connect () {
     this.adjustActions()
@@ -17,9 +17,10 @@ export default class extends Controller {
 
   adjustActions () {
     if (!this.hasContainerTarget) return
-    this.containerTarget.querySelectorAll('.form-instance').forEach((instanceEl, index) => {
+    const instanceEls = this.containerTarget.querySelectorAll(':scope > .form-instance')
+    instanceEls.forEach((instanceEl, index) => {
       instanceEl.querySelectorAll('.move-up').forEach((btnEl) => btnEl.classList.toggle('d-none', index === 0))
-      instanceEl.querySelectorAll('.move-down').forEach((btnEl) => btnEl.classList.toggle('d-none', index === this.instanceTargets.length - 1))
+      instanceEl.querySelectorAll('.move-down').forEach((btnEl) => btnEl.classList.toggle('d-none', index === instanceEls.length - 1))
     })
   }
 

--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -124,11 +124,16 @@ class DepositCollectionJob < ApplicationJob
   end
 
   def assign_person(contributor_form:)
-    collection.contributors.create!(first_name: contributor_form.first_name,
-                                    last_name: contributor_form.last_name,
-                                    role: contributor_form.person_role,
-                                    role_type: 'person',
-                                    orcid: contributor_form.with_orcid ? contributor_form.orcid : nil)
+    contributor = collection.contributors.create!(first_name: contributor_form.first_name,
+                                                  last_name: contributor_form.last_name,
+                                                  role: contributor_form.person_role,
+                                                  role_type: 'person',
+                                                  orcid: contributor_form.with_orcid ? contributor_form.orcid : nil)
+    contributor_form.affiliations.each do |affiliation_form|
+      contributor.affiliations.create!(institution: affiliation_form.institution,
+                                       uri: affiliation_form.uri,
+                                       department: affiliation_form.department)
+    end
   end
 
   def assign_organization(contributor_form:)

--- a/app/mappers/cocina/work_structural_mapper.rb
+++ b/app/mappers/cocina/work_structural_mapper.rb
@@ -12,7 +12,7 @@ module Cocina
 
     # @param [WorkForm] work_form
     # @param [Content] content
-    # @param [boolean] whether the object type is document
+    # @param [boolean] document whether the object type is document
     def initialize(work_form:, content:, document:)
       @work_form = work_form
       @content = content

--- a/app/mappers/form/work_contributors_mapper.rb
+++ b/app/mappers/form/work_contributors_mapper.rb
@@ -41,14 +41,14 @@ module Form
       attr_reader :contributor
 
       def affiliations
-        contributor.note.select { |note| note.type == 'affiliation' }.map do |note|
-          affiliation_from_note(note:)
+        Array(contributor.affiliation).map do |affiliation|
+          affiliation_from(affiliation)
         end
       end
 
-      def affiliation_from_note(note:)
-        institution = note.structuredValue.find { |descriptive_value| descriptive_value.identifier.present? }
-        department = note.structuredValue.find { |descriptive_value| descriptive_value.identifier.blank? }
+      def affiliation_from(affiliation)
+        institution = affiliation.structuredValue.find { |descriptive_value| descriptive_value.identifier.present? }
+        department = affiliation.structuredValue.find { |descriptive_value| descriptive_value.identifier.blank? }
 
         {
           'institution' => institution.value,

--- a/app/services/ror_service.rb
+++ b/app/services/ror_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Class for ROR support
+class RorService
+  def self.call(...)
+    new(...).call
+  end
+
+  def initialize(search:)
+    @search = search
+    @conn = new_conn
+  end
+
+  def call
+    results = organizations
+    return [] if results['number_of_results'].to_i.zero?
+
+    results['items'].map { |org| org.slice('id', 'name') }
+  end
+
+  attr_reader :conn, :search
+
+  private
+
+  def organizations
+    conn.get('/organizations', params, headers).body
+  rescue Faraday::Error => e
+    raise Error, "Connection err: #{e.message}"
+  end
+
+  def new_conn
+    Faraday.new({ url: Settings.ror.url }) do |f|
+      f.request :json
+      f.response :json
+      f.response :raise_error
+    end
+  end
+
+  def headers
+    {
+      'Accept' => 'application/json',
+      'User-Agent' => 'Stanford Self-Deposit (Hungry Hungry Hippo)'
+    }
+  end
+
+  def params
+    { query: search }
+  end
+end

--- a/app/views/affiliations/search.html.erb
+++ b/app/views/affiliations/search.html.erb
@@ -1,0 +1,3 @@
+<% @organizations.map do |organization| %>
+  <%= tag.li class: 'list-group-item', role: 'option', data: { autocomplete_value: organization['id'], autocomplete_label: organization['name'] } do %><%= organization['name'] %><% end %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,10 @@
     <meta name='viewport' content='width=device-width,initial-scale=1'>
     <meta name='apple-mobile-web-app-capable' content='yes'>
     <meta name='mobile-web-app-capable' content='yes'>
+    <% if Rails.env.test? %>
+      <%# Breadcrumbs were being unexpectedly prefetched in system specs. %>
+      <meta name="turbo-prefetch" content="false">
+    <% end %>
     <%= capybara_lockstep if defined?(Capybara::Lockstep) %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,9 @@ en:
         blank: 'must provide a last name'
       orcid:
         invalid: 'must be formatted as "XXXX-XXXX-XXXX-XXXX"'
+      affiliations:
+        uri:
+          invalid: 'select a valid ROR institution'
   date:
     formats:
       slashes_short: "%m/%d/%Y"
@@ -267,6 +270,15 @@ en:
           label: 'Abstract'
           tooltip_html: >-
             The abstract should describe the content you are depositing and its relation to or context within any other published works or larger projects. If you are depositing a dataset related to a publication, please describe the dataset itself and not the publication.
+        affiliations:
+          institution:
+            label: 'Institution'
+            tooltip_html: >-
+              Begin typing the name of the institution to see potential matches. Selections must be made from the list; you are not permitted to type in your own entry.
+          department:
+            label: 'Department/Center'
+            tooltip_html: >-
+              Enter the name of the department, center, institute, or program at the institution on the left with which this person is affiliated. This field is not required. You must enter an institution in order to enter a department.
         citation:
           label: 'Enter preferred citation'
         contributors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   get 'accounts/search', to: 'accounts#search'
   get 'accounts/search_user', to: 'accounts#search_user'
+  get 'affiliations/search', to: 'affiliations#search'
 
   get 'dashboard', to: 'dashboard#show'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -92,3 +92,9 @@ ahoy:
 
 google_analytics:
   enabled: false
+
+ror:
+  url: https://api.ror.org
+
+affiliations:
+  enabled: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,7 +1,13 @@
 enable_live_reloading: false
+
 staging_location: 'tmp/workspace'
+
 seed_user:
   orcid_id: https://orcid.org/0000-0000-0000-0000
   email_address: 'a.user@stanford.edu'
   first_name: 'A.'
   name: 'A. User'
+
+
+affiliations:
+  enabled: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,3 +2,6 @@ staging_location: 'tmp/workspace'
 
 notifications:
   enabled: false
+
+affiliations:
+  enabled: true

--- a/spec/cocina_builders/person_contributor_cocina_builder_spec.rb
+++ b/spec/cocina_builders/person_contributor_cocina_builder_spec.rb
@@ -45,10 +45,9 @@ RSpec.describe PersonContributorCocinaBuilder do
         ]
       end
 
-      it 'includes affiliations in the note' do
-        expected_note = [
+      it 'includes affiliations' do
+        expected_affiliations = [
           {
-            type: 'affiliation',
             structuredValue: [
               {
                 value: 'Stanford University',
@@ -65,7 +64,7 @@ RSpec.describe PersonContributorCocinaBuilder do
           }
         ]
 
-        expect(contributor_params[:note]).to eq(expected_note)
+        expect(contributor_params[:affiliation]).to eq(expected_affiliations)
       end
     end
 
@@ -80,9 +79,8 @@ RSpec.describe PersonContributorCocinaBuilder do
       end
 
       it 'includes affiliations in the note' do
-        expected_note = [
+        expected_affiliations = [
           {
-            type: 'affiliation',
             structuredValue: [
               {
                 value: 'Stanford University',
@@ -98,7 +96,7 @@ RSpec.describe PersonContributorCocinaBuilder do
           }
         ]
 
-        expect(contributor_params[:note]).to eq(expected_note)
+        expect(contributor_params[:affiliation]).to eq(expected_affiliations)
       end
     end
   end

--- a/spec/forms/affiliation_form_spec.rb
+++ b/spec/forms/affiliation_form_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AffiliationForm, type: :form do
+  let(:form) { described_class.new(institution:, uri:, department:) }
+
+  let(:institution) { nil }
+  let(:uri) { nil }
+  let(:department) { nil }
+
+  describe 'validations' do
+    context 'when institution, uri, and department are all present' do
+      let(:institution) { 'Stanford University' }
+      let(:uri) { 'https://ror.org/00f54p054' }
+      let(:department) { 'Department of Computer Science' }
+
+      it 'is valid' do
+        expect(form).to be_valid
+      end
+    end
+
+    context 'when institution but not uri is present' do
+      let(:institution) { 'Stanford University' }
+
+      it 'is not valid' do
+        expect(form).not_to be_valid
+        expect(form.errors[:institution]).to include('must be selected from the list')
+      end
+    end
+
+    context 'when institution and uri are both present' do
+      let(:institution) { 'Stanford University' }
+      let(:uri) { 'https://ror.org/00f54p054' }
+
+      it 'is valid' do
+        expect(form).to be_valid
+      end
+    end
+
+    context 'when department but not institution is present' do
+      let(:department) { 'Department of Computer Science' }
+
+      it 'is not valid' do
+        expect(form).not_to be_valid
+        expect(form.errors[:institution]).to include("can't be blank")
+      end
+    end
+  end
+end

--- a/spec/jobs/deposit_collection_job_spec.rb
+++ b/spec/jobs/deposit_collection_job_spec.rb
@@ -255,7 +255,14 @@ RSpec.describe DepositCollectionJob do
           'person_role' => 'researcher',
           'role_type' => 'person',
           'with_orcid' => true,
-          'orcid' => '0000-0000-0000-0000'
+          'orcid' => '0000-0000-0000-0000',
+          'affiliations_attributes' => [
+            {
+              'institution' => 'Stanford University',
+              'uri' => 'https://ror.org/01abcd',
+              'department' => 'Department of History'
+            }
+          ]
         },
         {
           'organization_name' => 'Stanford University',
@@ -294,6 +301,12 @@ RSpec.describe DepositCollectionJob do
       expect(person_contributor.role).to eq('researcher')
       expect(person_contributor.role_type).to eq('person')
       expect(person_contributor.orcid).to eq('0000-0000-0000-0000')
+      expect(person_contributor.affiliations.count).to eq(1)
+
+      affiliation = person_contributor.affiliations.first
+      expect(affiliation.institution).to eq('Stanford University')
+      expect(affiliation.uri).to eq('https://ror.org/01abcd')
+      expect(affiliation.department).to eq('Department of History')
 
       stanford_contributor = collection.contributors[1]
       expect(stanford_contributor.organization_name).to eq('Stanford University')

--- a/spec/mappers/form/work_contributors_mapper_spec.rb
+++ b/spec/mappers/form/work_contributors_mapper_spec.rb
@@ -74,9 +74,8 @@ RSpec.describe Form::WorkContributorsMapper do
             }
           }
         ],
-        note: [
+        affiliation: [
           {
-            type: 'affiliation',
             structuredValue: [
               {
                 value: 'Stanford University',
@@ -140,9 +139,8 @@ RSpec.describe Form::WorkContributorsMapper do
             }
           }
         ],
-        note: [
+        affiliation: [
           {
-            type: 'affiliation',
             structuredValue: [
               {
                 value: 'Stanford University',

--- a/spec/services/ror_service_spec.rb
+++ b/spec/services/ror_service_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RorService do
+  subject(:organizations) { described_class.call(search:) }
+
+  let(:search) { 'stanford' }
+
+  context 'when the ror service returns results' do
+    let(:body) do
+      {
+        number_of_results: 1,
+        items:
+        [
+          {
+            id: 'https://ror.org/00f54p054',
+            name: 'Stanford University'
+          }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "https://api.ror.org/organizations?query=#{search}")
+        .with(headers: { 'Accept' => 'application/json' })
+        .to_return(status: 200, body:, headers: { 'Content-Type': 'application/json;charset=UTF-8' })
+    end
+
+    it 'returns a successful response' do
+      expect(organizations.count).to eq(1)
+      expect(organizations.first['name']).to eq('Stanford University')
+    end
+  end
+
+  context 'when the ror service returns no results' do
+    let(:body) do
+      {
+        number_of_results: 0,
+        items: []
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "https://api.ror.org/organizations?query=#{search}")
+        .with(headers: { 'Accept' => 'application/json' })
+        .to_return(status: 200, body:, headers: { 'Content-Type': 'application/json;charset=UTF-8' })
+    end
+
+    it 'returns a successful but empty response' do
+      expect(organizations.count).to eq(0)
+    end
+  end
+
+  context 'when the ror service returns an error' do
+    let(:body) { nil }
+
+    before do
+      stub_request(:get, "https://api.ror.org/organizations?query=#{search}")
+        .with(headers: { 'Accept' => 'application/json' })
+        .to_return(status: 404, body:, headers: { 'Content-Type': 'application/json;charset=UTF-8' })
+    end
+
+    it 'raises an error' do
+      expect { organizations }.to raise_error(StandardError)
+    end
+  end
+end

--- a/spec/system/edit_work_spec.rb
+++ b/spec/system/edit_work_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Edit a work' do
     # Fill in in authors
     find('.nav-link', text: 'Contributors').click
     form_instances = all('.form-instance')
-    expect(form_instances.count).to eq(3)
+    expect(form_instances.count).to eq(4)
     within(form_instances[0]) do
       expect(page).to have_checked_field('Individual', with: 'person')
       expect(page).to have_select('Role', selected: 'Author')
@@ -112,13 +112,15 @@ RSpec.describe 'Edit a work' do
       expect(page).to have_field('ORCID iD', with: '0001-0002-0003-0004')
       expect(page).to have_field('First name', with: 'Jane')
       expect(page).to have_field('Last name', with: 'Stanford')
+      expect(page).to have_field('Institution', with: 'Stanford University')
+      expect(page).to have_field('Department/Center', with: 'Department of History')
     end
-    within(form_instances[1]) do
+    within(form_instances[2]) do
       expect(page).to have_checked_field('Organization', with: 'organization')
       expect(page).to have_select('Role', selected: 'Host institution')
       expect(page).to have_field('Organization name', with: 'Stanford University Libraries')
     end
-    within(form_instances[2]) do
+    within(form_instances[3]) do
       expect(page).to have_checked_field('Organization', with: 'organization')
       expect(page).to have_select('Role', selected: 'Degree granting institution')
       within('.stanford-degree-granting-institution-section') do

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -209,10 +209,12 @@ RSpec.describe 'Show a work' do
         expect(page).to have_css('th', text: 'Contributor')
         expect(page).to have_css('th', text: 'ORCID')
         expect(page).to have_css('th', text: 'Role')
+        expect(page).to have_css('th', text: 'Affiliation')
         within('tbody tr:nth-of-type(1)') do
           expect(page).to have_css('td:nth-of-type(1)', text: 'Jane Stanford')
           expect(page).to have_css('td:nth-of-type(2)', text: 'https://orcid.org/0001-0002-0003-0004')
           expect(page).to have_css('td:nth-of-type(3)', text: 'Author')
+          expect(page).to have_css('td:nth-of-type(4)', text: 'Stanford University')
         end
         within('tbody tr:nth-of-type(3)') do
           expect(page).to have_css('td:nth-of-type(1)', text: 'Department of Philosophy, Stanford University')

--- a/spec/system/validate_work_deposit_spec.rb
+++ b/spec/system/validate_work_deposit_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'Validate a work deposit' do
 
     # Add a blank contributor. It will be ignored.
     click_link_or_button('Add another contributor')
-    expect(page).to have_css('.form-instance', count: 2)
+    expect(page).to have_css('.form-instance', count: 3)
 
     # Abstract is marked invalid
     find('.nav-link.is-invalid', text: 'Abstract').click


### PR DESCRIPTION
Taking this out of draft for review.

Fixes #329 

(cc: @justinlittman) I think this is ready for review with 2 notable styling issue that I could use help with:

I can't seem to get the trashcan icon to the right of the affiliation form:
<img width="877" height="650" alt="Screenshot 2025-07-15 at 2 22 34 PM" src="https://github.com/user-attachments/assets/26570330-4012-449d-be4c-c4f2cc91fc09" />

I'm wondering how to go about changing this validation message to something useful. The validation is actually based on the hidden URI field and happens if the user enters a value but does not select from the pull down to get the ROR URI, therefore causing a validation error for the affiliation URI. I'm thinking it should say something like "please select a valid institution from the drop down" or something.

<img width="887" height="333" alt="Screenshot 2025-07-15 at 2 22 47 PM" src="https://github.com/user-attachments/assets/bfc771dc-be2c-4016-99a6-dc2c95775b66" />
