### PR TITLE
standardize user display as name (sunet)

### DIFF
--- a/app/components/collections/edit/participant_component.rb
+++ b/app/components/collections/edit/participant_component.rb
@@ -18,7 +18,7 @@ module Collections
       def value
         return unless sunetid
 
-        "#{sunetid}: #{name}"
+        "#{name} (#{sunetid})"
       end
 
       # This method is invoked by RepeatableNestedComponent to label the delete button.

--- a/app/components/works/edit/share_component.rb
+++ b/app/components/works/edit/share_component.rb
@@ -18,7 +18,7 @@ module Works
       def value
         return unless sunetid
 
-        "#{sunetid}: #{name}"
+        "#{name} (#{sunetid})"
       end
 
       def aria_label

--- a/app/javascript/controllers/participants_controller.js
+++ b/app/javascript/controllers/participants_controller.js
@@ -51,7 +51,7 @@ export default class extends Controller {
 
   addParticipant (accountData) {
     const formInstanceEl = this.nestedFormOutlet.add()
-    formInstanceEl.querySelector('.participant-label').innerHTML = `${accountData.sunetid}: ${accountData.name}`
+    formInstanceEl.querySelector('.participant-label').innerHTML = `${accountData.name} (${accountData.sunetid})`
     formInstanceEl.querySelector('input[name$="[sunetid]"]').value = accountData.sunetid
     formInstanceEl.querySelector('input[name$="[name]"]').value = accountData.name
     formInstanceEl.querySelector('[data-delete-btn] .visually-hidden').innerHTML = `Clear ${accountData.name}`

--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -16,7 +16,7 @@ class CollectionPresenter < FormPresenter
   # @param [Symbol] role :managers or :depositors
   # @return [Array<String>] an array of formatted sunetids and names
   def participants(role)
-    collection.send(role).map { |participant| "#{participant.name} (#{participant.sunetid})" }
+    collection.send(role).map { |participant| user_display(participant) }
   end
 
   def release
@@ -82,7 +82,7 @@ class CollectionPresenter < FormPresenter
   end
 
   def created_by
-    collection.user.name
+    user_display(collection.user)
   end
 
   def created_datetime

--- a/app/presenters/form_presenter.rb
+++ b/app/presenters/form_presenter.rb
@@ -25,4 +25,8 @@ class FormPresenter < SimpleDelegator
       link_to_new_tab(related_link.text || related_link.url, related_link.url)
     end
   end
+
+  def user_display(user)
+    "#{user.name} (#{user.sunetid})"
+  end
 end

--- a/app/presenters/work_presenter.rb
+++ b/app/presenters/work_presenter.rb
@@ -44,7 +44,7 @@ class WorkPresenter < FormPresenter
   end
 
   def depositor
-    "#{user.name} (#{user.sunetid})"
+    user_display(user)
   end
 
   def keywords
@@ -132,6 +132,10 @@ class WorkPresenter < FormPresenter
 
   def contact_emails
     (contact_emails_attributes.map(&:email) + [works_contact_email]).compact.join(', ')
+  end
+
+  def shared_with
+    share_users.order(:name).map { |user| user_display(user) }.join(', ')
   end
 
   private

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -21,7 +21,7 @@
   <% component.with_row(label: 'Collection', values: [@work_presenter.collection_link]) %>
   <% component.with_row(label: 'Shared with') do |row_component| %>
     <%= row_component.with_cell do %>
-      <div><%= @work_presenter.share_users.map(&:name).sort.join(', ') %></div>
+      <div><%= @work_presenter.shared_with %></div>
       <%= render Works::Show::ManageSharingButtonComponent.new(work: @work) %>
     <% end %>
   <% end %>

--- a/spec/system/create_collection_deposit_spec.rb
+++ b/spec/system/create_collection_deposit_spec.rb
@@ -115,18 +115,18 @@ RSpec.describe 'Create a collection deposit' do
     expect(page).to have_text('Managers')
     form_instances = page.all('.form-instance')
     within(form_instances[0]) do
-      expect(page).to have_css('span', text: 'jswithen: John Swithen')
+      expect(page).to have_css('span', text: 'John Swithen (jswithen)')
       expect(page).to have_button('Clear John Swithen')
     end
 
     fill_in('managers-textarea', with: 'stepking@stanford.edu')
     click_link_or_button('Add managers')
-    expect(page).to have_css('.participant-label', text: 'stepking: Stephen King')
+    expect(page).to have_css('.participant-label', text: 'Stephen King (stepking)')
     expect(page).to have_button('Clear Stephen King')
 
     fill_in('depositors-textarea', with: 'notjoehill, joehill')
     click_link_or_button('Add depositors')
-    expect(page).to have_css('.participant-label', text: 'joehill: Joe Hill')
+    expect(page).to have_css('.participant-label', text: 'Joe Hill (joehill)')
     expect(page).to have_field('depositors-textarea', with: 'notjoehill')
 
     expect(page).to have_checked_field('Send email to Collection Managers and Reviewers ' \
@@ -142,7 +142,7 @@ RSpec.describe 'Create a collection deposit' do
     find('label', text: 'Yes').click
     fill_in('reviewers-textarea', with: 'pennywise')
     click_link_or_button('Add reviewers')
-    expect(page).to have_css('.participant-label', text: 'pennywise: Pennywise')
+    expect(page).to have_css('.participant-label', text: 'Pennywise (pennywise)')
 
     # Clicking on Next to go to the type of deposit tab
     click_link_or_button('Next')

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -143,19 +143,19 @@ RSpec.describe 'Edit a collection' do
 
     # Remove the manager
     within form_instances[0] do
-      expect(page).to have_css('.participant-label', text: 'alborland: Al Borland') # Manager
+      expect(page).to have_css('.participant-label', text: 'Al Borland (alborland)') # Manager
       find('button[data-action="click->nested-form#delete"]').click
     end
-    expect(page).to have_no_text('alborland: Al Borland')
+    expect(page).to have_no_text('Al Borland (alborland)')
 
     fill_in('managers-textarea', with: 'stepking@stanford.edu')
     click_link_or_button('Add managers')
-    expect(page).to have_css('.participant-label', text: 'stepking: Stephen King')
+    expect(page).to have_css('.participant-label', text: 'Stephen King (stepking)')
 
     # Fill in the depositor form
     fill_in('depositors-textarea', with: 'joehill')
     click_link_or_button('Add depositors')
-    expect(page).to have_css('.participant-label', text: 'joehill: Joe Hill')
+    expect(page).to have_css('.participant-label', text: 'Joe Hill (joehill)')
 
     find('label', text: 'Send email to Collection Managers and Reviewers ' \
                         '(see Workflow section of form) when participants are added/removed').click
@@ -170,7 +170,7 @@ RSpec.describe 'Edit a collection' do
 
     fill_in('reviewers-textarea', with: 'pennywise')
     click_link_or_button('Add reviewers')
-    expect(page).to have_css('.participant-label', text: 'pennywise: Pennywise')
+    expect(page).to have_css('.participant-label', text: 'Pennywise (pennywise')
 
     # Clicking on Next to go to type of deposit tab
     click_link_or_button('Next')

--- a/spec/system/manage_shares_spec.rb
+++ b/spec/system/manage_shares_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Manage shares' do
 
       expect(page).to have_css('h1', text: work.title)
 
-      expect(page).to have_text('Jane Stanford, Leland Stanford Jr.')
+      expect(page).to have_text('Jane Stanford (jane), Leland Stanford Jr. (junior)')
 
       click_link_or_button('Manage sharing')
 
@@ -56,14 +56,14 @@ RSpec.describe 'Manage shares' do
       expect(form_instances.size).to eq(2)
 
       within(form_instances[0]) do
-        expect(page).to have_css('span', text: 'jane: Jane Stanford')
+        expect(page).to have_css('span', text: 'Jane Stanford (jane)')
         expect(page).to have_field('Share permission', with: Share::VIEW_PERMISSION)
         expect(page).to have_css('section[aria-label="Set sharing permissions for Jane Stanford"]')
         select('View and edit', from: 'Share permission')
       end
 
       within(form_instances[1]) do
-        expect(page).to have_css('span', text: 'junior: Leland Stanford Jr.')
+        expect(page).to have_css('span', text: 'Leland Stanford Jr. (junior)')
         expect(page).to have_field('Share permission', with: Share::VIEW_EDIT_DEPOSIT_PERMISSION)
         click_link_or_button('Clear')
       end
@@ -75,13 +75,13 @@ RSpec.describe 'Manage shares' do
       fill_in('Enter list of Stanford email addresses', with: 'dsj')
       click_link_or_button('Add')
 
-      expect(page).to have_css('span', text: 'dsj: David Starr Jordan')
+      expect(page).to have_css('span', text: 'David Starr Jordan (dsj)')
 
       click_link_or_button('Save')
 
       expect(page).to have_current_path(work_path(druid))
 
-      expect(page).to have_text('David Starr Jordan, Jane Stanford')
+      expect(page).to have_text('David Starr Jordan (dsj), Jane Stanford (jane)')
 
       expect(Share.find_by(work:, user: changing_share_user).permission).to eq(Share::VIEW_EDIT_PERMISSION)
       expect(Share.exists?(work:, user: deleting_share_user)).to be false


### PR DESCRIPTION
Fixes #1654 

Note that is also adjusts it when adding managers/participants to match the same style (not mentioned in the ticket but I noticed it).

See screenshots below:

<img width="757" height="260" alt="Screenshot 2025-07-14 at 1 41 59 PM" src="https://github.com/user-attachments/assets/8c4101ec-ef88-453d-94b1-6fc87ba6d93f" />


<img width="691" height="338" alt="Screenshot 2025-07-14 at 1 41 48 PM" src="https://github.com/user-attachments/assets/e4eac3ae-7982-42d7-93f9-d3c596406380" />


<img width="1191" height="559" alt="Screenshot 2025-07-14 at 1 43 06 PM" src="https://github.com/user-attachments/assets/855427d1-9bde-4ffe-bc14-402b0799e2d6" />
