### PR TITLE
do not end participant change emails the very first time a collection is saved

### DIFF
--- a/app/mailers/collections_mailer.rb
+++ b/app/mailers/collections_mailer.rb
@@ -35,8 +35,9 @@ class CollectionsMailer < ApplicationMailer
   def participants_changed_email
     return unless @collection.email_when_participants_changed
 
-    # if the collection is a first_version, don't send emails
-    return if @collection.first_version?
+    # if the collection is a first_version and has not already been saved at least once, don't send emails
+    # i.e. emails are only NOT sent the very first time a brand new collection is saved
+    return if @collection.first_version? && @collection.updated_at == @collection.created_at
 
     (@collection.managers + @collection.reviewers).uniq.each do |user|
       @user = user

--- a/spec/mailers/collections_mailer_spec.rb
+++ b/spec/mailers/collections_mailer_spec.rb
@@ -151,6 +151,40 @@ RSpec.describe CollectionsMailer do
           expect(mail.message).to be_a(ActionMailer::Base::NullMail)
         end
       end
+
+      context 'when adding participants while saving a collection that is still on v1 but has previously been saved' do
+        let(:collection) do
+          create(:collection,
+                 title: '20 Minutes into the Future',
+                 managers: [manager],
+                 email_when_participants_changed: true,
+                 version: 1)
+        end
+
+        before { collection.update(title: '21 Minutes into the Future') } # simulate an update when on v1
+
+        it 'renders the body' do
+          expect(mail).to match_body("Dear #{manager.first_name},")
+          expect(mail).to match_body('Members have been either added to or removed from the ' \
+                                     '21 Minutes into the Future collection.')
+        end
+      end
+
+      context 'when adding participants while saving a collection for the first time on v2' do
+        let(:collection) do
+          create(:collection,
+                 title: '20 Minutes into the Future',
+                 managers: [manager],
+                 email_when_participants_changed: true,
+                 version: 2)
+        end
+
+        it 'renders the body' do
+          expect(mail).to match_body("Dear #{manager.first_name},")
+          expect(mail).to match_body('Members have been either added to or removed from the ' \
+                                     '20 Minutes into the Future collection.')
+        end
+      end
     end
 
     context 'when notify managers and reviewers on participant changes is disabled' do


### PR DESCRIPTION
Fixes #1675 -- there are specs, but would be nice to verify on the server to be sure this change works as expected.