### PR TITLE
add delete all files in a work link

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -2,7 +2,7 @@
 
 # Controller for a Work contents (files)
 class ContentsController < ApplicationController
-  before_action :set_content, only: %i[update show show_table]
+  before_action :set_content, only: %i[update show destroy show_table]
   before_action :set_content_files, only: %i[show show_table]
 
   # Called from work edit/update form.
@@ -31,6 +31,14 @@ class ContentsController < ApplicationController
     update_files
 
     head :ok
+  end
+
+  def destroy
+    authorize! @content
+
+    @content.content_files.destroy_all
+
+    redirect_to content_path(@content)
   end
 
   private

--- a/app/policies/content_policy.rb
+++ b/app/policies/content_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ContentPolicy < ApplicationPolicy
-  alias_rule :show?, :show_table?, :update?, :edit?, to: :manage?
+  alias_rule :show?, :show_table?, :update?, :edit?, :destroy?, to: :manage?
 
   def manage?
     record.user_id == user.id

--- a/app/views/contents/_show.html.erb
+++ b/app/views/contents/_show.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag content, 'show' do %>
   <%= turbo_stream_from 'show', content %>
-  <% if total_files > Settings.search.file_search_box_min # there is at least this files in the object, so show search bar with section header %>
+  <% if total_files > Settings.search.file_search_box_min # there is at least this many files in the object, so show search bar with section header %>
       <div class="row">
         <div class="col-3">
           <%= render Edit::SectionHeaderComponent.new(title: t('works.edit.panes.files.list')) %>
@@ -31,6 +31,7 @@
     <p>Your files will appear here once they have been uploaded.</p>
   <% else # there is at least one file in the object, now decide if we show the hierarchical view without paging or the flat list view with paging %>
       <div data-controller="disable-other">
+        <div class="row"><div class="col-12 m-2 text-end"><%= link_to 'Delete all files', content_path, data: { turbo_method: :delete, turbo_confirm: 'Are you sure you want to delete all files?' } %></div></div>
         <% if total_files > Settings.file_upload.hierarchical_files_limit # lots of files, and the hierarchy would not work well, show flat list with paging %>
           <%= render Works::Edit::ContentNonHierarchyComponent.new(content_obj: content, content_files:) %>
         <% else # fewer files,  hierarchy will work fine, show hierarchy view without paging %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  resources :contents, only: %i[update show] do
+  resources :contents, only: %i[update show destroy] do
     member do
       get 'show_table', to: 'contents#show_table', as: 'show_table'
     end

--- a/spec/requests/delete_content_spec.rb
+++ b/spec/requests/delete_content_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Delete content files' do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in(user)
+  end
+
+  context 'when the user is not authorized' do
+    let(:content) { create(:content, :with_content_files) }
+
+    it 'redirects to root and does not delete any files' do
+      expect(content.content_files.count).to eq 2
+
+      delete "/contents/#{content.id}"
+
+      expect(response).to redirect_to(root_path)
+      expect(content.content_files.count).to eq 2
+    end
+  end
+
+  context 'when the user is authorized' do
+    let(:content) { create(:content, :with_content_files, user:) }
+
+    it 'destroys all of the content files' do
+      expect(content.content_files.count).to eq 2
+
+      delete "/contents/#{content.id}"
+
+      expect(content.reload.content_files.count).to eq 0
+    end
+  end
+end

--- a/spec/system/manage_files_spec.rb
+++ b/spec/system/manage_files_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Manage files for a work', :dropzone do
   let(:user) { create(:user) }
   let(:collection) { create(:collection, :with_druid, user:) }
+  let(:no_files_message) { 'Your files will appear here once they have been uploaded.' }
 
   before do
     sign_in(user)
@@ -16,7 +17,7 @@ RSpec.describe 'Manage files for a work', :dropzone do
 
       expect(page).to have_css('h1', text: 'Untitled deposit')
 
-      expect(page).to have_text('Your files will appear here once they have been uploaded.')
+      expect(page).to have_text(no_files_message)
 
       # Add one file
       # Can't test folder upload, so no hierarchy.
@@ -89,11 +90,13 @@ RSpec.describe 'Manage files for a work', :dropzone do
 
       expect(page).to have_css('h1', text: 'Untitled deposit')
 
-      expect(page).to have_text('Your files will appear here once they have been uploaded.')
+      expect(page).to have_text(no_files_message)
 
       # Add one file
       find('.dropzone').drop('spec/fixtures/files/hippo.png')
       await_upload
+
+      expect(page).to have_no_text(no_files_message)
 
       within('table#content-table') do
         expect(page).to have_css('td:nth-of-type(1)', text: 'hippo.png') # Filename
@@ -156,6 +159,12 @@ RSpec.describe 'Manage files for a work', :dropzone do
       expect(page).to have_field('Hide this file', checked: true)
       sleep 0.25 # Wait for the form to submit.
       expect(content_file.reload.hide).to be true
+
+      # Delete all of the files
+      accept_confirm do
+        click_link_or_button('Delete all files')
+      end
+      expect(page).to have_text(no_files_message)
     end
   end
 
@@ -174,7 +183,7 @@ RSpec.describe 'Manage files for a work', :dropzone do
 
       expect(page).to have_text('hippo.tiff: File is too big (4.61MiB). Max filesize: 1MiB.')
 
-      expect(page).to have_text('Your files will appear here once they have been uploaded.')
+      expect(page).to have_text(no_files_message)
 
       # Upload a smaller file
       find('.dropzone').drop('spec/fixtures/files/hippo.png')


### PR DESCRIPTION
Fixes #1614 - delete all files with one link.  I put a javascript confirmation dialog box in front of this even though it wasn't indicated in the ticket.

Note: one thing that confused me was that the delete doesn't actually "stick" unless you save the work.  This is also true of files deleted one by one.  I presume this is expected behavior (but it confused me during testing).

<img width="929" height="334" alt="Screenshot 2025-07-18 at 3 40 25 PM" src="https://github.com/user-attachments/assets/4c9b2a79-1bde-4afe-9781-eecb7026c986" />
