### PR TITLE
Update display of contributor affiliations on work show page

### DIFF
--- a/app/components/show/contributors_show_component.rb
+++ b/app/components/show/contributors_show_component.rb
@@ -61,9 +61,15 @@ module Show
     end
 
     def contributor_affiliations(contributor)
-      return if contributor.affiliations.empty?
+      return nil if contributor.affiliations.empty?
 
-      contributor.affiliations.filter_map(&:institution).join(', ')
+      safe_join(contributor.affiliations.map do |affiliation|
+        next if affiliation.institution.blank?
+
+        department = affiliation.department.present? ? affiliation.department.prepend(': ') : nil
+
+        content_tag(:p, [affiliation.institution, department].join, class: 'mb-0')
+      end)
     end
   end
 end

--- a/spec/system/show_work_spec.rb
+++ b/spec/system/show_work_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe 'Show a work' do
           expect(page).to have_css('td:nth-of-type(1)', text: 'Jane Stanford')
           expect(page).to have_css('td:nth-of-type(2)', text: 'https://orcid.org/0001-0002-0003-0004')
           expect(page).to have_css('td:nth-of-type(3)', text: 'Author')
-          expect(page).to have_css('td:nth-of-type(4)', text: 'Stanford University')
+          expect(page).to have_css('td:nth-of-type(4)', text: 'Stanford University: Department of History')
         end
         within('tbody tr:nth-of-type(3)') do
           expect(page).to have_css('td:nth-of-type(1)', text: 'Department of Philosophy, Stanford University')


### PR DESCRIPTION
Fixes #1676 

<img width="1255" height="262" alt="Screenshot 2025-07-22 at 1 43 38 PM" src="https://github.com/user-attachments/assets/0cccdf84-c6ff-4761-aa5d-ab74b6e79693" />
