### PR TITLE
foreign key constraint violation with clear

### DIFF
--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -113,7 +113,7 @@ class DepositCollectionJob < ApplicationJob
   end
 
   def assign_contributors
-    collection.contributors.clear
+    collection.contributors.destroy_all
     collection_form.contributors.each do |contributor_form|
       if contributor_form.person?(with_names: true)
         assign_person(contributor_form:)


### PR DESCRIPTION
Ref #1698 and https://app.honeybadger.io/projects/128495/faults/122245309

Not sure how what the intent was with clearing the contributors from a collection before adding them again, but just breaking the association by removing the key (which is what `.clear` does) seems to lead to a foreign key violation.  Can you we just destroy them and then re-add them, or is this bad? (i.e. are these contributors potentially referenced by other collections?)