### PR TITLE
ignore whitespace in admin druid search

### DIFF
--- a/app/forms/admin/druid_search_form.rb
+++ b/app/forms/admin/druid_search_form.rb
@@ -16,6 +16,8 @@ module Admin
     end
 
     def normalize_druid
+      druid.strip! # remove any trailing or leading whitespace the user may have inadvertently entered via a copy/paste
+
       return if druid.starts_with?('druid:') || druid.blank?
 
       self.druid = druid.prepend('druid:')


### PR DESCRIPTION
Because if you copy and paste a druid from a URL or webpage into the admin druid search textbox, you may get extra whitespace and then it'll tell you it can't find the druid, which is a LIE