### PR TITLE
Pause continuous deployment to stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,9 @@ pipeline {
       }
 
       when {
-        branch 'main'
+        // Uncomment this line and comment the following to turn continuous deployment on
+        // branch 'main'
+        expression { return null }
       }
 
       steps {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Deployment
 
-The application is deployed continuously by our on-prem Jenkins service (`sul-ci-prod`) to the H3 staging environment on every merge to `main`. See `Jenkinsfile` for how that is wired up. Notifications for deployments are sent to the `#dlss-access-cd` Slack channel.
+During work cycles, the application is deployed continuously by our on-prem Jenkins service (`sul-ci-prod`) to the H3 staging environment on every merge to `main`. See `Jenkinsfile` for how that is wired up. Notifications for deployments are sent to the `#dlss-access-cd` Slack channel.
 
 ## Development
 


### PR DESCRIPTION
Doing this in a way that should make it easy to turn it back on the next time we need do.

HOLD until we're sure we're ready to stop deploying `main` to stage.
