### PR TITLE
Ignore collections without druids in collection report.

### DIFF
--- a/app/services/admin/collection_report.rb
+++ b/app/services/admin/collection_report.rb
@@ -163,7 +163,7 @@ module Admin
       end
 
       def deposit_stats
-        @deposit_stats ||= collection.works.filter_map do |work|
+        @deposit_stats ||= collection.works.where.not(druid: nil).filter_map do |work|
           Sdr::Repository.status(druid: work.druid).status_message
         rescue Sdr::Repository::NotFoundResponse => e
           Honeybadger.notify('Error looking up work in SDR. This may be a draft work that was purged via Argo.',

--- a/spec/services/admin/collection_report_spec.rb
+++ b/spec/services/admin/collection_report_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe Admin::CollectionReport do
         allow(Sdr::Repository).to receive(:status).with(druid: druid_fixture).and_return(version_status)
         allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
         create(:work, druid: druid_fixture, collection:)
+        # This collection will be ignored since it does not have a druid
+        create(:collection)
       end
 
       it 'returns a csv with all collections including work stats' do


### PR DESCRIPTION
closes #1707

Note that this is probably just vestigial bad data in test environments.