### PR TITLE
Send one participants_changed email to all managers

### DIFF
--- a/app/mailers/collections_mailer.rb
+++ b/app/mailers/collections_mailer.rb
@@ -33,16 +33,7 @@ class CollectionsMailer < ApplicationMailer
   end
 
   def participants_changed_email
-    return unless @collection.email_when_participants_changed
-
-    # if the collection is a first_version and has not already been saved at least once, don't send emails
-    # i.e. emails are only NOT sent the very first time a brand new collection is saved
-    return if @collection.first_version? && @collection.updated_at == @collection.created_at
-
-    (@collection.managers + @collection.reviewers).uniq.each do |user|
-      @user = user
-      mail(to: @user.email_address, subject: "Participant changes for the #{@collection.title} collection in the SDR")
-    end
+    mail(to: @user.email_address, subject: "Participant changes for the #{@collection.title} collection in the SDR")
   end
 
   def first_version_created_email

--- a/app/subscription_handlers/collection_participants_changed_subscription_mailer.rb
+++ b/app/subscription_handlers/collection_participants_changed_subscription_mailer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Sends the appropriate emails when collections participants are changed.
+class CollectionParticipantsChangedSubscriptionMailer
+  def self.call(...)
+    new(...).call
+  end
+
+  # @param [Collection] collection the collection that was changed
+  def initialize(collection:, **)
+    @collection = collection
+  end
+
+  def call
+    return unless collection.email_when_participants_changed
+
+    # if the collection is a first_version and has not already been saved at least once, don't send emails
+    # i.e. emails are only NOT sent the very first time a brand new collection is saved
+    return if collection.first_version? && collection.updated_at == collection.created_at
+
+    managers_and_reviewers.each do |manager|
+      CollectionsMailer.with(collection:, user: manager).participants_changed_email.deliver_later
+    end
+  end
+
+  private
+
+  def managers_and_reviewers
+    managers = collection.managers + collection.reviewers
+    managers.reject { |user| user.email_address.blank? }.uniq
+  end
+
+  attr_reader :collection
+end

--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -10,10 +10,10 @@ Rails.application.config.after_initialize do # rubocop:disable Metrics/BlockLeng
     CollectionsMailer.with(**payload).deposit_access_removed_email.deliver_later
   end
   Notifier.subscribe(event_name: Notifier::DEPOSITOR_ADDED) do |payload|
-    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
+    CollectionParticipantsChangedSubscriptionMailer.call(**payload)
   end
   Notifier.subscribe(event_name: Notifier::DEPOSITOR_REMOVED) do |payload|
-    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
+    CollectionParticipantsChangedSubscriptionMailer.call(**payload)
   end
   Notifier.subscribe(event_name: Notifier::ACCESSIONING_STARTED) do |payload|
     CollectionAccessioningStartedSubscriptionMailer.call(**payload)
@@ -24,10 +24,10 @@ Rails.application.config.after_initialize do # rubocop:disable Metrics/BlockLeng
     CollectionsMailer.with(**payload).manage_access_granted_email.deliver_later
   end
   Notifier.subscribe(event_name: Notifier::MANAGER_ADDED) do |payload|
-    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
+    CollectionParticipantsChangedSubscriptionMailer.call(**payload)
   end
   Notifier.subscribe(event_name: Notifier::MANAGER_REMOVED) do |payload|
-    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
+    CollectionParticipantsChangedSubscriptionMailer.call(**payload)
   end
 
   # Reviewer change notifications

--- a/spec/jobs/deposit_collection_job_spec.rb
+++ b/spec/jobs/deposit_collection_job_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe DepositCollectionJob do
       allow(Notifier).to receive(:publish)
     end
 
-    it 'publishes a MANGER_ADDED notification' do
+    it 'publishes a MANAGER_ADDED notification' do
       described_class.perform_now(collection_form:, collection:, current_user:)
       expect(collection.managers).to include(manager)
       expect(Notifier).to have_received(:publish).with(Notifier::MANAGER_ADDED, collection:, user: manager)

--- a/spec/mailers/collections_mailer_spec.rb
+++ b/spec/mailers/collections_mailer_spec.rb
@@ -118,12 +118,10 @@ RSpec.describe CollectionsMailer do
       let(:collection) do
         create(:collection,
                title: '20 Minutes into the Future',
-               managers: [manager],
-               email_when_participants_changed: true,
-               version: 2) # Ensure it's not a first version
+               managers: [manager])
       end
-      let(:mail) { described_class.with(user:, collection:).participants_changed_email }
-      let(:manager) { create(:user) }
+      let(:mail) { described_class.with(user: manager, collection:).participants_changed_email }
+      let(:manager) { create(:user, first_name: 'Edison') }
 
       it 'renders the headers' do
         expect(mail.subject).to eq 'Participant changes for the 20 Minutes into the Future ' \
@@ -136,64 +134,6 @@ RSpec.describe CollectionsMailer do
         expect(mail).to match_body("Dear #{manager.first_name},")
         expect(mail).to match_body('Members have been either added to or removed from the ' \
                                    '20 Minutes into the Future collection.')
-      end
-
-      context 'when adding participants while setting up a new collection' do
-        let(:collection) do
-          create(:collection,
-                 title: '20 Minutes into the Future',
-                 managers: [manager],
-                 email_when_participants_changed: true,
-                 version: 1)
-        end
-
-        it 'does not render an email' do
-          expect(mail.message).to be_a(ActionMailer::Base::NullMail)
-        end
-      end
-
-      context 'when adding participants while saving a collection that is still on v1 but has previously been saved' do
-        let(:collection) do
-          create(:collection,
-                 title: '20 Minutes into the Future',
-                 managers: [manager],
-                 email_when_participants_changed: true,
-                 version: 1)
-        end
-
-        before { collection.update(title: '21 Minutes into the Future') } # simulate an update when on v1
-
-        it 'renders the body' do
-          expect(mail).to match_body("Dear #{manager.first_name},")
-          expect(mail).to match_body('Members have been either added to or removed from the ' \
-                                     '21 Minutes into the Future collection.')
-        end
-      end
-
-      context 'when adding participants while saving a collection for the first time on v2' do
-        let(:collection) do
-          create(:collection,
-                 title: '20 Minutes into the Future',
-                 managers: [manager],
-                 email_when_participants_changed: true,
-                 version: 2)
-        end
-
-        it 'renders the body' do
-          expect(mail).to match_body("Dear #{manager.first_name},")
-          expect(mail).to match_body('Members have been either added to or removed from the ' \
-                                     '20 Minutes into the Future collection.')
-        end
-      end
-    end
-
-    context 'when notify managers and reviewers on participant changes is disabled' do
-      before do
-        ActionMailer::Base.deliveries.clear
-      end
-
-      it 'does not render an email' do
-        expect(ActionMailer::Base.deliveries).to be_empty
       end
     end
   end

--- a/spec/subscription_handlers/collection_participants_changed_subscription_mailer_spec.rb
+++ b/spec/subscription_handlers/collection_participants_changed_subscription_mailer_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionParticipantsChangedSubscriptionMailer, :active_job_test_adapter do
+  include ActionMailer::TestHelper
+
+  let(:current_user) { create(:user) }
+  let(:owner) { create(:user) }
+  let(:manager) { create(:user) }
+  let(:reviewer) { create(:user) }
+
+  context 'when previously deposited collection' do
+    let(:collection) do
+      create(:collection, user: owner, version: 2, managers: [manager],
+                          reviewers: [reviewer], email_when_participants_changed: true)
+    end
+
+    it 'sends the collection participants changed email to managers and reviewers' do
+      described_class.call(collection:)
+
+      assert_enqueued_email_with CollectionsMailer.with(collection:, user: manager), :participants_changed_email
+      assert_enqueued_email_with CollectionsMailer.with(collection:, user: reviewer), :participants_changed_email
+    end
+  end
+
+  context 'when collection is new' do
+    let(:collection) do
+      create(:collection,
+             title: '20 Minutes into the Future',
+             managers: [manager],
+             email_when_participants_changed: true,
+             version: 1)
+    end
+
+    it 'does not render an email' do
+      expect do
+        described_class.call(collection:)
+      end.not_to have_enqueued_mail(CollectionsMailer, :participants_changed_email)
+    end
+  end
+
+  context 'when collection with email_when_participants_changed false' do
+    let(:collection) do
+      create(:collection, user: owner, managers: [manager],
+                          reviewers: [reviewer], email_when_participants_changed: false)
+    end
+
+    it 'sends the collection participants changed email to managers and reviewers' do
+      expect do
+        described_class.call(collection:)
+      end.not_to have_enqueued_mail(CollectionsMailer, :participants_changed_email)
+    end
+  end
+
+  context 'when a participant is a manager and reviewer' do
+    let(:collection) do
+      create(:collection, user: owner, version: 2, managers: [manager],
+                          reviewers: [manager], email_when_participants_changed: true)
+    end
+
+    before do
+      allow(CollectionsMailer).to receive(:with).and_call_original
+    end
+
+    it 'sends the email to the manager address once' do
+      described_class.call(collection:)
+
+      expect(CollectionsMailer).to have_received(:with).with(collection:, user: manager).once
+      assert_enqueued_email_with CollectionsMailer.with(collection:, user: manager), :participants_changed_email
+    end
+  end
+end


### PR DESCRIPTION
Use a subscription handler to manage sending participants changed email. 

Tested on stage. 

Fixes #1735 