### PR TITLE
raise standarderror

### DIFF
--- a/app/services/ror_service.rb
+++ b/app/services/ror_service.rb
@@ -25,8 +25,6 @@ class RorService
 
   def organizations
     conn.get('/v2/organizations', params, headers).body
-  rescue Faraday::Error => e
-    raise StandardError, "RoR Service connection error: #{e.message}"
   end
 
   def new_conn

--- a/app/services/ror_service.rb
+++ b/app/services/ror_service.rb
@@ -26,7 +26,7 @@ class RorService
   def organizations
     conn.get('/v2/organizations', params, headers).body
   rescue Faraday::Error => e
-    raise Error, "Connection err: #{e.message}"
+    raise StandardError, "RoR Service connection error: #{e.message}"
   end
 
   def new_conn


### PR DESCRIPTION
see https://app.honeybadger.io/projects/128495/faults/122702166

~~I think we want to raise `StandardError` instead to get better HB alerts?~~

Just let faraday exception go to HB if it happens