### PR TITLE
Remove duplicates from works list in dashboard collection table

### DIFF
--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -46,7 +46,7 @@ class WorkPolicy < ApplicationPolicy
       relation.left_outer_joins(:shares)
             # This is any share, not a specific permission
             .where(shares: { user: })
-    )
+    ).distinct
   end
 
   private

--- a/app/services/work_sort_service.rb
+++ b/app/services/work_sort_service.rb
@@ -38,9 +38,11 @@ class WorkSortService
   private
 
   def statuses_for(works)
-    Sdr::Repository.statuses(
-      druids: works.where.not(druid: nil).pluck(:druid)
-    )
+    # Rather than using pluck on the ActiveRecord Relation, convert to an array first.
+    # This is because we are using distinct previously in the work_policy collection scope.
+    druids = works.where.not(druid: nil).map(&:druid)
+
+    Sdr::Repository.statuses(druids:)
   end
 
   def presenters_from(works:, statuses:)

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe WorkPolicy do
       policy.apply_scope(target, name: :collection, type: :active_record_relation, scope_options: { collection: }).to_a
     end
 
-    let!(:unowned_work) { create(:work, collection:, title: 'unknowned') }
+    let!(:unowned_work) { create(:work, collection:, title: 'unowned') }
 
     let(:policy) { described_class.new(user:) }
 
@@ -284,6 +284,18 @@ RSpec.describe WorkPolicy do
       let(:permission) { 'deposit' }
 
       it { is_expected.to eq([shared_work]) }
+    end
+
+    context 'when there are shares for the work in the collection' do
+      let(:user) { owner }
+      let!(:shared_work) { create(:work, user: owner, collection:, title: 'shared') }
+      let(:permission) { 'deposit' }
+
+      before do
+        create(:share, user: plain_old_user, work: shared_work, permission:)
+      end
+
+      it { is_expected.to eq([owned_work, shared_work]) }
     end
   end
 end


### PR DESCRIPTION
Dashboard query to populate the works in a collection was including some works multiple times in the result. This resulted in the user seeing the same work multiple times in the dashboard table. Only non-admins or people who are not managers/reviewers of the collection would see this result. The work also had to have been shared with others. 