### PR TITLE
Replace unprocessable_entity with unprocessable_content.

### DIFF
--- a/app/controllers/admin/depositors_search_controller.rb
+++ b/app/controllers/admin/depositors_search_controller.rb
@@ -19,7 +19,7 @@ module Admin
       if @depositors_search_form.valid?
         @druid_to_sunetid_map = Admin::DepositorsSearch.call(form: @depositors_search_form)
       else
-        render :search, status: :unprocessable_entity
+        render :search, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/admin/druid_search_controller.rb
+++ b/app/controllers/admin/druid_search_controller.rb
@@ -16,7 +16,7 @@ module Admin
       if @druid_search_form.valid?
         redirect_to_work_or_collection
       else
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/admin/move_controller.rb
+++ b/app/controllers/admin/move_controller.rb
@@ -21,7 +21,7 @@ module Admin
 
         render_move_success
       else
-        render :form, status: :unprocessable_entity
+        render :form, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/admin/users_search_controller.rb
+++ b/app/controllers/admin/users_search_controller.rb
@@ -18,7 +18,7 @@ module Admin
         @status_map = get_status_map(@user)
         render :new
       else
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -53,7 +53,7 @@ class CollectionsController < ApplicationController
       redirect_to wait_collections_path(collection.id)
     else
       add_blank_contributor
-      render :form, status: :unprocessable_entity
+      render :form, status: :unprocessable_content
     end
   end
 
@@ -68,7 +68,7 @@ class CollectionsController < ApplicationController
       redirect_to wait_collections_path(@collection.id)
     else
       add_blank_contributor
-      render :form, status: :unprocessable_entity
+      render :form, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/content_files_controller.rb
+++ b/app/controllers/content_files_controller.rb
@@ -20,7 +20,7 @@ class ContentFilesController < ApplicationController
     if @content_file.update(content_file_params)
       redirect_to content_file_path(@content_file)
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/globuses_controller.rb
+++ b/app/controllers/globuses_controller.rb
@@ -30,7 +30,7 @@ class GlobusesController < ApplicationController
   def done_uploading
     authorize! with: GlobusPolicy
 
-    return render :uploading, status: :unprocessable_entity if (@tasks_in_progress = tasks_in_progress?)
+    return render :uploading, status: :unprocessable_content if (@tasks_in_progress = tasks_in_progress?)
 
     GlobusListJob.perform_later(content: @content)
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -70,7 +70,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
     else
       handle_invalid
       set_license_presenter
-      render :form, status: :unprocessable_entity
+      render :form, status: :unprocessable_content
     end
   end
 
@@ -88,7 +88,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
       handle_no_changes_or_invalid
       set_license_presenter
       set_presenter
-      render :form, status: :unprocessable_entity
+      render :form, status: :unprocessable_content
     end
   end
 
@@ -126,7 +126,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
       redirect_path = perform_review
       redirect_to redirect_path
     else
-      render :show, status: :unprocessable_entity
+      render :show, status: :unprocessable_content
     end
   end
 

--- a/spec/requests/admin/depositors_search_spec.rb
+++ b/spec/requests/admin/depositors_search_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Search for depositor IDs' do
 
         it 're-renders the form with errors' do
           get "/admin/depositors_search/search?admin_depositors_search[druids]=#{URI.encode_uri_component(druids)}"
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to match(/work not found: druid:foobar/)
         end
       end

--- a/spec/requests/admin/druid_search_spec.rb
+++ b/spec/requests/admin/druid_search_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Search for druid' do
       it 'show search results' do
         get '/admin/druid_search/search?admin_druid_search[druid]=foo&commit=Submit'
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include('not found')
       end
     end

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Create work' do
       it 'is able to submit the new work form' do
         post '/works', params: { work: { collection_druid: collection_druid_fixture, content_id: content.id } }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -51,7 +51,7 @@ RSpec.describe 'Create work' do
       it 'is able to submit the new work form' do
         post '/works', params: { work: { collection_druid: collection_druid_fixture, content_id: content.id } }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe 'Create work' do
       it 'is able to submit the new work form' do
         post '/works', params: { work: { collection_druid: collection_druid_fixture, content_id: content.id } }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/requests/update_content_file_spec.rb
+++ b/spec/requests/update_content_file_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Update content file' do
       it 'renders the edit form with an HTTP 422' do
         patch "/content_files/#{content_file.id}", params: { content_file: content_file_params }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end


### PR DESCRIPTION
```
warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.
```