### PR TITLE
add RoR client id to API calls

### DIFF
--- a/app/services/ror_service.rb
+++ b/app/services/ror_service.rb
@@ -38,7 +38,8 @@ class RorService
   def headers
     {
       'Accept' => 'application/json',
-      'User-Agent' => 'Stanford Self-Deposit (Hungry Hungry Hippo)'
+      'User-Agent' => 'Stanford Self-Deposit (Hungry Hungry Hippo)',
+      'Client-Id' => Settings.ror.client_id
     }
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -95,3 +95,4 @@ google_analytics:
 
 ror:
   url: https://api.ror.org
+  client_id: hungry-hungry-hippo-stanford-university # actual client ID in shared_configs

--- a/spec/services/ror_service_spec.rb
+++ b/spec/services/ror_service_spec.rb
@@ -6,11 +6,16 @@ RSpec.describe RorService do
   subject(:organizations) { described_class.call(search:) }
 
   let(:search) { 'stanford' }
+  let(:headers) do
+    { 'Accept' => 'application/json',
+      'User-Agent' => 'Stanford Self-Deposit (Hungry Hungry Hippo)',
+      'Client-Id' => Settings.ror.client_id }
+  end
 
   context 'when the ror service returns results' do
     before do
       stub_request(:get, "https://api.ror.org/v2/organizations?query=#{search}")
-        .with(headers: { 'Accept' => 'application/json' })
+        .with(headers:)
         .to_return(status: 200, body:, headers: { 'Content-Type': 'application/json;charset=UTF-8' })
     end
 
@@ -101,7 +106,7 @@ RSpec.describe RorService do
 
     before do
       stub_request(:get, "https://api.ror.org/v2/organizations?query=#{search}")
-        .with(headers: { 'Accept' => 'application/json' })
+        .with(headers:)
         .to_return(status: 200, body:, headers: { 'Content-Type': 'application/json;charset=UTF-8' })
     end
 
@@ -115,7 +120,7 @@ RSpec.describe RorService do
 
     before do
       stub_request(:get, "https://api.ror.org/v2/organizations?query=#{search}")
-        .with(headers: { 'Accept' => 'application/json' })
+        .with(headers:)
         .to_return(status: 404, body:, headers: { 'Content-Type': 'application/json;charset=UTF-8' })
     end
 


### PR DESCRIPTION
Add RoR Client ID to header for API calls to avoid usage limits

prod shared_configs PR: https://github.com/sul-dlss/shared_configs/pull/2419
(qa and stage shared_configs already merged)