### PR TITLE
Allow all AJ-based jobs to retry automatically

### DIFF
--- a/app/jobs/collection_reports_job.rb
+++ b/app/jobs/collection_reports_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Creates a collection report requested via the admin UI and emails it to the user.
-class CollectionReportsJob < ApplicationJob
+class CollectionReportsJob < RetriableJob
   # @param [Admin::CollectionReportForm] collection_report_form
   # @param [User] current_user
   def perform(collection_report_form:, current_user:)

--- a/app/jobs/globus_list_job.rb
+++ b/app/jobs/globus_list_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Job to list files in a Globus endpoint and create ContentFile records.
-class GlobusListJob < ApplicationJob
+class GlobusListJob < RetriableJob
   include Rails.application.routes.url_helpers
 
   def perform(content:, cancel_check_interval: 100)

--- a/app/jobs/globus_setup_job.rb
+++ b/app/jobs/globus_setup_job.rb
@@ -2,7 +2,7 @@
 
 # Creates a Globus directory for a user than can be used to upload files for a new work.
 # Note that until a draft is saved / deposited, the druid or work id is not known, hence using /new.
-class GlobusSetupJob < ApplicationJob
+class GlobusSetupJob < RetriableJob
   def perform(user:, content:)
     @user = user
     @content = content

--- a/app/jobs/retriable_job.rb
+++ b/app/jobs/retriable_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# SolidQueue does not auto-retry jobs so we use ActiveJob to accomplish the same thing.
+class RetriableJob < ApplicationJob
+  # This includes the first run plus all retries
+  MAX_ATTEMPTS = 5
+
+  # Retriable jobs should retry when any exception is raised. Retry
+  # `MAX_ATTEMPTS` times, and use exponential backoff so that the attempts are
+  # spread across a span of roughly ten minutes.
+  #
+  # If the number of attempts hits the max, log and alert that this has happened.
+  retry_on StandardError, attempts: MAX_ATTEMPTS,
+                          wait: ->(executions) { (executions**4) + (Kernel.rand * (executions**3)) + 2 } do |job, error|
+    # We're out of retries
+    Rails.logger.error(
+      "Job #{job.job_id} was failed after #{MAX_ATTEMPTS} runs due to #{error.class}: #{error.message}"
+    )
+    Honeybadger.context(job_id: job.job_id, attempts: MAX_ATTEMPTS)
+    raise error
+  end
+end

--- a/app/jobs/terms_reminder_email_job.rb
+++ b/app/jobs/terms_reminder_email_job.rb
@@ -5,7 +5,7 @@
 # Running daily means there should not be too many emails sent at a time (i.e. since users agree to
 # the terms of deposit over time as they first start using H3, the number of users surpassing a
 # year on any given day should be small).
-class TermsReminderEmailJob < ApplicationJob
+class TermsReminderEmailJob < RetriableJob
   def perform
     users = User.where(terms_reminder_email_last_sent_at: ...1.year.ago)
                 .or(User.where(agreed_to_terms_at: ...1.year.ago, terms_reminder_email_last_sent_at: nil))

--- a/app/jobs/work_reports_job.rb
+++ b/app/jobs/work_reports_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Creates a work item report requested via the admin UI and emails it to the user.
-class WorkReportsJob < ApplicationJob
+class WorkReportsJob < RetriableJob
   # @param [Admin::WorkReportForm] work_report_form
   # @param [User] current_user
   def perform(work_report_form:, current_user:)


### PR DESCRIPTION
This touches every job but the deposit complete job, which is based on Sneakers not on AJ.

This is the same implementation used in Heracles.
