### PR TITLE
CollectionRoundtripper#roundtripped_cocina_object: call RoundtripSupport.normalize_cocina_object on result before returning for more consistent comparison with normalized_original_cocina_object result

### DIFF
--- a/app/roundtrippers/collection_roundtripper.rb
+++ b/app/roundtrippers/collection_roundtripper.rb
@@ -33,8 +33,10 @@ class CollectionRoundtripper
   attr_reader :collection_form, :content
 
   def roundtripped_cocina_object
-    Cocina::CollectionMapper.call(collection_form:,
-                                  source_id: normalized_original_cocina_object.identification&.sourceId)
+    Cocina::CollectionMapper.call(
+      collection_form:,
+      source_id: normalized_original_cocina_object.identification&.sourceId
+    ).then { |roundtripped_obj| RoundtripSupport.normalize_cocina_object(cocina_object: roundtripped_obj) }
   end
 
   def normalized_original_cocina_object


### PR DESCRIPTION
connects with #1839 (even if this is the right fix, the should probably be a new test?)