### PR TITLE
downcase entered sunets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -641,6 +641,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -26,7 +26,7 @@ class AccountsController < ApplicationController
 
   # Returns the sunetid from the params, either from :id (search) or :sunetid (search_user).
   def sunetid
-    @sunetid ||= params[:id] || params[:sunetid]
+    @sunetid ||= (params[:id] || params[:sunetid])&.downcase
   end
 
   # Does a lookup from the account service in production mode, otherwise examines local database for users


### PR DESCRIPTION
Fixes #1805 - downcase entered sunets before looking them up

Probably not needed once we switch to using the Person API to do the lookups, but harmless