### PR TITLE
ensure page title does not have html entities in it

### DIFF
--- a/app/components/elements/breadcrumb_nav_component.rb
+++ b/app/components/elements/breadcrumb_nav_component.rb
@@ -16,7 +16,7 @@ module Elements
     }
 
     def page_title_from_breadcrumbs
-      breadcrumbs.filter_map(&:truncated_text).unshift('SDR').join(' | ')
+      CGI.unescapeHTML(breadcrumbs.filter_map(&:truncated_text).unshift('SDR').join(' | '))
     end
   end
 end


### PR DESCRIPTION
Fixes #1740

Not sure where exactly the collection titles are having these added, probably here: https://github.com/sul-dlss/hungry-hungry-hippo/blob/main/app/components/elements/breadcrumb_nav_component.rb#L11

Tested this on localhost with a collection title containing an apostrophe and it works now as expected.