### PR TITLE
iterate over druids in order entered

### DIFF
--- a/app/services/admin/depositors_search.rb
+++ b/app/services/admin/depositors_search.rb
@@ -29,6 +29,8 @@ module Admin
     attr_reader :druid_list
 
     def selected_works
+      # iterate over the druids so we can preserve the order the user entered them in the results
+      # see https://github.com/sul-dlss/hungry-hungry-hippo/issues/1786
       druid_list.map do |druid|
         Work.joins(:user).select('works.druid, works.user_id, users.email_address').find_by(druid:)
       end


### PR DESCRIPTION
Fixes #1786 

I believe the problem is that we take the druid list entered by the user and then pass it to sql in the where clause as an array.  While efficient (it makes postgres do the work of finding all the druids at once), I am not sure it guarantees the ordering of the sql response.  Iterating one by one will increase the number of sql queries but will guarantee the resulting array will be the same order as provided.  Given this is a druid list provided by the user, I think it is reasonable to assume it is not going to be massive, and thus the performance penalty is mitigated.
