### PR TITLE
rename and re-order columns on collection deposits page

### DIFF
--- a/app/components/collections/show/deposits_component.html.erb
+++ b/app/components/collections/show/deposits_component.html.erb
@@ -3,9 +3,9 @@
                                                 empty_message:) do |component| %>
   <% component.with_headers([
                               { label: 'Deposit' },
+                              { label: 'Deposit Status' },
                               { label: 'Owner' },
-                              { label: 'Status' },
-                              { label: 'Modified' },
+                              { label: 'Last Modified' },
                               { label: t('sharing_link.label'), tooltip: t('sharing_link.tooltip_html') }
                             ]) %>
   <% component.with_rows(collection_deposits) %>

--- a/app/components/collections/show/deposits_component.rb
+++ b/app/components/collections/show/deposits_component.rb
@@ -31,8 +31,8 @@ module Collections
         work = presenter.work
         [
           helpers.link_to(work.title, work_or_wait_path(work), data: { turbo_frame: '_top' }),
-          work.user.name,
           presenter.status_message,
+          work.user.name,
           work.object_updated_at ? helpers.l(work.object_updated_at, format: '%b %d, %Y') : nil,
           presenter.sharing_link
         ]

--- a/app/views/collections/works.html.erb
+++ b/app/views/collections/works.html.erb
@@ -18,12 +18,12 @@
       <%= render Elements::SortDropdownComponent.new(classes: 'ms-2') do |component| %>
         <% component.with_sort_option(label: 'Deposit (ascending)', link: works_collection_path(@collection, sort_by: 'works.title asc', q: @search_term)) %>
         <% component.with_sort_option(label: 'Deposit (descending)', link: works_collection_path(@collection, sort_by: 'works.title desc', q: @search_term)) %>
+        <% component.with_sort_option(label: 'Deposit Status (ascending)', link: works_collection_path(@collection, sort_by: 'status asc', q: @search_term)) %>
+        <% component.with_sort_option(label: 'Deposit Status (descending)', link: works_collection_path(@collection, sort_by: 'status desc', q: @search_term)) %>
         <% component.with_sort_option(label: 'Owner (ascending)', link: works_collection_path(@collection, sort_by: 'users.name asc', q: @search_term)) %>
         <% component.with_sort_option(label: 'Owner (descending)', link: works_collection_path(@collection, sort_by: 'users.name desc', q: @search_term)) %>
-        <% component.with_sort_option(label: 'Status (ascending)', link: works_collection_path(@collection, sort_by: 'status asc', q: @search_term)) %>
-        <% component.with_sort_option(label: 'Status (descending)', link: works_collection_path(@collection, sort_by: 'status desc', q: @search_term)) %>
-        <% component.with_sort_option(label: 'Date modified (Newest first)', link: works_collection_path(@collection, sort_by: 'works.object_updated_at desc', q: @search_term)) %>
-        <% component.with_sort_option(label: 'Date modified (Oldest first)', link: works_collection_path(@collection, sort_by: 'works.object_updated_at asc', q: @search_term)) %>
+        <% component.with_sort_option(label: 'Last modified (Newest first)', link: works_collection_path(@collection, sort_by: 'works.object_updated_at desc', q: @search_term)) %>
+        <% component.with_sort_option(label: 'Last modified (Oldest first)', link: works_collection_path(@collection, sort_by: 'works.object_updated_at asc', q: @search_term)) %>
       <% end %>
     </div>
   </div>

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -192,23 +192,23 @@ RSpec.describe 'Show a collection' do
       # Deposits table
       within('table#deposits-table') do
         expect(page).to have_css('th', text: 'Deposit')
+        expect(page).to have_css('th', text: 'Deposit Status')
         expect(page).to have_css('th', text: 'Owner')
-        expect(page).to have_css('th', text: 'Status')
-        expect(page).to have_css('th', text: 'Modified')
+        expect(page).to have_css('th', text: 'Last Modified')
         expect(page).to have_css('th', text: 'Link for sharing')
         all_trs = page.all('tbody tr')
         expect(all_trs.size).to eq(2) # Since paginated
         work = works[0]
         row = all_trs.find { |tr| tr.has_css?('td:nth-of-type(1)', text: work.title) }
         within(row) do
-          expect(page).to have_css('td:nth-of-type(2)', text: work.user.name)
-          expect(page).to have_css('td:nth-of-type(3)', text: 'Pending review')
+          expect(page).to have_css('td:nth-of-type(2)', text: 'Pending review')
+          expect(page).to have_css('td:nth-of-type(3)', text: work.user.name)
           expect(page).to have_css('td:nth-of-type(5)', text: "https://doi.org/10.80343/#{work.druid.delete_prefix('druid:')}")
         end
         work = works[1]
         row = all_trs.find { |tr| tr.has_css?('td:nth-of-type(1)', text: work.title) }
         within(row) do
-          expect(page).to have_css('td:nth-of-type(3)', text: 'Deposited')
+          expect(page).to have_css('td:nth-of-type(2)', text: 'Deposited')
         end
       end
 
@@ -246,7 +246,7 @@ RSpec.describe 'Show a collection' do
         expect(all_trs.size).to eq(1) # Since paginated
         within(all_trs.first) do
           expect(page).to have_css('td:nth-of-type(1)', text: works[2].title)
-          expect(page).to have_css('td:nth-of-type(3)', text: 'Saving')
+          expect(page).to have_css('td:nth-of-type(2)', text: 'Saving')
           expect(page).to have_css('td:nth-of-type(5)', exact_text: '')
         end
       end


### PR DESCRIPTION
Fixes #1835 

Note that I also updated the text in the drop-down sort menu to match the new column names and orders (see screenshot below)

<img width="1174" height="404" alt="Screenshot 2026-02-04 at 3 58 00 PM" src="https://github.com/user-attachments/assets/686be991-08d8-42c8-ae35-c49f9d11175e" />
