### PR TITLE
Handle missing affiliation URI.

### DIFF
--- a/app/cocina_builders/contributor_affiliation_cocina_builder.rb
+++ b/app/cocina_builders/contributor_affiliation_cocina_builder.rb
@@ -25,14 +25,17 @@ class ContributorAffiliationCocinaBuilder
 
   def institution_params
     {
-      value: institution,
-      identifier: [
-        {
-          uri:,
-          type: 'ROR',
-          source: { code: 'ror' }
-        }
-      ]
-    }
+      value: institution
+    }.tap do |params|
+      if uri.present?
+        params[:identifier] = [
+          {
+            uri:,
+            type: 'ROR',
+            source: { code: 'ror' }
+          }
+        ]
+      end
+    end
   end
 end

--- a/app/mappers/form/work_contributors_mapper.rb
+++ b/app/mappers/form/work_contributors_mapper.rb
@@ -46,9 +46,15 @@ module Form
         end
       end
 
-      def affiliation_from(affiliation)
+      def affiliation_from(affiliation) # rubocop:disable Metrics/AbcSize
         institution = affiliation.structuredValue.find { |descriptive_value| descriptive_value.identifier.present? }
-        department = affiliation.structuredValue.find { |descriptive_value| descriptive_value.identifier.blank? }
+        if institution.present?
+          department = affiliation.structuredValue.find { |descriptive_value| descriptive_value.identifier.blank? }
+        else
+          # If institution doesn't have a ROR identifier, assume that first is institution and second is department.
+          institution = affiliation.structuredValue.first
+          department = affiliation.structuredValue.second
+        end
 
         {
           'institution' => institution.value,

--- a/spec/cocina_builders/person_contributor_cocina_builder_spec.rb
+++ b/spec/cocina_builders/person_contributor_cocina_builder_spec.rb
@@ -99,5 +99,29 @@ RSpec.describe PersonContributorCocinaBuilder do
         expect(contributor_params[:affiliation]).to eq(expected_affiliations)
       end
     end
+
+    context 'when ROR URI is not present' do
+      let(:affiliations) do
+        [
+          AffiliationForm.new(
+            institution: 'Stanford University'
+          )
+        ]
+      end
+
+      it 'includes affiliations' do
+        expected_affiliations = [
+          {
+            structuredValue: [
+              {
+                value: 'Stanford University'
+              }
+            ]
+          }
+        ]
+
+        expect(contributor_params[:affiliation]).to eq(expected_affiliations)
+      end
+    end
   end
 end

--- a/spec/mappers/form/work_contributors_mapper_spec.rb
+++ b/spec/mappers/form/work_contributors_mapper_spec.rb
@@ -221,6 +221,63 @@ RSpec.describe Form::WorkContributorsMapper do
     end
   end
 
+  context 'when a person with an affiliation without a ROR' do
+    let(:cocina_contributor_params) do
+      {
+        name: [
+          {
+            structuredValue: [
+              { value: 'Jane', type: 'forename' },
+              { value: 'Stanford', type: 'surname' }
+            ]
+          }
+        ],
+        type: 'person',
+        status: 'primary',
+        identifier: [
+          {
+            type: 'ORCID',
+            value: '0000-0000-0000-0000',
+            source: {
+              uri: 'https://orcid.org'
+            }
+          }
+        ],
+        affiliation: [
+          {
+            structuredValue: [
+              {
+                value: 'Stanford University'
+              },
+              { value: 'Department of History' }
+            ]
+          }
+        ]
+      }
+    end
+
+    it 'maps to contributor params' do
+      expect(contributor_params).to eq([
+                                         'first_name' => 'Jane',
+                                         'last_name' => 'Stanford',
+                                         'role_type' => 'person',
+                                         'person_role' => nil,
+                                         'organization_role' => nil,
+                                         'organization_name' => nil,
+                                         'suborganization_name' => nil,
+                                         'stanford_degree_granting_institution' => false,
+                                         'orcid' => '0000-0000-0000-0000',
+                                         'with_orcid' => true,
+                                         'affiliations_attributes' => [
+                                           {
+                                             'institution' => 'Stanford University',
+                                             'department' => 'Department of History'
+                                           }
+                                         ]
+                                       ])
+    end
+  end
+
   context 'when role is absent' do
     let(:cocina_contributor_params) do
       {


### PR DESCRIPTION
closes #1879

In the current H3, an affiliation will always have a ROR. However, that may not be the case when mapping from CrossRef, etc.