### PR TITLE
email link sends user to collection deposits tab

### DIFF
--- a/app/views/collections_mailer/invitation_to_deposit_email.html.erb
+++ b/app/views/collections_mailer/invitation_to_deposit_email.html.erb
@@ -1,7 +1,7 @@
 <%= render Emails::SalutationComponent.new(user: @user) %>
 
 <p>You have been invited to deposit to the <%= @collection.title %> collection in the Stanford Digital Repository.
-  Start your deposit at <%= link_to collection_url(@collection.druid), collection_url(@collection.druid, anchor: 'deposits') %>.</p>
+  Start your deposit at <%= link_to collection_url(@collection.druid), collection_url(@collection.druid, tab: 'deposits') %>.</p>
 
 <p>SDR deposits can be discovered in the Stanford library catalog and can be accessed by others at a public webpage. <a href="https://purl.stanford.edu/wd068fv8349">Example of a public webpage.</a>
 

--- a/spec/mailers/previews/collections_mailer_preview.rb
+++ b/spec/mailers/previews/collections_mailer_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Preview with http://localhost:3000/rails/mailers/collections_mailer/invitation_to_deposit_email
+class CollectionsMailerPreview < ActionMailer::Preview
+  def invitation_to_deposit_email
+    user = User.first || FactoryBot.create(:user)
+    collection = Collection.first || FactoryBot.create(:collection)
+
+    CollectionsMailer.with(user:, collection:).invitation_to_deposit_email
+  end
+end


### PR DESCRIPTION
Fixes #1878 

We need to go use a `?tab=deposits` in the URL and not an anchor.  See https://github.com/sul-dlss/hungry-hungry-hippo/blob/main/app/views/collections/show.html.erb#L20

Created a mailer preview to verify