### PR TITLE
explicitly delete content before work

### DIFF
--- a/app/controllers/admin/delete_work_controller.rb
+++ b/app/controllers/admin/delete_work_controller.rb
@@ -12,6 +12,10 @@ module Admin
     def destroy
       authorize!
 
+      # ensure all associated content is deleted first (possible race condition
+      # causing issues with foreign key constraint errors)
+      work.content.destroy_all
+
       work.destroy!
       render_delete_success
     end


### PR DESCRIPTION
Fixes #1893 (maybe) --  it seems like the work that triggered that ticket did actually get deleted despite the sql constraint error. This just explicitly deletes the associated content first (and all of the content_files via the dependent destroy) to see if this helps.  Note that rails should be doing this automatically via callbacks and the existing dependent destroy in the work, but perhaps it is not happening fast enough, or perhaps there are issues with "dangling" content that hasn't been cleaned up properly?