### PR TITLE
Update the datacite gem to pick up validation fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
       listen (~> 3)
       parser (~> 3)
       webrick-websocket (~> 0.0.4)
-    datacite (0.8.0)
+    datacite (0.8.1)
       activesupport
       dry-monads (~> 1.3)
       faraday (~> 2.0)


### PR DESCRIPTION
Pick up the most recent datacite-ruby release to pick up mapping/validation fix.