### PR TITLE
Builds out DOI section of article form.

### DIFF
--- a/app/components/articles/edit/lookup_table_component.html.erb
+++ b/app/components/articles/edit/lookup_table_component.html.erb
@@ -1,0 +1,6 @@
+<%= render Elements::Tables::TableComponent.new(id: 'article-table', label: 'Details for the article', show_label: false, classes:) do |component| %>
+  <% component.with_row(label: 'Title', values: [title]) %>
+  <% component.with_row(label: 'Authors', values: [authors]) %>
+  <% component.with_row(label: 'Publication date', values: [publication_date]) %>
+  <% component.with_row(label: 'Abstract', values: [abstract]) %>
+<% end %>

--- a/app/components/articles/edit/lookup_table_component.rb
+++ b/app/components/articles/edit/lookup_table_component.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Articles
+  module Edit
+    # Component for rendering the article details from a CrossRef lookup
+    class LookupTableComponent < ApplicationComponent
+      def initialize(article_work_form:, classes: [])
+        @article_work_form = article_work_form
+        @classes = classes
+        super()
+      end
+
+      attr_reader :article_work_form, :classes
+
+      delegate :title, to: :article_work_form
+
+      def publication_date
+        if article_work_form.publication_date.present?
+          I18n.l(article_work_form.publication_date.to_date,
+                 format: :long)
+        else
+          ''
+        end
+      end
+
+      def authors
+        article_work_form.contributors.map do |contributor|
+          formatted_contributor(contributor)
+        end.join(', ')
+      end
+
+      def abstract
+        article_work_form.abstract.present? ? helpers.simple_format(article_work_form.abstract).html_safe : '' # rubocop:disable Rails/OutputSafety
+      end
+
+      def render?
+        article_work_form.present?
+      end
+
+      private
+
+      def formatted_contributor(contributor)
+        "#{contributor.first_name} #{contributor.last_name}".tap do |name|
+          name << " #{Settings.orcid.url}/#{contributor.orcid}" if contributor.orcid.present?
+          name << " (#{contributor.affiliations.map(&:institution).join('; ')})" if contributor.affiliations.any?
+        end
+      end
+    end
+  end
+end

--- a/app/views/articles/form.html.erb
+++ b/app/views/articles/form.html.erb
@@ -48,13 +48,32 @@
 
     <%= render Elements::HorizontalRuleComponent.new(classes: 'my-5') %>
 
-    <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :doi, label: 'DOI for published version of this work', mark_required: true) %>
-
-    <%= render Elements::Forms::SubmitComponent.new(label: 'Lookup', classes: 'mt-2', variant: :'outline-primary', data: { action: 'unsaved-changes#allowFormSubmission' }, value: 'lookup') %>
-
-    <% if @article_work_form %>
-      <%= @article_work_form.title %>
+    <%= render Elements::AlertComponent.new(classes: 'mb-4') do %>
+      If you don't have a DOI, please use the <%= link_to 'full deposit form', new_work_path(collection_druid: @collection.druid) %> to deposit your item.
     <% end %>
+
+    <div class="row align-items-top">
+      <div class="col-4 pt-2">
+        <%= render Elements::Forms::LabelComponent.new(form:, field_name: :doi, label_text: 'DOI for published version of this article') %>
+      </div>
+      <div class="col-8">
+        <div class="d-flex align-items-center">
+          <div class="input-group">
+            <span class="input-group-text">
+              https://doi.org/
+            </span>
+            <%= form.text_field :doi, class: 'form-control' %>
+          </div>
+          <div class="ms-1 text-nowrap">
+            <%= render Elements::Forms::SubmitComponent.new(label: 'Look up', data: { action: 'unsaved-changes#allowFormSubmission' }, value: 'lookup') %>
+          </div>
+        </div>
+
+        <%= render Elements::Forms::InvalidFeedbackComponent.new(form:, field_name: :doi) %>
+      </div>
+    </div>
+
+    <%= render Articles::Edit::LookupTableComponent.new(article_work_form: @article_work_form, classes: 'mt-3') %>
 
     <div class="d-flex justify-content-between mt-5 mb-4">
       <div>

--- a/spec/components/articles/edit/lookup_table_component_spec.rb
+++ b/spec/components/articles/edit/lookup_table_component_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Articles::Edit::LookupTableComponent, type: :component do
+  let(:component) { described_class.new(article_work_form: article_form) }
+
+  let(:article_form) do
+    ArticleWorkForm.new(
+      title: title_fixture,
+      abstract: abstract_fixture,
+      publication_date_attributes: { year: 2025, month: 8, day: 13 },
+      contributors_attributes: [
+        {
+          first_name: 'Yufeng',
+          last_name: 'Song',
+          person_role: 'author',
+          orcid: '0009-0001-6788-1717',
+          affiliations_attributes: [
+            {
+              institution: 'Department of Pediatrics, University of Virginia',
+              uri: 'https://ror.org/0153tk833'
+            }
+          ]
+        },
+        {
+          first_name: 'Frances',
+          last_name: 'Mehl',
+          person_role: 'author',
+          orcid: '0009-0005-9929-3185'
+        },
+        {
+          first_name: 'Lyndsey M.',
+          last_name: 'Muehling',
+          person_role: 'author',
+          affiliations_attributes: [
+            {
+              institution: 'Department of Medicine, University of Virginia',
+              uri: 'https://ror.org/0153tk833'
+            }
+          ]
+        },
+        {
+          first_name: 'Glenda',
+          last_name: 'Canderan',
+          person_role: 'author'
+        }
+      ]
+    )
+  end
+
+  it 'renders the article details table' do
+    render_inline(component)
+
+    table = page.find('table#article-table[aria-label="Details for the article"]')
+    rows = table.all('tr')
+    expect(rows.length).to eq(4)
+    expect(rows[0]).to have_css('th', text: 'Title')
+    expect(rows[0]).to have_css('td', text: title_fixture)
+    expect(rows[1]).to have_css('th', text: 'Authors')
+    expect(rows[1])
+      .to have_css('td', text: 'Yufeng Song https://orcid.org/0009-0001-6788-1717 (Department of Pediatrics, ' \
+                               'University of Virginia), Frances Mehl https://orcid.org/0009-0005-9929-3185, Lyndsey ' \
+                               'M. Muehling (Department of Medicine, University of Virginia), Glenda Canderan')
+    expect(rows[2]).to have_css('th', text: 'Publication date')
+    expect(rows[2]).to have_css('td', text: 'August 13, 2025')
+    expect(rows[3]).to have_css('th', text: 'Abstract')
+    expect(rows[3]).to have_css('td', text: abstract_fixture)
+  end
+end

--- a/spec/system/create_article_deposit_spec.rb
+++ b/spec/system/create_article_deposit_spec.rb
@@ -49,13 +49,13 @@ RSpec.describe 'Create an article deposit' do
     expect(page).to have_css('h1', text: 'Article deposit')
 
     # Validate blank DOI submission
-    click_link_or_button('Lookup')
+    click_link_or_button('Look up')
 
     expect(page).to have_css('.invalid-feedback', text: "can't be blank")
 
     # Validate missing DOI submission
     fill_in 'DOI', with: not_found_doi
-    click_link_or_button('Lookup')
+    click_link_or_button('Look up')
     expect(page).to have_css('.invalid-feedback', text: 'not found')
 
     # Deposit without required fields
@@ -66,9 +66,13 @@ RSpec.describe 'Create an article deposit' do
     expect(page).to have_css('.invalid-feedback', text: 'lookup before saving or depositing')
 
     # Lookup
-    click_link_or_button('Lookup')
+    click_link_or_button('Look up')
     expect(page).to have_no_css('.invalid-feedback')
-    expect(page).to have_content(title_fixture)
+
+    within('#article-table') do
+      expect(page).to have_css('th', text: 'Title')
+      expect(page).to have_css('td', text: title_fixture)
+    end
 
     # Adding a file
     find('.dropzone').drop('spec/fixtures/files/hippo.png')

--- a/spec/system/create_article_edit_spec.rb
+++ b/spec/system/create_article_edit_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Create an article then edit before deposit' do
     expect(page).to have_css('table#content-table td', text: 'hippo.png')
 
     fill_in 'DOI', with: doi
-    click_link_or_button('Lookup')
+    click_link_or_button('Look up')
 
     # Deposit
     click_link_or_button('Edit before deposit')


### PR DESCRIPTION
closes #1949

<img width="1235" height="716" alt="image" src="https://github.com/user-attachments/assets/e1f63fc6-4f85-4131-be6c-2050a8692ed7" />
