### PR TITLE
Add an OKComputer status check for globus

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -18,3 +18,17 @@ if Settings.rabbitmq.enabled
                                                               username: Settings.rabbitmq.username,
                                                               password: Settings.rabbitmq.password)
 end
+
+# A custom OkComputer status check for Globus.
+# It uses the Globus user_valid? check to determine if the Globus service is healthy.
+# NOTE: This does not FAIL if the status user is invalid because that still indicates that the Globus service is up
+class GlobusStatusCheck < OkComputer::Check
+  def check
+    GlobusClient.user_valid?('dummy@stanford.edu')
+  rescue StandardError => e
+    mark_failure
+    mark_message "Globus status check failed: #{e.message}"
+  end
+end
+
+OkComputer::Registry.register 'globus', GlobusStatusCheck.new if Settings.globus.enabled


### PR DESCRIPTION
This is a relatively basic custom OKComputer status check for Globus. I chose to use the `GlobusClient.user_valid?` (https://github.com/sul-dlss/globus_client/blob/main/lib/globus_client.rb#L214) as this will only mint a new token if the current token fails. This should avoid constantly minting new tokens that may happen if we used https://github.com/sul-dlss/globus_client/blob/main/lib/globus_client/authenticator.rb#L11 directly.

This will only be included in OKComputer checks when `Settings.globus.enabled: true`. 

Passing:
```
Default Collection
  database: PASSED Schema version: 20260217184300 (0.077s)
  default: PASSED Application is running (0.000s)
  globus: PASSED  (1.507s)
  ruby_version: PASSED Ruby 3.4.2-p28 (0.000s)
```

Failing when the authentication fails:
```
Default Collection
  database: PASSED Schema version: 20260217184300 (0.081s)
  default: PASSED Application is running (0.000s)
  globus: FAILED Globus status check failed: There was a problem with the access token: {"errors": [{"status": "401", "title": "Unauthorized", "id": "10d40040-8a40-4309-ac9a-fcf3d7b5b090", "detail": "Basic auth failed", "code": "UNAUTHORIZED"}], "error": "unauthorized", "error_description": "Unauthorized"}  (0.805s)
  ruby_version: PASSED Ruby 3.4.2-p28 (0.000s)
```

and

```
Default Collection
  database: PASSED Schema version: 20260217184300 (0.010s)
  default: PASSED Application is running (0.000s)
  globus: FAILED Globus status check failed: There was a problem with the access token: {"error":"invalid_client"}  (0.780s)
  ruby_version: PASSED Ruby 3.4.2-p28 (0.000s)
```