### PR TITLE
add ahoy events for tracking article form starting and depositing

### DIFF
--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -9,9 +9,12 @@ module Ahoy
     TOOLTIP_CLICKED = 'tooltip clicked'
     WORK_FORM_STARTED = 'work form started' # User is presented with a work form
     WORK_FORM_COMPLETED = 'work form completed' # User has submitted a valid work form
+    ARTICLE_FORM_STARTED = 'article form started' # User is presented with an article form
+    ARTICLE_FORM_COMPLETED = 'article form completed' # User has submitted a valid article form
     FORM_CHANGED = 'form changed' # User has changed a form
     FILES_UPLOADED = 'files uploaded' # User has uploaded files
     WORK_CREATED = 'work created'
+    ARTICLE_CREATED = 'article created'
     WORK_UPDATED = 'work updated'
     UNCHANGED_WORK_SUBMITTED = 'unchanged work submitted'
     INVALID_WORK_SUBMITTED = 'invalid work submitted'

--- a/spec/system/create_article_deposit_spec.rb
+++ b/spec/system/create_article_deposit_spec.rb
@@ -123,5 +123,14 @@ RSpec.describe 'Create an article deposit' do
     end
 
     expect(Sdr::Repository).to have_received(:accession)
+
+    # Ahoy events created
+    work = Work.find_by(druid:)
+    expect(work).to be_present
+    completed_events = Ahoy::Event.where_event(Ahoy::Event::ARTICLE_FORM_COMPLETED, work_id: work.id)
+    expect(completed_events.count).to eq(1)
+    visit_id = completed_events.first.visit_id
+    expect(Ahoy::Event.where_event(Ahoy::Event::ARTICLE_FORM_STARTED).where(visit_id:).count).to eq(1)
+    expect(Ahoy::Event.where_event(Ahoy::Event::ARTICLE_CREATED, work_id: work.id, deposit: true).count).to eq(1)
   end
 end

--- a/spec/system/create_article_edit_spec.rb
+++ b/spec/system/create_article_edit_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Create an article then edit before deposit' do
     sign_in(user)
   end
 
-  it 'creates and an article and opens for edit', :dropzone do
+  it 'creates an article and opens for edit', :dropzone do
     visit dashboard_path
     click_link_or_button('Deposit article by DOI')
 
@@ -89,5 +89,15 @@ RSpec.describe 'Create an article then edit before deposit' do
 
     # DOI tab should not be present since DOI will not be assigned
     expect(page).to have_no_css('.nav-link', text: 'DOI')
+
+    # Ahoy events created
+    work = Work.find_by(druid:)
+    expect(work).to be_present
+    completed_events = Ahoy::Event.where_event(Ahoy::Event::ARTICLE_FORM_COMPLETED, work_id: work.id)
+    expect(completed_events.count).to eq(1)
+    visit_id = completed_events.first.visit_id
+    expect(Ahoy::Event.where_event(Ahoy::Event::ARTICLE_FORM_STARTED).where(visit_id:).count).to eq(1)
+    # article NOT created
+    expect(Ahoy::Event.where_event(Ahoy::Event::ARTICLE_CREATED, work_id: work.id, deposit: true).count).to eq(0)
   end
 end


### PR DESCRIPTION
Part of #1935 - add ahoy events so we can track article form creation and depositing the same way we do for works

Still todo: update Wiki documentation if this PR is accepted