### PR TITLE
Allows changing github_deposit_enabled settings without other changes.

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -277,7 +277,7 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
     return true if @version_status.open? && (deposit? || request_review?)
 
     # If no previous change, then check for a current change.
-    cocina_object_changed?
+    settings_changed? || cocina_object_changed?
   end
 
   def cocina_object_changed?
@@ -362,5 +362,11 @@ class WorksController < ApplicationController # rubocop:disable Metrics/ClassLen
     else
       WorkForm
     end
+  end
+
+  def settings_changed?
+    work = Work.find_by!(druid:)
+    work.update_settings_from_form(work_form: @work_form)
+    work.changed?
   end
 end

--- a/app/jobs/deposit_github_repository_job.rb
+++ b/app/jobs/deposit_github_repository_job.rb
@@ -12,8 +12,7 @@ class DepositGithubRepositoryJob < ApplicationJob
     # work.github_deposit_enabled.nil? indicates the user has never made a choice to enable GitHub deposit.
     # For the initial deposit (not draft), GitHub deposit is enabled by default.
     # For subsequent edits, the user has a choice which is recorded in the work form.
-    github_deposit_enabled = work.github_deposit_enabled.nil? || work_form.github_deposit_enabled
-
-    work.update!(github_deposit_enabled:)
+    work.update_settings_from_form(work_form:)
+    work.save!
   end
 end

--- a/app/models/github_repository.rb
+++ b/app/models/github_repository.rb
@@ -10,4 +10,8 @@ class GithubRepository < Work
   # Note that github_deposit_enabled is a nillable boolean.
   # Nil indicates that the user has not made a choice about whether to enable GitHub deposit.
   # Only a value of true indicates that GitHub deposit is enabled.
+
+  def update_settings_from_form(work_form:)
+    self.github_deposit_enabled = github_deposit_enabled.nil? || work_form.github_deposit_enabled
+  end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -67,4 +67,8 @@ class Work < ApplicationRecord
   def to_param
     druid
   end
+
+  # Updates any settings given a WorkForm (without persisting).
+  # This methods is overridden in subclasses with settings, e.g., GithubRepositoryWork.
+  def update_settings_from_form(work_form:); end
 end

--- a/spec/models/github_repository_spec.rb
+++ b/spec/models/github_repository_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GithubRepository do
+  describe '#update_settings_from_form' do
+    # self.github_deposit_enabled = github_deposit_enabled.nil? || work_form.github_deposit_enabled
+    context 'when github_deposit_enabled is nil' do
+      let(:work) { create(:github_repository, github_deposit_enabled: nil) }
+      let(:work_form) { instance_double(WorkForm) }
+
+      it 'change settings' do
+        # A Work does not have any settings, so this should not change anything.
+        expect { work.update_settings_from_form(work_form:) }.to change(work, :github_deposit_enabled).to(true)
+      end
+    end
+
+    context 'when github_deposit_enabled is changed by form' do
+      let(:work) { create(:github_repository, github_deposit_enabled: true) }
+      let(:work_form) { instance_double(WorkForm, github_deposit_enabled: false) }
+
+      it 'change settings' do
+        expect { work.update_settings_from_form(work_form:) }.to change(work, :github_deposit_enabled).to(false)
+      end
+    end
+  end
+end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -47,4 +47,15 @@ RSpec.describe Work do
       expect(Notifier).to have_received(:publish).with(Notifier::ACCESSIONING_COMPLETE, object: work)
     end
   end
+
+  describe '.update_settings_from_form' do
+    let(:work) { create(:work) }
+    let(:work_form) { instance_double(WorkForm) }
+
+    it 'does not change settings' do
+      # A Work does not have any settings, so this should not change anything.
+      work.update_settings_from_form(work_form:)
+      expect(work.changed?).to be(false)
+    end
+  end
 end

--- a/spec/system/edit_github_repository_spec.rb
+++ b/spec/system/edit_github_repository_spec.rb
@@ -20,57 +20,92 @@ RSpec.describe 'Edit a Github repository' do
   let!(:work) { create(:github_repository, druid:, user:, collection:) }
 
   before do
-    # On the second call, this will return the cocina object submitted to update.
-    # This will allow us to test the updated values.
-    allow(Sdr::Repository).to receive(:find).with(druid:).and_invoke(
-      ->(_arg) { cocina_object }, # edit
-      ->(_arg) { cocina_object }, # DepositWorkJob
-      ->(_arg) { @updated_cocina_object } # show after update
-    )
-    allow(Sdr::Repository).to receive(:find_latest_user_version).and_return(cocina_object)
-    allow(Sdr::Repository).to receive(:status).with(druid:).and_return(
-      build(:openable_version_status, version: cocina_object.version),
-      build(:draft_version_status, version: cocina_object.version)
-    )
-    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
-    # It is already open.
-    allow(Sdr::Repository).to receive(:open_if_needed) { |args| args[:cocina_object] }
-    allow(Sdr::Repository).to receive(:update) do |args|
-      @updated_cocina_object = args[:cocina_object]
-    end
     allow(Sdr::Event).to receive(:list).and_return([])
+    allow(Sdr::Repository).to receive(:find_latest_user_version).and_return(cocina_object)
+    allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
 
     sign_in(user)
   end
 
-  it 'edits a Github repository' do
-    visit edit_work_path(druid, tab: 'title')
+  context 'when editing metadata and changing setting' do
+    before do
+      # On the second call, this will return the cocina object submitted to update.
+      # This will allow us to test the updated values.
+      allow(Sdr::Repository).to receive(:find).with(druid:).and_invoke(
+        ->(_arg) { cocina_object }, # edit
+        ->(_arg) { cocina_object }, # DepositWorkJob
+        ->(_arg) { @updated_cocina_object } # show after update
+      )
+      allow(Sdr::Repository).to receive(:status).with(druid:).and_return(
+        build(:openable_version_status, version: cocina_object.version),
+        build(:draft_version_status, version: cocina_object.version)
+      )
+      # It is already open.
+      allow(Sdr::Repository).to receive(:open_if_needed) { |args| args[:cocina_object] }
+      allow(Sdr::Repository).to receive(:update) do |args|
+        @updated_cocina_object = args[:cocina_object]
+      end
+    end
 
-    expect(page).to have_css('h1', text: title_fixture)
+    it 'edits a Github repository' do
+      visit edit_work_path(druid, tab: 'title')
 
-    expect(page).to have_button('Next')
-    expect(page).to have_no_button('Save as draft')
-    expect(page).to have_no_button('Discard draft')
+      expect(page).to have_css('h1', text: title_fixture)
 
-    fill_in('Title of deposit', with: updated_title)
+      expect(page).to have_button('Next')
+      expect(page).to have_no_button('Save as draft')
+      expect(page).to have_no_button('Discard draft')
 
-    find('.nav-link', text: 'Deposit', exact_text: true).click
-    expect(page).to have_field('work[whats_changing]', with: 'Metadata update', type: 'hidden')
-    expect(page).to have_checked_field('work[github_deposit_enabled]', with: true)
-    choose('No')
+      fill_in('Title of deposit', with: updated_title)
 
-    click_link_or_button('Save')
+      find('.nav-link', text: 'Deposit', exact_text: true).click
+      expect(page).to have_field('work[whats_changing]', with: 'Metadata update', type: 'hidden')
+      expect(page).to have_checked_field('work[github_deposit_enabled]', with: true)
+      choose('No')
 
-    # Waiting page may be too fast to catch so not testing.
-    # On show page
-    expect(page).to have_css('h1', text: updated_title)
-    expect(page).to have_css('.status', text: 'New version in draft')
-    expect(page).to have_link('Edit or deposit', href: edit_work_path(druid))
+      click_link_or_button('Save')
 
-    expect(work.reload.github_deposit_enabled).to be(false)
+      # Waiting page may be too fast to catch so not testing.
+      # On show page
+      expect(page).to have_css('h1', text: updated_title)
+      expect(page).to have_css('.status', text: 'New version in draft')
+      expect(page).to have_link('Edit or deposit', href: edit_work_path(druid))
 
-    # Ahoy event is created
-    expect(Ahoy::Event.where_event(Ahoy::Event::WORK_UPDATED, work_id: work.id, deposit: true,
-                                                              review: false).count).to eq(1)
+      expect(work.reload.github_deposit_enabled).to be(false)
+
+      # Ahoy event is created
+      expect(Ahoy::Event.where_event(Ahoy::Event::WORK_UPDATED, work_id: work.id, deposit: true,
+                                                                review: false).count).to eq(1)
+    end
+  end
+
+  context 'when changing setting only' do
+    before do
+      allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
+      allow(Sdr::Repository).to receive(:status)
+        .with(druid:)
+        .and_return(build(:openable_version_status, version: cocina_object.version))
+      allow(RoundtripSupport).to receive(:changed?).and_return(false)
+    end
+
+    it 'edits a Github repository' do
+      visit edit_work_path(druid, tab: 'title')
+
+      expect(page).to have_css('h1', text: title_fixture)
+
+      find('.nav-link', text: 'Deposit', exact_text: true).click
+      expect(page).to have_checked_field('work[github_deposit_enabled]', with: true)
+      choose('No')
+
+      click_link_or_button('Save')
+
+      # Waiting page may be too fast to catch so not testing.
+      # On show page
+      expect(page).to have_css('h1', text: title_fixture)
+      expect(page).to have_css('.status', text: 'Deposited')
+      expect(page).to have_link('Edit or deposit', href: edit_work_path(druid))
+
+      expect(work.reload.github_deposit_enabled).to be(false)
+    end
   end
 end


### PR DESCRIPTION
closes #1981