### PR TITLE
Bold labels on collection and work forms.

### DIFF
--- a/app/components/collections/edit/license_component.html.erb
+++ b/app/components/collections/edit/license_component.html.erb
@@ -2,7 +2,7 @@
   <div class="form-check d-flex pt-2 row">
     <div class="col-md-4">
       <%= form.radio_button :license_option, 'required', class: 'form-check-input', data: { radio_target: 'radio', action: 'radio#toggle' } %>
-      <%= form.label :license_option_required, 'Require license for all deposits', class: 'form-check-label' %>
+      <%= form.label :license_option_required, 'Require license for all deposits', class: 'form-check-label fw-bold' %>
     </div>
     <div class="col-md-5">
       <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :license, options: license_options, hidden_label: true, label: 'Required license', container_classes: 'mb-4', prompt: 'Select required license...') %>
@@ -14,7 +14,7 @@
   <div class="form-check d-flex pt-2 row">
     <div class="col-md-4">
       <%= form.radio_button :license_option, 'depositor_selects', class: 'form-check-input', data: { radio_target: 'radio', action: 'radio#toggle' } %>
-      <%= form.label :license_option_depositor_selects, 'Depositor selects license', class: 'form-check-label' %>
+      <%= form.label :license_option_depositor_selects, 'Depositor selects license', class: 'form-check-label fw-bold' %>
     </div>
     <div class="col-md-5">
       <%= render Elements::Forms::SelectFieldComponent.new(form:, field_name: :default_license, options: license_options, hidden_label: true, label: 'Default license', container_classes: 'mb-4', prompt: 'Select license to display by default...') %>

--- a/app/components/works/edit/abstract_component.html.erb
+++ b/app/components/works/edit/abstract_component.html.erb
@@ -1,2 +1,2 @@
-<%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :abstract, label: t('works.edit.fields.abstract.label'), tooltip: t('works.edit.fields.abstract.tooltip_html'), container_classes: 'pane-section', mark_required: true) %>
+<%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :abstract, label: t('works.edit.fields.abstract.label'), tooltip: t('works.edit.fields.abstract.tooltip_html'), container_classes: 'pane-section', mark_required: true, label_classes: 'fw-bold') %>
 <%= render NestedComponentPresenter.for(form:, field_name: :keywords, model_class: KeywordForm, form_component: Works::Edit::KeywordComponent, hidden_label: true, bordered: false, single_field: true, fieldset_classes: 'pane-section') %>

--- a/app/components/works/edit/citation_component.html.erb
+++ b/app/components/works/edit/citation_component.html.erb
@@ -1,3 +1,3 @@
 <%= tag.div class: 'pane-section' do %>
-  <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :citation, label: t('works.edit.fields.citation.label')) %>
+  <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :citation, label: t('works.edit.fields.citation.label'), label_classes: 'fw-bold') %>
 <% end %>

--- a/app/components/works/edit/title_component.html.erb
+++ b/app/components/works/edit/title_component.html.erb
@@ -1,16 +1,16 @@
 <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :title, label: t('works.edit.fields.title.label'), tooltip: t('works.edit.fields.title.tooltip_html'),
-                                                       help_text: t('works.edit.fields.title.help_text'), width: 500, rows: 1, container_classes: 'pane-section', mark_required: true) %>
-        <%= render NestedComponentPresenter.for(form:, field_name: :contact_emails, model_class: ContactEmailForm, form_component: Works::Edit::ContactEmailsComponent, hidden_label: true, bordered: false, single_field: true, fieldset_classes: 'pane-section') %>
+                                                       help_text: t('works.edit.fields.title.help_text'), width: 500, rows: 1, container_classes: 'pane-section', mark_required: true, label_classes: 'fw-bold') %>
+<%= render NestedComponentPresenter.for(form:, field_name: :contact_emails, model_class: ContactEmailForm, form_component: Works::Edit::ContactEmailsComponent, hidden_label: true, bordered: false, single_field: true, fieldset_classes: 'pane-section') %>
 
-        <% if works_contact_email.present? %>
-          <%= form.hidden_field :works_contact_email %>
+<% if works_contact_email.present? %>
+  <%= form.hidden_field :works_contact_email %>
 
-          <div class="pane-section">
-            <p>
-              Contact email provided by collection manager <%= render Elements::TooltipComponent.new(target_label: 'Provided contact email', tooltip: t('works.edit.fields.works_contact_email.tooltip_html')) %>
-            </p>
-            <p>
-              <%= works_contact_email %>
-            </p>
-          </div>
-        <% end %>
+  <div class="pane-section">
+    <p>
+      Contact email provided by collection manager <%= render Elements::TooltipComponent.new(target_label: 'Provided contact email', tooltip: t('works.edit.fields.works_contact_email.tooltip_html')) %>
+    </p>
+    <p>
+      <%= works_contact_email %>
+    </p>
+  </div>
+<% end %>

--- a/app/views/collections/form.html.erb
+++ b/app/views/collections/form.html.erb
@@ -34,8 +34,8 @@
     <%# TabListComponent will render the actual form. %>
     <% form_with(model: @collection_form) do |form| %>
       <% component.with_collection_pane(tab_name: :details, label: t('collections.edit.panes.details.label'), active_tab_name:, collection_presenter: @collection_presenter, previous_tab_btn: false, mark_required: true) do %>
-        <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :title, label: t('collections.edit.fields.title.label'), tooltip: t('collections.edit.fields.title.tooltip_html'), container_classes: 'pane-section', mark_required: true) %>
-        <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :description, label: t('collections.edit.fields.description.label'), tooltip: t('collections.edit.fields.description.tooltip_html'), container_classes: 'pane-section', mark_required: true) %>
+        <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :title, label: t('collections.edit.fields.title.label'), tooltip: t('collections.edit.fields.title.tooltip_html'), container_classes: 'pane-section', mark_required: true, label_classes: 'fw-bold') %>
+        <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :description, label: t('collections.edit.fields.description.label'), tooltip: t('collections.edit.fields.description.tooltip_html'), container_classes: 'pane-section', mark_required: true, label_classes: 'fw-bold') %>
         <%= render NestedComponentPresenter.for(form:, field_name: :contact_emails, model_class: ContactEmailForm, form_component: Collections::Edit::ContactEmailsComponent, hidden_label: true, bordered: false, single_field: true, fieldset_classes: 'pane-section') %>
       <% end %>
 
@@ -81,7 +81,7 @@
       <% end %>
 
       <% component.with_collection_pane(tab_name: :works_contact_email, label: t('collections.edit.panes.works_contact_email.label'), help_text: t('collections.edit.panes.works_contact_email.help_text'), active_tab_name:, collection_presenter: @collection_presenter) do %>
-        <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :works_contact_email, label: t('collections.edit.fields.works_contact_email.label'), tooltip: t('collections.edit.fields.works_contact_email.tooltip_html'), container_classes: 'pane-section') %>
+        <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :works_contact_email, label: t('collections.edit.fields.works_contact_email.label'), tooltip: t('collections.edit.fields.works_contact_email.tooltip_html'), container_classes: 'pane-section', label_classes: 'fw-bold') %>
       <% end %>
 
       <% component.with_collection_pane(tab_name: :contributors, label: t('collections.edit.panes.contributors.label'), help_text: t('collections.edit.panes.contributors.help_text'), active_tab_name:, collection_presenter: @collection_presenter) do %>

--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -107,7 +107,7 @@
               By calling tab-error#changed on the input event, the DOM is updated sooner than the change event,
               allowing the form to be submitted without blocking.
             %>
-            <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :whats_changing, label: t('works.edit.fields.whats_changing.label'), tooltip: t('works.edit.fields.whats_changing.tooltip_html'), maxlength: 100, data: { action: 'input->tab-error#changed' }) %>
+            <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :whats_changing, label: t('works.edit.fields.whats_changing.label'), tooltip: t('works.edit.fields.whats_changing.tooltip_html'), maxlength: 100, data: { action: 'input->tab-error#changed' }, label_classes: 'fw-bold') %>
           </div>
         <% else %>
           <%# This is a dummy value that is needed for validation, but won't be used for the version description. %>


### PR DESCRIPTION
closes #1988

It turns out that not all labels should be bolded, so did this individually instead of systematically.