### PR TITLE
Makes contacts, abstracts, and keywords optional for articles.

### DIFF
--- a/app/components/elements/forms/label_component.html.erb
+++ b/app/components/elements/forms/label_component.html.erb
@@ -1,6 +1,4 @@
-<%= form.label field_name, class: classes do %>
-  <%= content || label_text %>
-<% end %>
+<%= form.label field_name, class: classes do %><%= content || label_text %><% end %>
 <%# This is outside the label so that clicking on it doesn't toggle some inputs like checkboxes. %>
 <%= render SdrViewComponents::Elements::TooltipComponent.new(target_label: label_text, tooltip:) %>
 <%= tag.span { caption } if caption %>

--- a/app/components/works/edit/abstract_component.html.erb
+++ b/app/components/works/edit/abstract_component.html.erb
@@ -1,2 +1,6 @@
-<%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :abstract, label: t('works.edit.fields.abstract.label'), tooltip: t('works.edit.fields.abstract.tooltip_html'), container_classes: 'pane-section', mark_required: true, label_classes: 'fw-bold') %>
-<%= render NestedComponentPresenter.for(form:, field_name: :keywords, model_class: KeywordForm, form_component: Works::Edit::KeywordComponent, bordered: false, single_field: true, fieldset_classes: 'pane-section', mark_required: true) %>
+<%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :abstract, label: t('works.edit.fields.abstract.label'),
+                                                       tooltip: t('works.edit.fields.abstract.tooltip_html'), container_classes: 'pane-section',
+                                                       mark_required: mark_abstract_required, label_classes: 'fw-bold') %>
+<%= render NestedComponentPresenter.for(form:, field_name: :keywords, model_class: KeywordForm, form_component: Works::Edit::KeywordComponent,
+                                        bordered: false, single_field: true, fieldset_classes: 'pane-section',
+                                        mark_required: mark_keywords_required, label_text: keywords_label) %>

--- a/app/components/works/edit/abstract_component.rb
+++ b/app/components/works/edit/abstract_component.rb
@@ -4,12 +4,20 @@ module Works
   module Edit
     # Component for the abstract pane on the edit form.
     class AbstractComponent < ApplicationComponent
-      def initialize(form:)
+      def initialize(form:, mark_abstract_required: true, mark_keywords_required: true)
         @form = form
+        @mark_abstract_required = mark_abstract_required
+        @mark_keywords_required = mark_keywords_required
         super()
       end
 
-      attr_reader :form
+      attr_reader :form, :mark_abstract_required, :mark_keywords_required
+
+      def keywords_label
+        I18n.t('keywords.edit.legend').dup.tap do |text|
+          text << ' (at least one is required)' if mark_keywords_required
+        end
+      end
     end
   end
 end

--- a/app/components/works/edit/title_component.html.erb
+++ b/app/components/works/edit/title_component.html.erb
@@ -1,7 +1,8 @@
 <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :title, label: t('works.edit.fields.title.label'), tooltip: t('works.edit.fields.title.tooltip_html'),
                                                        help_text: t('works.edit.fields.title.help_text'), width: 500, rows: 1, container_classes: 'pane-section', mark_required: true, label_classes: 'fw-bold') %>
 <%= render NestedComponentPresenter.for(form:, field_name: :contact_emails, model_class: ContactEmailForm, form_component: Works::Edit::ContactEmailsComponent,
-                                        bordered: false, single_field: true, fieldset_classes: 'pane-section', tooltip: helpers.t('contact_emails.edit.works.tooltip_html'), label_text: contact_emails_label_text, mark_required: !works_contact_email?) %>
+                                        bordered: false, single_field: true, fieldset_classes: 'pane-section', tooltip: helpers.t('contact_emails.edit.works.tooltip_html'),
+                                        label_text: contact_emails_label_text, mark_required: mark_contact_emails_required?) %>
 
 <% if works_contact_email? %>
   <%= form.hidden_field :works_contact_email %>

--- a/app/components/works/edit/title_component.rb
+++ b/app/components/works/edit/title_component.rb
@@ -4,9 +4,10 @@ module Works
   module Edit
     # Component for the title pane on the edit form.
     class TitleComponent < ApplicationComponent
-      def initialize(form:, work_form:)
+      def initialize(form:, work_form:, mark_contact_emails_required: true)
         @form = form
         @work_form = work_form
+        @mark_contact_emails_required = mark_contact_emails_required
         super()
       end
 
@@ -16,12 +17,16 @@ module Works
 
       def contact_emails_label_text
         I18n.t('contact_emails.edit.legend').dup.tap do |text|
-          text << ' (at least one is required)' unless works_contact_email?
+          text << ' (at least one is required)' if mark_contact_emails_required?
         end
       end
 
       def works_contact_email?
         works_contact_email.present?
+      end
+
+      def mark_contact_emails_required?
+        @mark_contact_emails_required && !works_contact_email?
       end
     end
   end

--- a/app/views/works/article_form.html.erb
+++ b/app/views/works/article_form.html.erb
@@ -32,7 +32,7 @@
       <% end %>
 
       <% component.with_work_pane(tab_name: :title, label: t('works.edit.panes.title.label'), form_id:, discard_draft_form_id:, work_presenter: @work_presenter, active_tab_name:, mark_required: true) do %>
-        <%= render Works::Edit::TitleComponent.new(form:, work_form: @work_form) %>
+        <%= render Works::Edit::TitleComponent.new(form:, work_form: @work_form, mark_contact_emails_required: false) %>
       <% end %>
 
       <% component.with_work_pane(tab_name: :contributors, label: t('works.edit.panes.contributors.label'), help_text: t('works.edit.panes.contributors.help_text'), tooltip: t('works.edit.panes.contributors.tooltip_html'), form_id:, discard_draft_form_id:, work_presenter: @work_presenter, active_tab_name:) do %>
@@ -40,7 +40,7 @@
       <% end %>
 
       <% component.with_work_pane(tab_name: :abstract, label: t('works.edit.panes.abstract.label'), help_text: t('works.edit.panes.abstract.help_text'), form_id:, discard_draft_form_id:, work_presenter: @work_presenter, active_tab_name:) do %>
-        <%= render Works::Edit::AbstractComponent.new(form:) %>
+        <%= render Works::Edit::AbstractComponent.new(form:, mark_abstract_required: false, mark_keywords_required: false) %>
       <% end %>
 
       <% component.with_work_pane(tab_name: :types, label: t('works.edit.panes.types.label'), form_id:, discard_draft_form_id:, work_presenter: @work_presenter, active_tab_name:, mark_required: true) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -174,7 +174,7 @@ en:
           label: 'Start typing a keyword'
   keywords:
     edit:
-      legend: 'Keywords (at least one is required)'
+      legend: 'Keywords'
       tooltip_html: >-
         Enter one keyword or phrase per box. Keywords should reflect significant concepts related to the deposit. As you type, terms will be suggested to you, but free-text entries are also permitted.
   license:

--- a/spec/components/works/edit/abstract_component_spec.rb
+++ b/spec/components/works/edit/abstract_component_spec.rb
@@ -11,7 +11,26 @@ RSpec.describe Works::Edit::AbstractComponent, type: :component do
   it 'renders the pane' do
     render_inline(described_class.new(form:))
 
+    expect(page).to have_css('label', exact_text: 'Abstract')
     expect(page).to have_field('Abstract', with: abstract_fixture)
+
+    expect(page).to have_css('legend label', exact_text: 'Keywords (at least one is required)')
     expect(page).to have_field('[keywords_attributes][0][text]', with: 'Biology')
+  end
+
+  context 'when abstract is not required' do
+    it 'does not mark the abstract field as required' do
+      render_inline(described_class.new(form:, mark_abstract_required: false))
+
+      expect(page).to have_css('label', exact_text: 'Abstract (optional)')
+    end
+  end
+
+  context 'when keywords is not required' do
+    it 'does not mark the keywords field as required' do
+      render_inline(described_class.new(form:, mark_keywords_required: false))
+
+      expect(page).to have_css('legend label', exact_text: 'Keywords (optional)')
+    end
   end
 end

--- a/spec/components/works/edit/title_component_spec.rb
+++ b/spec/components/works/edit/title_component_spec.rb
@@ -30,4 +30,16 @@ RSpec.describe Works::Edit::TitleComponent, type: :component do
       expect(page).to have_css('legend label', exact_text: 'Contact emails (at least one is required)')
     end
   end
+
+  context 'when contact email is not required' do
+    before do
+      work_form.works_contact_email = nil
+    end
+
+    it 'does not mark the contact email field as required' do
+      render_inline(described_class.new(form:, work_form:, mark_contact_emails_required: false))
+
+      expect(page).to have_css('legend label', exact_text: 'Contact emails (optional)')
+    end
+  end
 end

--- a/spec/system/create_article_edit_spec.rb
+++ b/spec/system/create_article_edit_spec.rb
@@ -69,6 +69,11 @@ RSpec.describe 'Create an article then edit before deposit' do
 
     find('.nav-link', text: 'Title and contact').click
     expect(page).to have_field('Title of deposit', with: title_fixture)
+    expect(page).to have_css('legend label', text: 'Contact emails (optional)')
+
+    find('.nav-link', text: 'Abstract and keywords (optional)').click
+    expect(page).to have_css('label', text: 'Abstract (optional)')
+    expect(page).to have_css('legend label', text: 'Keywords (optional)')
 
     find('.nav-link', text: 'Type of deposit').click
     expect(page).to have_field('Text', checked: true)


### PR DESCRIPTION
closes #1948