### PR TITLE
Update component library to latest and display rosette in header

### DIFF
--- a/app/components/structure/header_component.html.erb
+++ b/app/components/structure/header_component.html.erb
@@ -1,4 +1,4 @@
-<%= render SdrViewComponents::Structure::HeaderComponent.new(title: t('app_name'), variant: :white, sul_logo: 'polychrome', rosette: false) do |header| %>
+<%= render SdrViewComponents::Structure::HeaderComponent.new(title: t('app_name'), variant: :white, sul_logo: 'polychrome') do |header| %>
   <%= header.with_primary_navigation_link do %>
     <%= render Structure::LoginMenuComponent.new %>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, 'data-turbo-track': 'reload' %>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2025-02-04/styles/sul.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/sul-dlss/component-library@v2026-01-27/styles/sul.css">
     <%= stylesheet_link_tag 'component_library_overrides' %>
     <%= javascript_importmap_tags %>
   </head>


### PR DESCRIPTION
Part of #1979 

- Includes the rosette in the header
- Updates the component library to pick up fixes since last february

<img width="721" height="93" alt="Screenshot 2026-02-25 at 12 24 27 PM" src="https://github.com/user-attachments/assets/09942d0c-d5fe-4c63-8099-54c299cb5483" />

