### PR TITLE
Mark contact email as required for collections and adds help text.

### DIFF
--- a/app/views/collections/form.html.erb
+++ b/app/views/collections/form.html.erb
@@ -37,7 +37,7 @@
         <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :title, label: t('collections.edit.fields.title.label'), tooltip: t('collections.edit.fields.title.tooltip_html'), container_classes: 'pane-section', mark_required: true, label_classes: 'fw-bold') %>
         <%= render Elements::Forms::TextareaFieldComponent.new(form:, field_name: :description, label: t('collections.edit.fields.description.label'), tooltip: t('collections.edit.fields.description.tooltip_html'), container_classes: 'pane-section', mark_required: true, label_classes: 'fw-bold') %>
         <%= render NestedComponentPresenter.for(form:, field_name: :contact_emails, model_class: ContactEmailForm, form_component: Collections::Edit::ContactEmailsComponent, bordered: false, single_field: true, fieldset_classes: 'pane-section',
-                                                tooltip: I18n.t('contact_emails.edit.collections.tooltip_html')) %>
+                                                tooltip: I18n.t('contact_emails.edit.collections.tooltip_html'), mark_required: true) %>
       <% end %>
 
       <% component.with_collection_pane(tab_name: :related_links, label: t('collections.edit.panes.related_links.label'), tooltip: t('collections.edit.panes.related_links.tooltip_html'), help_text: t('collections.edit.panes.related_links.help_text'), active_tab_name:, collection_presenter: @collection_presenter) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,6 +153,8 @@ en:
   contact_emails:
     edit:
       legend: 'Contact emails'
+      help_html: >-
+        One email per box.
       collections:
         tooltip_html: >-
           Enter one or more valid email addresses (one per box) where people can write to ask questions about this collection. Consider using a group address that will be active and monitored for a long time to ensure that questions are received. Email addresses will appear on the public webpage for the collection.


### PR DESCRIPTION
closes #2037

<img width="905" height="208" alt="image" src="https://github.com/user-attachments/assets/10c34d26-f5ae-4ae0-ac8f-9c70644d4b2e" />
