### PR TITLE
Fix footer image

### DIFF
--- a/app/components/structure/footer_component.html.erb
+++ b/app/components/structure/footer_component.html.erb
@@ -6,7 +6,8 @@
         <div
           id="sul-footer-img"
           class="col-sm-12 col-lg-4 col-xl-3 d-flex justify-content-center justify-content-lg-start">
-          <a href="https://library.stanford.edu" class="prefooter-logo">Stanford University Libraries</a>
+          <a href="https://library.stanford.edu" class="prefooter-logo">
+            <span class="visually-hidden">Stanford University Libraries</span></a>
         </div>
         <div
           class="col d-flex flex-wrap justify-content-center justify-content-lg-between align-items-center gap-3 gap-lg-0">


### PR DESCRIPTION
Fixes #2032 

<img width="606" height="88" alt="Screenshot 2026-02-27 at 8 13 43 AM" src="https://github.com/user-attachments/assets/88d34ed5-3b4d-42aa-87c5-3ff2a557a148" />
