### PR TITLE
Add alert message to github deposits

### DIFF
--- a/app/components/works/show/depositing_github_component.html.erb
+++ b/app/components/works/show/depositing_github_component.html.erb
@@ -1,0 +1,9 @@
+<% if alert? %>
+  <%= render SdrViewComponents::Elements::AlertComponent.new(variant: :note,
+                                                             data: { turbo_permanent: true }, id: 'depositing-github-note') do %>
+    One more step to complete deposit - <%= link_to 'Go to GitHub', github_releases_path %> to create a release for this GitHub repository.
+  <% end %>
+<% else %>
+  <%# This is so that when the page morphs, the alert is permanent. %>
+  <div id="depositing-github-note" data-turbo-permanent="true"></div>
+<% end %>

--- a/app/components/works/show/depositing_github_component.rb
+++ b/app/components/works/show/depositing_github_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Works
+  module Show
+    # Component for notifying the user that the work is being deposited.
+    class DepositingGithubComponent < ApplicationComponent
+      def initialize(work_presenter:)
+        @work_presenter = work_presenter
+        super()
+      end
+
+      def alert?
+        @work_presenter.github_repository? && @work_presenter.version_status.first_draft?
+      end
+
+      def github_releases_path
+        "http://github.com/#{@work_presenter.github_repository_name}/releases"
+      end
+    end
+  end
+end

--- a/app/presenters/work_presenter.rb
+++ b/app/presenters/work_presenter.rb
@@ -157,7 +157,8 @@ class WorkPresenter < FormPresenter
 
   private
 
-  delegate :collection, :created_at, :user, :review_state, :pending_review?, :share_users, to: :work
+  delegate :collection, :created_at, :github_repository_name, :user,
+           :review_state, :pending_review?, :share_users, to: :work
 
   def content_files_in_deposit
     ContentFile.where(content_id: work_form.content_id)

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -18,6 +18,7 @@
 <%= render Works::Show::ReviewRejectedComponent.new(work: @work) %>
 <%= render Works::Show::PendingReviewComponent.new(work_presenter: @work_presenter) %>
 <%= render Works::Show::DepositingComponent.new(work_presenter: @work_presenter) %>
+<%= render Works::Show::DepositingGithubComponent.new(work_presenter: @work_presenter) %>
 <%= render Works::Show::HeaderComponent.new(presenter: @work_presenter) %>
 
 <%= render Works::Show::GithubPollButtonComponent.new(work: @work, classes: 'mb-3') %>

--- a/spec/components/works/show/depositing_github_component_spec.rb
+++ b/spec/components/works/show/depositing_github_component_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Works::Show::DepositingGithubComponent, type: :component do
+  let(:work) { create(:github_repository) }
+  let(:work_presenter) do
+    WorkPresenter.new(work_form: WorkForm.new, version_status:, work:)
+  end
+
+  context 'when first draft version' do
+    let(:version_status) { build(:first_draft_version_status) }
+
+    it 'renders the alert' do
+      render_inline(described_class.new(work_presenter:))
+
+      expect(page).to have_css('.alert', text: 'One more step to complete deposit - ' \
+                                               'Go to GitHub to create a release for this GitHub repository.')
+      expect(page).to have_css('#depositing-github-note[data-turbo-permanent]')
+    end
+  end
+
+  context 'when other version and accessioning' do
+    let(:version_status) { build(:accessioning_version_status) }
+
+    it 'does not render the alert' do
+      render_inline(described_class.new(work_presenter:))
+
+      expect(page).to have_no_css('.alert', text: 'One more step to complete deposit - ' \
+                                                  'Go to GitHub to create a release for this GitHub repository.')
+      expect(page).to have_css('#depositing-github-note[data-turbo-permanent]')
+    end
+  end
+end

--- a/spec/system/create_github_repository_spec.rb
+++ b/spec/system/create_github_repository_spec.rb
@@ -26,15 +26,12 @@ RSpec.describe 'Create a Github repository and work deposit' do
       cocina_object = Cocina::Models.build(cocina_params)
       @registered_cocina_object = Cocina::Models.with_metadata(cocina_object, 'abc123')
     end
-    allow(Sdr::Repository).to receive(:accession)
     allow(Sdr::Repository).to receive(:find_latest_user_version).with(druid:).and_return(nil)
     allow(Sdr::Repository).to receive(:check_lock)
 
     # Stubbing out for edit form
     allow(Sdr::Repository).to receive(:find).with(druid:).and_invoke(->(_arg) { @registered_cocina_object })
-    allow(Sdr::Repository).to receive(:status).with(druid:).and_return(build(:first_draft_version_status),
-                                                                       build(:draft_version_status),
-                                                                       build(:first_accessioning_version_status))
+    allow(Sdr::Repository).to receive(:status).with(druid:).and_return(build(:first_draft_version_status))
     allow(Sdr::Repository).to receive(:latest_user_version).with(druid:).and_return(1)
     allow(Sdr::Event).to receive(:list).and_return([])
 
@@ -44,7 +41,6 @@ RSpec.describe 'Create a Github repository and work deposit' do
     allow(Sdr::Repository).to receive(:update) do |args|
       @updated_cocina_object = args[:cocina_object]
     end
-    allow(Sdr::Repository).to receive(:accession)
 
     create(:collection, user:, title: collection_title_fixture, druid: collection_druid_fixture, depositors: [user],
                         github_deposit_enabled: true)
@@ -155,8 +151,8 @@ RSpec.describe 'Create a Github repository and work deposit' do
     # Waiting page may be too fast to catch so not testing.
     # On show page
     expect(page).to have_css('h1', text: 'sul-dlss/hungry-hungry-hippo')
-    expect(page).to have_css('.status', text: 'Depositing')
-    expect(page).to have_css('.alert-success', text: 'Deposit successfully submitted')
+    expect(page).to have_css('.alert-note', text: 'One more step to complete deposit - Go to GitHub ' \
+                                                  'to create a release for this GitHub repository.')
     within('table#license-table') do
       expect(page).to have_css('tr', text: 'License')
       expect(page).to have_css('td', text: 'CC-BY-4.0 Attribution International')
@@ -165,7 +161,7 @@ RSpec.describe 'Create a Github repository and work deposit' do
       expect(page).to have_css('tr', text: 'Contact emails')
       expect(page).to have_css('td', text: user.email_address)
     end
-    expect(page).to have_no_link('Edit or deposit')
+    expect(page).to have_link('Edit or deposit')
 
     # Ahoy events are created
     work = GithubRepository.find_by(druid:)


### PR DESCRIPTION
Fixes #2062 

<img width="1241" height="313" alt="Screenshot 2026-03-03 at 10 17 16 AM" src="https://github.com/user-attachments/assets/6c7597c0-41dc-48b4-80e2-db732aa6293e" />
