### PR TITLE
Add ahoy tracking for article DOI/PMCID lookups

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -32,6 +32,7 @@ class ArticlesController < ApplicationController
       # or via a lookup to Pubmed).  @article_form.valid? checks if the DOI is present and exists in Crossref.
       set_article_work_form if @article_form.valid?
       @article_form.last_doi_lookup = @article_form.doi # Keeps track if the user performed a DOI lookup.
+      track_doi_lookup
       render :form, status: :unprocessable_content
     elsif @article_form.valid?(:deposit)
       # @article_form.valid?(:deposit) checks all of the fields.
@@ -76,6 +77,21 @@ class ArticlesController < ApplicationController
   def track_article_create(work:, work_form:)
     ahoy.track Ahoy::Event::ARTICLE_FORM_COMPLETED, form_id: work_form.form_id, work_id: work.id
     ahoy.track Ahoy::Event::ARTICLE_CREATED, work_id: work.id, deposit: deposit?, review: request_review?
+  end
+
+  def track_doi_lookup
+    identifier_type = @article_form.doi_identifier? ? 'DOI' : 'PMCID'
+    event_type = if @article_form.doi_found? == false
+                   Ahoy::Event::IDENTIFIER_LOOKUP_NOT_FOUND
+                 elsif @article_form.doi_journal_article? == false
+                   Ahoy::Event::IDENTIFIER_LOOKUP_NOT_ARTICLE
+                 elsif @article_form.doi_has_complete_metadata? == false
+                   Ahoy::Event::IDENTIFIER_LOOKUP_WITH_INCOMPLETE_METADATA
+                 else
+                   Ahoy::Event::IDENTIFIER_LOOKUP_SUCCESS
+                 end
+
+    ahoy.track event_type, identifier: @article_form.identifier, identifier_type:
   end
 
   def article_form_params

--- a/app/forms/article_form.rb
+++ b/app/forms/article_form.rb
@@ -35,14 +35,7 @@ class ArticleForm < ApplicationForm
   before_validation do
     if identifier.present?
       identifier.strip!
-
-      # already looks like a DOI? no need to do an extra lookup; else lookup in Pubmed
-      # DOI identification could be more robust if needed using regex, e.g. https://www.crossref.org/blog/dois-and-matching-regular-expressions/
-      self.doi = if identifier.include?('/')
-                   identifier
-                 else
-                   PubmedService.call(search: identifier)
-                 end
+      set_doi
       results = CrossrefService.call(doi:)
       @doi_has_complete_metadata = results[:title].present? && results[:contributors_attributes].present?
       @doi_found = true
@@ -53,6 +46,16 @@ class ArticleForm < ApplicationForm
   rescue CrossrefService::NotJournalArticle
     @doi_found = true
     @doi_journal_article = false
+  end
+
+  # already looks like a DOI? no need to do an extra lookup; else lookup in Pubmed
+  # DOI identification could be more robust if needed using regex, e.g. https://www.crossref.org/blog/dois-and-matching-regular-expressions/
+  def set_doi
+    self.doi = doi_identifier? ? identifier : PubmedService.call(search: identifier)
+  end
+
+  def doi_identifier?
+    identifier.include?('/')
   end
 
   def doi_found?

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -11,6 +11,10 @@ module Ahoy
     WORK_FORM_COMPLETED = 'work form completed' # User has submitted a valid work form
     ARTICLE_FORM_STARTED = 'article form started' # User is presented with an article form
     ARTICLE_FORM_COMPLETED = 'article form completed' # User has submitted a valid article form
+    IDENTIFIER_LOOKUP_SUCCESS = 'identifier lookup success' # DOI/PMCID found with complete metadata
+    IDENTIFIER_LOOKUP_WITH_INCOMPLETE_METADATA = 'identifier lookup with incomplete metadata' # incomplete metadata
+    IDENTIFIER_LOOKUP_NOT_ARTICLE = 'identifier lookup not article' # DOI/PMCID found but it is not a journal article
+    IDENTIFIER_LOOKUP_NOT_FOUND = 'identifier lookup not found' # DOI/PMCID not found
     FORM_CHANGED = 'form changed' # User has changed a form
     FILES_UPLOADED = 'files uploaded' # User has uploaded files
     WORK_CREATED = 'work created'

--- a/spec/system/create_article_deposit_spec.rb
+++ b/spec/system/create_article_deposit_spec.rb
@@ -66,6 +66,9 @@ RSpec.describe 'Create an article deposit' do
     fill_in 'identifier_field', with: not_found_doi
     click_link_or_button('Look up')
     expect(page).to have_css('.invalid-feedback', text: 'Unable to retrieve metadata for this DOI/PMCID')
+    expect(Ahoy::Event.where_event(Ahoy::Event::IDENTIFIER_LOOKUP_NOT_FOUND,
+                                   identifier: not_found_doi,
+                                   identifier_type: 'DOI').count).to eq(1)
 
     # Deposit without required fields
     fill_in 'identifier_field', with: doi
@@ -78,6 +81,9 @@ RSpec.describe 'Create an article deposit' do
     # Lookup
     click_link_or_button('Look up')
     expect(page).to have_no_css('.invalid-feedback')
+    expect(Ahoy::Event.where_event(Ahoy::Event::IDENTIFIER_LOOKUP_SUCCESS,
+                                   identifier: doi,
+                                   identifier_type: 'DOI').count).to eq(1)
 
     within('#article-table') do
       expect(page).to have_css('th', text: 'Title')
@@ -178,12 +184,72 @@ RSpec.describe 'Create an article deposit' do
       fill_in 'identifier_field', with: pmid
       click_link_or_button('Look up')
       expect(page).to have_no_css('.invalid-feedback')
+      expect(Ahoy::Event.where_event(Ahoy::Event::IDENTIFIER_LOOKUP_SUCCESS,
+                                     identifier: pmid,
+                                     identifier_type: 'PMCID').count).to eq(1)
 
       within('#article-table') do
         expect(page).to have_css('th', text: 'DOI')
         expect(page).to have_css('td', text: "https://doi.org/#{doi}")
         expect(page).to have_css('th', text: 'Title')
         expect(page).to have_css('td', text: pubmed_article_title)
+      end
+    end
+  end
+
+  context 'with a DOI' do
+    let(:doi) { '10.1073/pnas.2513219122' }
+
+    context 'with metadata that indicates it is not a journal article' do
+      before do
+        allow(CrossrefService).to receive(:call).with(doi:).and_raise(CrossrefService::NotJournalArticle)
+      end
+
+      it 'alerts that the DOI is not a journal article', :dropzone do
+        visit dashboard_path
+        click_link_or_button(I18n.t('collections.buttons.labels.deposit_article'))
+
+        # Breadcrumb
+        expect(page).to have_link('Dashboard', href: dashboard_path)
+        expect(page).to have_link(collection_title_fixture, href: collection_path(collection_druid_fixture))
+        expect(page).to have_css('.breadcrumb-item', text: 'Article deposit')
+
+        expect(page).to have_css('h1', text: 'Article deposit')
+
+        # Look up DOI via PMID
+        fill_in 'identifier_field', with: doi
+        click_link_or_button('Look up')
+        expect(page).to have_css('.invalid-feedback',
+                                 text: 'The metadata for this identifier indicates it is not a journal article.')
+        expect(Ahoy::Event.where_event(Ahoy::Event::IDENTIFIER_LOOKUP_NOT_ARTICLE,
+                                       identifier: doi,
+                                       identifier_type: 'DOI').count).to eq(1)
+      end
+    end
+
+    context 'with metadata that is incomplete' do
+      before do
+        allow(CrossrefService).to receive(:call).with(doi:).and_return({ title: title_fixture })
+      end
+
+      it 'alerts that the DOI is not a journal article', :dropzone do
+        visit dashboard_path
+        click_link_or_button(I18n.t('collections.buttons.labels.deposit_article'))
+
+        # Breadcrumb
+        expect(page).to have_link('Dashboard', href: dashboard_path)
+        expect(page).to have_link(collection_title_fixture, href: collection_path(collection_druid_fixture))
+        expect(page).to have_css('.breadcrumb-item', text: 'Article deposit')
+
+        expect(page).to have_css('h1', text: 'Article deposit')
+
+        # Look up DOI via PMID
+        fill_in 'identifier_field', with: doi
+        click_link_or_button('Look up')
+        expect(page).to have_css('.invalid-feedback', text: 'The metadata for this identifier is incomplete.')
+        expect(Ahoy::Event.where_event(Ahoy::Event::IDENTIFIER_LOOKUP_WITH_INCOMPLETE_METADATA,
+                                       identifier: doi,
+                                       identifier_type: 'DOI').count).to eq(1)
       end
     end
   end


### PR DESCRIPTION
Fixes #2024 

A couple of thoughts for possible follow up:
- This isn't tracking lookup error events (i.e. when CrossRef returns an error other than not found). This likely isn't as important as we'll get those in HB.
- When PMCID this is looking the PMCID only, not the resulting DOI if it's found. Not sure it's worth the complication of adding that, but that would be a good follow up if we want it.