### PR TITLE
Remove alert persistence for github information

### DIFF
--- a/app/components/works/show/depositing_github_component.html.erb
+++ b/app/components/works/show/depositing_github_component.html.erb
@@ -1,9 +1,4 @@
-<% if alert? %>
-  <%= render SdrViewComponents::Elements::AlertComponent.new(variant: :note,
-                                                             data: { turbo_permanent: true }, id: 'depositing-github-note') do %>
-    One more step to complete deposit - <%= link_to 'Go to GitHub', github_releases_path %> to create a release for this GitHub repository.
-  <% end %>
-<% else %>
-  <%# This is so that when the page morphs, the alert is permanent. %>
-  <div id="depositing-github-note" data-turbo-permanent="true"></div>
+<%= render SdrViewComponents::Elements::AlertComponent.new(variant: :note,
+                                                           id: 'depositing-github-note') do %>
+  One more step to complete deposit - <%= link_to 'Go to GitHub', github_releases_path %> to create a release for this GitHub repository.
 <% end %>

--- a/app/components/works/show/depositing_github_component.rb
+++ b/app/components/works/show/depositing_github_component.rb
@@ -9,7 +9,7 @@ module Works
         super()
       end
 
-      def alert?
+      def render?
         @work_presenter.github_repository? && @work_presenter.version_status.first_draft?
       end
 

--- a/spec/components/works/show/depositing_github_component_spec.rb
+++ b/spec/components/works/show/depositing_github_component_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Works::Show::DepositingGithubComponent, type: :component do
 
       expect(page).to have_css('.alert', text: 'One more step to complete deposit - ' \
                                                'Go to GitHub to create a release for this GitHub repository.')
-      expect(page).to have_css('#depositing-github-note[data-turbo-permanent]')
     end
   end
 
@@ -28,7 +27,6 @@ RSpec.describe Works::Show::DepositingGithubComponent, type: :component do
 
       expect(page).to have_no_css('.alert', text: 'One more step to complete deposit - ' \
                                                   'Go to GitHub to create a release for this GitHub repository.')
-      expect(page).to have_css('#depositing-github-note[data-turbo-permanent]')
     end
   end
 end


### PR DESCRIPTION
Fixes #2103 

Once the polling button is clicked 2 alerts are shown:
<img width="1211" height="236" alt="Screenshot 2026-03-03 at 3 00 54 PM" src="https://github.com/user-attachments/assets/83e31ab0-d5bd-4ad4-a38b-114e70fac73e" />

After a release is picked up:
<img width="1223" height="228" alt="Screenshot 2026-03-03 at 3 04 50 PM" src="https://github.com/user-attachments/assets/acf5eae7-6274-4d73-af0f-0550b796c7e1" />
