### PR TITLE
Output related works as a link if it is a URL

### DIFF
--- a/app/components/works/show/related_content_show_component.html.erb
+++ b/app/components/works/show/related_content_show_component.html.erb
@@ -4,7 +4,7 @@
     <% component.with_row(label: 'Related published work') do |row_component| %>
       <% row_component.with_cell do %>
         <p class="my-0">
-          <%= related_work %>
+          <%= label_for(related_work) %>
         </p>
         <% if related_work.relationship %>
           <p class="my-0">

--- a/app/components/works/show/related_content_show_component.rb
+++ b/app/components/works/show/related_content_show_component.rb
@@ -4,6 +4,8 @@ module Works
   module Show
     # Component for rendering related contents on the work show page
     class RelatedContentShowComponent < ApplicationComponent
+      include LinkHelper
+
       def initialize(work_presenter:)
         @work_presenter = work_presenter
         super()
@@ -17,6 +19,19 @@ module Works
 
       def relationship_label_for(related_work)
         t("related_works.edit.fields.relationship.options.#{related_work.relationship}")
+      end
+
+      # Returns a link if the related work is a URL, otherwise returns the related work
+      # param related_work [RelatedWorkForm] the related work to generate a label for
+      # return [String, RelatedWorkForm] a link if the related work is a URL, otherwise the related work
+      def label_for(related_work)
+        label = related_work.to_s
+        uri = URI.parse(label)
+        return label unless %w[http https].include?(uri.scheme)
+
+        link_to_new_tab label, label
+      rescue URI::InvalidURIError, URI::BadURIError
+        related_work
       end
     end
   end

--- a/spec/components/works/show/related_content_show_component_spec.rb
+++ b/spec/components/works/show/related_content_show_component_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Works::Show::RelatedContentShowComponent, type: :component do
+  let(:related_work) { RelatedWorkForm.new(citation:, identifier:, relationship:) }
+  let(:citation) { 'A related work' }
+  let(:identifier) { 'https://example.org/related' }
+  let(:relationship) { 'isCitedBy' }
+  let(:work_presenter) do
+    WorkPresenter.new(work_form: WorkForm.new(related_works: [related_work]),
+                      version_status: instance_double(VersionStatus, editable?: false),
+                      work: instance_double(Work))
+  end
+
+  context 'with a related work that has a URL' do
+    it 'renders the related work with a link' do
+      render_inline(described_class.new(work_presenter:))
+
+      expect(page).to have_content('Related published work')
+      expect(page).to have_link('https://example.org/related', href: 'https://example.org/related')
+      expect(page).to have_content('Is Cited By')
+    end
+  end
+
+  context 'with a related work that is not a URL' do
+    let(:identifier) { nil }
+
+    it 'renders the related work with a link' do
+      render_inline(described_class.new(work_presenter:))
+
+      expect(page).to have_content('Related published work')
+      expect(page).to have_no_link('https://example.org/related', href: 'https://example.org/related')
+      expect(page).to have_content('A related work')
+      expect(page).to have_content('Is Cited By')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2102 

<img width="849" height="175" alt="Screenshot 2026-03-03 at 3 49 25 PM" src="https://github.com/user-attachments/assets/099a7892-2a2b-455e-af03-54f9573df737" />
