### PR TITLE
Fix typo on home page.

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -13,7 +13,7 @@
                     </div>
                     <h1 class="card-text mb-3">Create or manage your deposits</h1>
                     <%= render SdrViewComponents::Elements::ButtonLinkComponent.new(link: dashboard_path, label: 'Enter here', variant: 'primary', size: 'lg') %>
-                    <p class="mt-2">including capstones and thesis</p>
+                    <p class="mt-2">including capstones and theses</p>
                   <% end %>
                 <% end %>
               </div>


### PR DESCRIPTION
closes #2110

<img width="838" height="332" alt="image" src="https://github.com/user-attachments/assets/8ee5171b-cf69-4fc1-bd72-8c57fd1811d7" />
