### PR TITLE
Validate the cocina against datacite on depositor work job if assign_doi is set

### DIFF
--- a/app/jobs/deposit_work_job.rb
+++ b/app/jobs/deposit_work_job.rb
@@ -146,7 +146,7 @@ class DepositWorkJob < ApplicationJob # rubocop:disable Metrics/ClassLength
 
   def accession_or_persist_complete(druid:) # rubocop:disable Metrics/AbcSize
     if accession?
-      validate_datacite if assign_doi
+      validate_datacite
       work.accession!
       Sdr::Repository.accession(druid:, new_user_version: new_user_version?,
                                 version_description: work_form.whats_changing)
@@ -224,16 +224,15 @@ class DepositWorkJob < ApplicationJob # rubocop:disable Metrics/ClassLength
   # This performs the Datacite validation and notifies Honeybadger if there are validation errors.
   # It currently does not raise an error, because we don't want to block the deposit if there are validation errors yet,
   # but we do want to be notified so that we can address any issues and determine how problematic this is for our users.
-  # Controlled by the Settings.validate_datacite.enabled feature flag (false by default).
-  def validate_datacite # rubocop:disable Metrics/AbcSize
-    return unless work_form.persisted? && Settings.validate_datacite.enabled
+  # Controlled by the Settings.validate_datacite.enabled feature flag (true by default).
+  def validate_datacite
+    return unless assign_doi && work_form.persisted? && Settings.validate_datacite.enabled
 
     datacite_validation = Datacite::Validators::CocinaValidator.new(cocina_object: mapped_cocina_object)
     return unless datacite_validation.errors.any?
 
-    errors = datacite_validation.errors.join("\n")
-    Honeybadger.notify("Datacite validation failed", context: { druid: work.druid, errors: datacite_validation.errors })
+    Honeybadger.notify('Datacite validation failed', context: { druid: work.druid, errors: datacite_validation.errors })
   rescue StandardError => e
-    Honeybadger.notify("Unexpected error during datacite validation for #{work.druid}: #{e.message}")
+    Honeybadger.notify('Unexpected error during datacite validation', context: { druid: work.druid, error: e })
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -131,4 +131,4 @@ extract_abstracts:
   enabled: false
 
 validate_datacite:
-  enabled: false
+  enabled: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -19,6 +19,3 @@ article_deposit:
 
 extract_abstracts:
   enabled: true
-
-validate_datacite:
-  enabled: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -17,6 +17,3 @@ gemini_api:
 
 extract_abstracts:
   enabled: true
-
-validate_datacite:
-  enabled: true

--- a/spec/jobs/deposit_work_job_spec.rb
+++ b/spec/jobs/deposit_work_job_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe DepositWorkJob do
         described_class.perform_now(work_form:, work:, deposit: true,
                                     request_review: false, current_user:, ahoy_visit:)
         expect(Honeybadger).to have_received(:notify)
-          .with("Datacite validation failed for #{work.druid}: validation error")
+          .with('Datacite validation failed', context: { druid: work.druid, errors: datacite_validation.errors })
         expect(Sdr::Repository).to have_received(:update)
           .with(cocina_object:, user_name: current_user.sunetid, description: nil)
         expect(Sdr::Repository).to have_received(:accession)
@@ -243,7 +243,8 @@ RSpec.describe DepositWorkJob do
         described_class.perform_now(work_form:, work:, deposit: true,
                                     request_review: false, current_user:, ahoy_visit:)
         expect(Honeybadger).to have_received(:notify)
-          .with("Unexpected error during datacite validation for #{work.druid}: unexpected validation error")
+          .with('Unexpected error during datacite validation', context: { druid: work.druid,
+                                                                          error: an_instance_of(StandardError) })
         expect(Sdr::Repository).to have_received(:update)
           .with(cocina_object:, user_name: current_user.sunetid, description: nil)
         expect(Sdr::Repository).to have_received(:accession)


### PR DESCRIPTION
Fixes #1802

For now, as discussed, this is behind a feature flag (Settings.validate_datacite.enabled) and only notifies Honeybadger when validation fails so that we can assess if this works as expected and how to alert users, etc.