### PR TITLE
Add missing period to abstract help text.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,7 +363,7 @@ en:
           tab_label: 'Abstract and keywords'
           label: 'Describe your deposit'
           help_text: >-
-            Enter a summary statement (up to 5,000 characters) describing the work that you are depositing
+            Enter a summary statement (up to 5,000 characters) describing the work that you are depositing.
             A detailed statement may improve the discovery of your work in web searches.
             You must also enter at least one keyword.
         access:


### PR DESCRIPTION
closes #2138

<img width="854" height="118" alt="image" src="https://github.com/user-attachments/assets/43c52b7e-6515-4f8c-b623-7fe59d82ca6c" />
