### PR TITLE
[HOLD] Add additional tooltips

### DIFF
--- a/app/components/works/edit/license_component.rb
+++ b/app/components/works/edit/license_component.rb
@@ -4,11 +4,14 @@ module Works
   module Edit
     # Select field for license
     class LicenseComponent < ApplicationComponent
-      def initialize(form:, license_presenter:, license_help_url: Settings.license_url, show_terms_of_use: true)
+      def initialize(form:, license_presenter:, license_help_url: Settings.license_url,
+                     show_terms_of_use: true,
+                     tooltip: nil)
         @form = form
         @license_presenter = license_presenter
         @license_help_url = license_help_url
         @show_terms_of_use = show_terms_of_use
+        @tooltip = tooltip
         super()
       end
 
@@ -29,7 +32,7 @@ module Works
       end
 
       def tooltip
-        helpers.t('works.edit.fields.license.tooltip_html')
+        @tooltip || helpers.t('works.edit.fields.license.tooltip_html')
       end
 
       def license_options

--- a/app/components/works/edit/version_identification_component.rb
+++ b/app/components/works/edit/version_identification_component.rb
@@ -21,7 +21,8 @@ module Works
                label_classes: 'fw-bold',
                mark_required: true,
                prompt: 'Select...',
-               container_classes: 'mb-4')
+               container_classes: 'mb-4',
+               tooltip: I18n.t('works.edit.fields.version_identification.tooltip_html'))
       end
     end
   end

--- a/app/views/articles/form.html.erb
+++ b/app/views/articles/form.html.erb
@@ -55,6 +55,7 @@
 
     <%= render Elements::Forms::LabelComponent.new(form:, field_name: :identifier,
                                                    label_text: 'Enter DOI or PMCID for published version of this work. If PMCID does not work, try the DOI.',
+                                                   tooltip: I18n.t('works.edit.fields.identifier.tooltip_html'),
                                                    mark_required: true, classes: 'fw-bold') %>
     <div class="d-flex align-items-center">
       <div class="flex-grow-1">

--- a/app/views/works/article_form.html.erb
+++ b/app/views/works/article_form.html.erb
@@ -54,7 +54,7 @@
       <% end %>
 
       <% component.with_work_pane(tab_name: :license, label: t('works.edit.panes.license.label'), form_id:, discard_draft_form_id:, work_presenter: @work_presenter, active_tab_name:, mark_required: true) do %>
-        <%= render Works::Edit::LicenseComponent.new(form:, license_presenter: @license_presenter) %>
+        <%= render Works::Edit::LicenseComponent.new(form:, license_presenter: @license_presenter, license_help_url: Settings.article_license_url, tooltip: I18n.t('works.edit.fields.license.tooltip_html')) %>
         <% unless @collection.no_custom_rights_statement_option? %>
           <%= render Works::Edit::TermsOfUseComponent.new(form:, collection: @collection) %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,12 @@ en:
   affiliations:
     edit:
       legend: 'Affiliation for this individual'
+  article:
+    edit:
+      fields:
+        license:
+          tooltip_html: >-
+            We strongly recommend that you assign a license to your work, as it will help others understand what you are allowing them to do with your work and under what conditions.  Click on "Get help selecting a license" for specific guidance for licenses for articles.
   contact_sdr: 'Contact SDR staff'
   content_files:
     edit:
@@ -341,6 +347,9 @@ en:
           help_text: 'Assigning a license may improve discovery of your work in web searches.'
           tooltip_html: >-
             We strongly recommend that you assign a license to your work, as it will help others understand what you are allowing them to do with your work and under what conditions.  Click on "Get help selecting a license" for assistance with the license options presented here.
+        identifier:
+          tooltip_html: >-
+            Enter a DOI (with or without "https://doi.org/ or a PMCID (with or without "PMC") to retrieve metadata about your article from the DOI metadata.
         custom_rights_statement:
           label: 'Additional terms of use'
           tooltip_html: >-
@@ -360,6 +369,8 @@ en:
         version_identification:
           label: 'Which version are you depositing?'
           validation: 'selection required'
+          tooltip_html: >-
+            Indicate which version of the article you are depositing. The "author submitted version" is the version before peer review or editing as submitted by an author to a journal. The "author accepted version" is the version accepted for publication and typically includes all changes made as a result of peer review. The "final published version of the work" is the peer reviewed, edited, formatted, and typeset version of the article.
       buttons:
         globus_deposit_files: 'Use Globus to transfer files'
       messages:


### PR DESCRIPTION
Fixes #2140 

1.) Article specific license tooltip
<img width="283" height="268" alt="Screenshot 2026-03-04 at 3 14 22 PM" src="https://github.com/user-attachments/assets/8baf809e-da2c-450b-b7ab-a63d54976e4c" />

2.) Fixed helptext link

3) Article version tooltip:
<img width="305" height="386" alt="Screenshot 2026-03-04 at 3 23 32 PM" src="https://github.com/user-attachments/assets/044f7832-28c0-417b-be0d-521cc5add479" />

4) DOI/PMCID tooltip:
<img width="361" height="227" alt="Screenshot 2026-03-04 at 3 28 48 PM" src="https://github.com/user-attachments/assets/14926c0a-80fb-4a1e-9132-da347a09a726" />
