### PR TITLE
Display github polling on show page

### DIFF
--- a/app/presenters/work_presenter.rb
+++ b/app/presenters/work_presenter.rb
@@ -151,6 +151,10 @@ class WorkPresenter < FormPresenter
     work.is_a?(GithubRepository)
   end
 
+  def github_deposit_future_releases
+    github_deposit_enabled ? 'Yes' : 'No'
+  end
+
   def article?
     work.is_a?(Article)
   end

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -36,6 +36,9 @@
   <% end %>
   <% component.with_row(label: 'Depositor', values: [@work_presenter.depositor]) %>
   <% component.with_row(label: 'Version', values: [@work_presenter.user_version]) %>
+  <% if @work_presenter.github_repository? %>
+    <% component.with_row(label: 'Automatically deposit future GitHub releases?', values: [@work_presenter.github_deposit_future_releases]) %>
+  <% end %>
   <% component.with_row(label: 'Total number of files', values: [@work_presenter.number_of_files_in_deposit]) %>
   <% component.with_row(label: 'Size', values: [number_to_human_size(@work_presenter.size_of_deposit)]) %>
   <% component.with_row(label: 'Deposit created', values: [@work_presenter.deposited_at]) %>

--- a/spec/system/create_github_repository_spec.rb
+++ b/spec/system/create_github_repository_spec.rb
@@ -153,6 +153,12 @@ RSpec.describe 'Create a Github repository and work deposit' do
     expect(page).to have_css('h1', text: 'sul-dlss/hungry-hungry-hippo')
     expect(page).to have_css('.alert-note', text: 'One more step to complete deposit - Go to GitHub ' \
                                                   'to create a release for this GitHub repository.')
+
+    within('table#details-table') do
+      expect(page).to have_css('tr', text: 'Automatically deposit future GitHub releases?')
+      expect(page).to have_css('td', text: 'Yes')
+    end
+
     within('table#license-table') do
       expect(page).to have_css('tr', text: 'License')
       expect(page).to have_css('td', text: 'CC-BY-4.0 Attribution International')

--- a/spec/system/create_work_deposit_spec.rb
+++ b/spec/system/create_work_deposit_spec.rb
@@ -269,6 +269,11 @@ RSpec.describe 'Create a work deposit' do
       expect(page).to have_css('.alert-success', text: 'Deposit successfully submitted')
       expect(page).to have_no_link('Edit or deposit')
 
+      # Details section
+      within('table#details-table') do
+        expect(page).to have_no_css('tr', text: 'Automatically deposit future GitHub releases?')
+      end
+
       # Contributors
       within('#contributors-table') do
         expect(page).to have_css('td', text: 'Jane Stanford')


### PR DESCRIPTION
Fixes #2101 

Visible only on a github repository:

<img width="790" height="508" alt="Screenshot 2026-03-04 at 3 59 56 PM" src="https://github.com/user-attachments/assets/e911ea1b-835d-4755-b1e9-2283e5cba263" />

Not visible on a work (article) show page:
<img width="753" height="455" alt="Screenshot 2026-03-04 at 4 00 07 PM" src="https://github.com/user-attachments/assets/f2f05222-0fc3-4a49-8c89-145711fa9e6f" />

