### PR TITLE
Reset date forms on validation instead of nil

### DIFF
--- a/app/forms/base_work_form.rb
+++ b/app/forms/base_work_form.rb
@@ -115,12 +115,14 @@ class BaseWorkForm < ApplicationForm
   attribute :create_date_type, :string, default: 'single'
   validates :create_date_type, inclusion: { in: %w[single range] }
 
+  # Reset the opposite create date type when switching between single and range
+  # to prevent validation errors from the hidden form fields.
   before_validation do
     if create_date_type == 'range'
-      self.create_date_single = nil
+      self.create_date_single = DateForm.new
     else
-      self.create_date_range_from = nil
-      self.create_date_range_to = nil
+      self.create_date_range_from = DateForm.new
+      self.create_date_range_to = DateForm.new
     end
   end
 


### PR DESCRIPTION
Fixes #2156 

Because the date fields are nested attributes based on `DateForm` clearing them pre-validation with `nil` removes the fields from the form, and therefore there are no fields for the given field names at https://github.com/sul-dlss/hungry-hungry-hippo/blob/main/app/components/elements/forms/non_repeatable_nested_component.html.erb#L11 so we get the blank form.

This clears them by setting them to a blank `DateForm`, thus preserving the fields in the form.