### PR TITLE
Add github buttons to show page

### DIFF
--- a/app/components/works/show/github_edit_button_component.rb
+++ b/app/components/works/show/github_edit_button_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Works
+  module Show
+    # Component for the button to edit GitHub settings.
+    class GithubEditButtonComponent < ApplicationComponent
+      def initialize(presenter:)
+        @presenter = presenter
+        super()
+      end
+
+      attr_reader :presenter
+
+      def call
+        render SdrViewComponents::Elements::ButtonLinkComponent.new(link: edit_polymorphic_path(presenter,
+                                                                                                tab: :deposit),
+                                                                    label: 'Manage automatic deposits',
+                                                                    variant: 'outline-primary')
+      end
+
+      def render?
+        @presenter&.editable?
+      end
+    end
+  end
+end

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -21,8 +21,6 @@
 <%= render Works::Show::DepositingGithubComponent.new(work_presenter: @work_presenter) %>
 <%= render Works::Show::HeaderComponent.new(presenter: @work_presenter) %>
 
-<%= render Works::Show::GithubPollButtonComponent.new(work: @work, classes: 'mb-3') %>
-
 <%= render Elements::Tables::TableComponent.new(id: 'details-table', classes: 'mb-5') do |component| %>
   <% component.with_caption do %><%= render Show::TableHeadingComponent.new(text: 'Details') %><% end %>
   <% component.with_row(label: 'Public webpage', tooltip: t('collections.fields.sharing_link.tooltip_html'), values: [@work_presenter.purl_link]) %>
@@ -37,7 +35,16 @@
   <% component.with_row(label: 'Depositor', values: [@work_presenter.depositor]) %>
   <% component.with_row(label: 'Version', values: [@work_presenter.user_version]) %>
   <% if @work_presenter.github_repository? %>
-    <% component.with_row(label: 'Automatically deposit future GitHub releases?', values: [@work_presenter.github_deposit_future_releases]) %>
+    <% component.with_row(label: 'Automatically deposit future GitHub releases?',
+                          tooltip: I18n.t('works.fields.github_deposit_enabled.tooltip_html')) do |row_component| %>
+      <%= row_component.with_cell do %>
+        <div><%= @work_presenter.github_deposit_future_releases %></div>
+        <div class="d-flex">
+          <%= render Works::Show::GithubEditButtonComponent.new(presenter: @work_presenter) %>
+          <%= render Works::Show::GithubPollButtonComponent.new(work: @work, classes: 'ms-2') %>
+        </div>
+      <% end %>
+    <% end %>
   <% end %>
   <% component.with_row(label: 'Total number of files', values: [@work_presenter.number_of_files_in_deposit]) %>
   <% component.with_row(label: 'Size', values: [number_to_human_size(@work_presenter.size_of_deposit)]) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,7 +169,10 @@ en:
       doi_link:
         tooltip_html: >-
           Use this DOI link for sharing the public webpage for your deposit. If there is no DOI link, use public webpage link above. The link will be active when the deposit is completed.
- 
+      github_deposit_enabled:
+        tooltip_html: >-
+          If "Yes," all future GitHub releases will be automatically deposited in the SDR. If "No," no future GitHub releases will be archived. Click "Manage automatic deposits" to change this setting <b>before creating a new release</b>.
+
   ## EDIT PAGES    
   # Shared by multiple forms
   form:
@@ -408,7 +411,7 @@ en:
         help_html: >-
           You can always return to this form and change this selection if needed.
         tooltip_html: >-
-          If you select "Yes," all future GitHub releases will automatically deposited in the SDR. If you select "No," no future GitHub releases will be archived unless you return here <b>before creating the release you want to archive</b> to change this back to "Yes." Any changes you have made to the metadata will be saved as a draft and published with the next GitHub release; current published work will not be updated.
+          If you select "Yes," all future GitHub releases will be automatically deposited in the SDR. If you select "No," no future GitHub releases will be archived unless you return here <b>before creating the release you want to archive</b> to change this back to "Yes." Any changes you have made to the metadata will be saved as a draft and published with the next GitHub release; current published work will not be updated.
   work_form:
     buttons:
         globus_deposit_files: 'Use Globus to transfer files'

--- a/spec/system/create_github_repository_spec.rb
+++ b/spec/system/create_github_repository_spec.rb
@@ -158,6 +158,8 @@ RSpec.describe 'Create a Github repository and work deposit' do
     within('table#details-table') do
       expect(page).to have_css('tr', text: 'Automatically deposit future GitHub releases?')
       expect(page).to have_css('td', text: 'Yes')
+      expect(page).to have_link('Manage automatic deposits', href: edit_work_path(druid, tab: :deposit))
+      expect(page).to have_button('Check for new GitHub releases')
     end
 
     within('table#license-table') do


### PR DESCRIPTION
Fixes #2157 

<img width="863" height="490" alt="Screenshot 2026-03-05 at 4 28 31 PM" src="https://github.com/user-attachments/assets/840690ed-917c-4692-9a05-fe45934b0bbf" />
