### PR TITLE
Set content_file.label to the release name for new github release

### DIFF
--- a/app/jobs/deposit_github_release_job.rb
+++ b/app/jobs/deposit_github_release_job.rb
@@ -113,10 +113,10 @@ class DepositGithubReleaseJob < ApplicationJob
     @content ||= Content.create!(user:, work: github_repository)
   end
 
-  def create_content_file(tempfile:, filename:, mime_type:)
+  def create_content_file(tempfile:, filename:, mime_type:, label: '')
     content_file = ContentFile.create(file_type: :attached,
                                       size: tempfile.size,
-                                      label: '',
+                                      label:,
                                       content:,
                                       mime_type:,
                                       filepath: filename)
@@ -148,7 +148,10 @@ class DepositGithubReleaseJob < ApplicationJob
   def download_zipball
     Tempfile.create(binmode: true) do |tempfile|
       Github::Downloader.new(url: github_release.zip_url).download_to(tempfile)
-      create_content_file(tempfile:, filename: "#{github_release.release_tag}.zip", mime_type: 'application/zip')
+      create_content_file(tempfile:,
+                          filename: "#{github_release.release_tag}.zip",
+                          label: github_release.release_name,
+                          mime_type: 'application/zip')
     end
   end
 

--- a/spec/jobs/deposit_github_release_job_spec.rb
+++ b/spec/jobs/deposit_github_release_job_spec.rb
@@ -145,6 +145,7 @@ RSpec.describe DepositGithubReleaseJob do
           expect(content_file.filepath).to eq('test4.zip')
           expect(content_file.file.attachment.blob.byte_size).to eq('fake zip content'.bytesize)
           expect(content_file.mime_type).to eq('application/zip')
+          expect(content_file.label).to eq('Release 4')
           asset_content_file = content.content_files.second
           expect(asset_content_file.filepath).to eq('Feb18_2026_collection_report.csv')
           expect(asset_content_file.file.attachment.blob.byte_size).to eq('fake asset content'.bytesize)


### PR DESCRIPTION
Fixes #2177 

<img width="613" height="216" alt="Screenshot 2026-03-09 at 1 20 23 PM" src="https://github.com/user-attachments/assets/99aa4372-ecca-4fcb-8d1d-4a26d75ad27b" />
