### PR TITLE
Do not default license tooltip

### DIFF
--- a/app/components/works/edit/license_component.rb
+++ b/app/components/works/edit/license_component.rb
@@ -14,7 +14,7 @@ module Works
         super()
       end
 
-      attr_reader :form, :show_terms_of_use, :license_help_url
+      attr_reader :form, :show_terms_of_use, :license_help_url, :tooltip
 
       delegate :required_license_option?, to: :@license_presenter
 
@@ -28,10 +28,6 @@ module Works
 
       def help_text
         helpers.t('work_form.fields.license.help_text')
-      end
-
-      def tooltip
-        @tooltip || helpers.t('work_form.fields.license.tooltip_html')
       end
 
       def license_options

--- a/app/views/works/form.html.erb
+++ b/app/views/works/form.html.erb
@@ -69,7 +69,7 @@
       <% end %>
 
       <% component.with_work_pane(tab_name: :license, label: t('work_form.panes.license.label'), form_id:, discard_draft_form_id:, work_presenter: @work_presenter, active_tab_name:, mark_required: true) do %>
-        <%= render Works::Edit::LicenseComponent.new(form:, license_presenter: @license_presenter) %>
+        <%= render Works::Edit::LicenseComponent.new(form:, license_presenter: @license_presenter, tooltip: I18n.t('work_form.fields.license.tooltip_html')) %>
         <% unless @collection.no_custom_rights_statement_option? %>
           <%= render Works::Edit::TermsOfUseComponent.new(form:, collection: @collection) %>
         <% end %>


### PR DESCRIPTION
We do not want to display a license tooltip on the article for and we are currently setting a default license tooltip, so we need to not have a default and always include one if we want it displayed.