### PR TITLE
Add notes to article and github workflows on collection form

### DIFF
--- a/app/components/collections/edit/workflow_component.html.erb
+++ b/app/components/collections/edit/workflow_component.html.erb
@@ -41,6 +41,7 @@
           </div>
         </div>
       <% end %>
+      <p class="mt-2"><%= t('collection_form.fields.article_workflow.following_text_html') %></p>
     </div>
   <% end %>
 
@@ -63,6 +64,7 @@
           </div>
         </div>
       <% end %>
+      <p><%= t('collection_form.fields.github_workflow.following_text_html') %></p>
 
       <% if form.object.github_deposit_enabled %>
         <p class="mt-2">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,6 +249,15 @@ en:
         label: 'Article workflow'
         help_text_html: >-
           This allows the user to deposit a published article with an existing DOI.
+        following_text_html: >-
+          Regardless of the collection settings, these articles will:
+
+          <ul class="mb-0">
+            <li>be available immediately to anyone in the world</li>
+            <li>not receive a DOI</li>
+            <li>not be assigned default email, authors, or work types for the collection</li>
+            <li>Depositors will be allowed to choose any license.</li>
+          </ul>
       description:
         label: 'Description'
         help_text: >-
@@ -269,6 +278,11 @@ en:
         help_text_html: >-
           This allows the user to connect their GitHub account to the SDR for automated deposits of GitHub repositories to
           this collection.
+        following_text_html: >-
+          <ul class="mb-0">
+            <li>Default email, authors, and work types assigned at the collection level will not be included in these deposits.</li>
+            <li>Once a Github repository is set up for automatic depositing, new releases will continue to be deposited unless turned off in the edit form for the individual item.</li>
+          </ul>
       related_links:
         text:
           label: 'Link text'


### PR DESCRIPTION
Fixes #2182 

<img width="906" height="714" alt="Screenshot 2026-03-10 at 4 29 54 PM" src="https://github.com/user-attachments/assets/6b7288a0-6c59-414c-b4bd-6b2f3507e681" />
