### PR TITLE
Widen the news section on the homepage

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -82,7 +82,7 @@
   </div>
 
   <div class="row mt-5 gy-2 justify-content-center">
-    <div class="col col-sm-12 w-50">
+    <div class="col col-sm-12 w-75">
       <div class="d-flex align-items-center ">
         <div class="m-3">
           <%= image_tag 'home_news.jpg', height: 54, width: 185, alt: 'News' %>


### PR DESCRIPTION
Fixes #2190 

This is mostly dependent on the screen/window width, but this sets it slightly wider than it was in relation.

<img width="1361" height="871" alt="Screenshot 2026-03-11 at 9 08 56 AM" src="https://github.com/user-attachments/assets/3ba3872a-1026-4700-8e75-4e9c45841a11" />
