### PR TITLE
warn user when navigate away after PMC/DOI lookup

### DIFF
--- a/app/views/articles/form.html.erb
+++ b/app/views/articles/form.html.erb
@@ -60,9 +60,9 @@
                                                    mark_required: true, classes: 'fw-bold') %>
     <div class="d-flex align-items-center">
       <div class="flex-grow-1">
-      <%= form.text_field :identifier, id: 'identifier_field', class: 'form-control flex-grow-1', data: { action: 'change->unsaved-changes#changed' } %>
+      <%= form.text_field :identifier, class: 'form-control flex-grow-1', data: { action: 'change->unsaved-changes#changed' } %>
       </div>
-      <%= render Elements::Forms::SubmitComponent.new(label: 'Look up', data: { action: 'unsaved-changes#allowFormSubmission' }, value: 'lookup', classes: 'ms-2') %>
+      <%= render Elements::Forms::SubmitComponent.new(label: 'Look up', value: 'lookup', classes: 'ms-2') %>
     </div>
     <%= render Elements::Forms::InvalidFeedbackComponent.new(form:, field_name: :identifier) %>
 

--- a/spec/system/create_article_deposit_spec.rb
+++ b/spec/system/create_article_deposit_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Create an article deposit' do
     expect(page).to have_css('.invalid-feedback', text: 'This field cannot be blank.')
 
     # Validate missing DOI submission
-    fill_in 'identifier_field', with: not_found_doi
+    fill_in 'article_identifier', with: not_found_doi
     click_link_or_button('Look up')
     expect(page).to have_css('.invalid-feedback', text: 'Unable to retrieve metadata for this DOI/PMCID')
     expect(Ahoy::Event.where_event(Ahoy::Event::IDENTIFIER_LOOKUP_NOT_FOUND,
@@ -72,7 +72,7 @@ RSpec.describe 'Create an article deposit' do
                                    identifier_type: 'DOI').count).to eq(1)
 
     # Deposit without required fields
-    fill_in 'identifier_field', with: doi
+    fill_in 'article_identifier', with: doi
     click_link_or_button('Deposit')
     expect(page).to have_css('.invalid-feedback', text: 'must have at least one file')
     expect(page).to have_css('.invalid-feedback', text: 'selection required')
@@ -182,7 +182,7 @@ RSpec.describe 'Create an article deposit' do
       expect(page).to have_css('h1', text: 'Article deposit')
 
       # Look up DOI via PMID
-      fill_in 'identifier_field', with: pmid
+      fill_in 'article_identifier', with: pmid
       click_link_or_button('Look up')
       expect(page).to have_no_css('.invalid-feedback')
       expect(Ahoy::Event.where_event(Ahoy::Event::IDENTIFIER_LOOKUP_SUCCESS,
@@ -218,7 +218,7 @@ RSpec.describe 'Create an article deposit' do
         expect(page).to have_css('h1', text: 'Article deposit')
 
         # Look up DOI via PMID
-        fill_in 'identifier_field', with: doi
+        fill_in 'article_identifier', with: doi
         click_link_or_button('Look up')
         expect(page).to have_css('.invalid-feedback',
                                  text: 'The metadata for this identifier indicates it is not a journal article.')
@@ -245,7 +245,7 @@ RSpec.describe 'Create an article deposit' do
         expect(page).to have_css('h1', text: 'Article deposit')
 
         # Look up DOI via PMID
-        fill_in 'identifier_field', with: doi
+        fill_in 'article_identifier', with: doi
         click_link_or_button('Look up')
         expect(page).to have_css('.invalid-feedback', text: 'The metadata for this identifier is incomplete.')
         expect(Ahoy::Event.where_event(Ahoy::Event::IDENTIFIER_LOOKUP_WITH_INCOMPLETE_METADATA,

--- a/spec/system/create_article_edit_spec.rb
+++ b/spec/system/create_article_edit_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Create an article then edit before deposit' do
     # Setting version description
     select('Author accepted version', from: 'Which version are you depositing?')
 
-    fill_in 'identifier_field', with: doi
+    fill_in 'article_identifier', with: doi
     click_link_or_button('Look up')
 
     # Deposit

--- a/spec/system/create_article_extract_abstract_spec.rb
+++ b/spec/system/create_article_extract_abstract_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Create an article deposit using abstract extract' do
 
       expect(page).to have_css('h1', text: 'Article deposit')
 
-      fill_in 'identifier_field', with: doi
+      fill_in 'article_identifier', with: doi
       click_link_or_button('Look up')
 
       click_link_or_button('Get abstract from file using AI')
@@ -112,7 +112,7 @@ RSpec.describe 'Create an article deposit using abstract extract' do
 
       expect(page).to have_css('h1', text: 'Article deposit')
 
-      fill_in 'identifier_field', with: doi
+      fill_in 'article_identifier', with: doi
       click_link_or_button('Look up')
 
       find('.dropzone').drop('spec/fixtures/files/Strategies_for_Digital_Library_Migration.pdf')
@@ -133,7 +133,7 @@ RSpec.describe 'Create an article deposit using abstract extract' do
 
       expect(page).to have_css('h1', text: 'Article deposit')
 
-      fill_in 'identifier_field', with: doi
+      fill_in 'article_identifier', with: doi
       click_link_or_button('Look up')
 
       find('.dropzone').drop('spec/fixtures/files/Strategies_for_Digital_Library_Migration.pdf')


### PR DESCRIPTION
Fixes #2219 and fixes #2222

- we do not need a custom ID for the article deposit, and this is messing up the label's ability to connect to the input
- adjust tests to use the new default ID added by rails for this field
- alters the lookup button so it does NOT cancel the "form changed" flag, allowing the user to receive a warning if they do a PID lookup and then try to navigate away

There may still be other issues related to navigating away from a form before saving is complete, which occurs after a validation error.  This is a more general issue however and I suggest we tackle this in a separate ticket.