### PR TITLE
move action buttons to new row above title on work show page

### DIFF
--- a/app/components/works/show/header_component.html.erb
+++ b/app/components/works/show/header_component.html.erb
@@ -1,8 +1,4 @@
-<div class="d-flex justify-content-between">
-  <div class="mb-4">
-    <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h1, text: title, classes: 'd-inline') %>
-    <span class="fst-italic status ms-4"><%= status_message %></span>
-  </div>
+<div class="d-flex justify-content-end">
   <div class="d-flex align-items-start ms-5">
     <%= render Edit::EditDraftButtonComponent.new(presenter:, classes: 'text-nowrap') %>
     <%= render Edit::DiscardDraftButtonComponent.new(presenter:, classes: 'ms-2 text-nowrap') %>
@@ -12,5 +8,9 @@
       <% component.with_function(label: 'Delete', link: new_work_admin_delete_path(druid), data: { turbo_frame: 'admin-card' }) %>
     <% end %>
   </div>
+</div>
+<div class="mb-4 mt-2">
+  <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h1, text: title, classes: 'd-inline') %>
+  <span class="fst-italic status ms-4"><%= status_message %></span>
 </div>
 <%= tag.turbo_frame id: 'admin-card' %>


### PR DESCRIPTION
Fixes #2194 - very similar change to what was done on the collection show page a couple weeks ago

<img width="1244" height="546" alt="Screenshot 2026-03-13 at 2 09 13 PM" src="https://github.com/user-attachments/assets/f689d815-7429-4922-83dc-4b165a49d476" />

<img width="577" height="633" alt="Screenshot 2026-03-13 at 2 09 19 PM" src="https://github.com/user-attachments/assets/3bb38b68-e475-4b25-b0d7-bf566d17e5fa" />
