### PR TITLE
switch selected tab link to red in collection show page; add search pill

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -408,3 +408,25 @@ fieldset.form-fieldset legend {
   margin: 2rem 0;
   opacity: 1;
 }
+
+.search-term-pill {
+  background-color: var(--stanford-stone-light);
+  color: var(--stanford-black);
+  border-radius: 1rem;
+  border: 1px solid var(--stanford-90-black);
+  padding: 0;
+
+  .search-term-pill-text {
+    padding: 0.25rem 0.5rem 0.25rem 0.75rem;
+  }
+
+  a {
+    color: var(--stanford-black);
+    text-decoration: none;
+    border-left: 1px solid var(--stanford-90-black);
+    padding: 0.25rem 0.75rem;
+    align-self: stretch;
+    display: flex;
+    align-items: center;
+  }
+}

--- a/app/views/collections/works.html.erb
+++ b/app/views/collections/works.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag 'collection-works' do %>
   <div class="d-flex justify-content-between mb-3">
-    <div>
+    <div class="d-flex align-items-center">
       <%= form_with url: works_collection_path, method: :get do |form| %>
         <div class="input-group">
           <%# Not using TextFieldComponent because field-container conflicts with input-group. %>
@@ -12,6 +12,14 @@
             <%= render Elements::Forms::SubmitComponent.new(label: 'Search', classes: 'btn-sm py-1') %>
           </div>
         </div>
+      <% end %>
+      <% if @search_term.present? %>
+        <span class="search-term-pill d-inline-flex align-items-center ms-2">
+          <span class="search-term-pill-text"><%= @search_term %></span>
+          <%= link_to works_collection_path(@collection), aria: { label: t('collections.buttons.clear_search') } do %>
+            <span aria-hidden="true">&times;</span>
+          <% end %>
+        </span>
       <% end %>
     </div>
     <div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,6 +166,7 @@ en:
       deposit_github_repository:
         label: 'Deposit a GitHub repository'
         aria_label: 'Deposit a GitHub repository to %{collection_title}'
+      clear_search: 'Clear search'
     fields:
       sharing_link:
         label: 'Link for sharing'


### PR DESCRIPTION
Fixes #2201   

1. Change black nav link to red. The CSS changed is scoped in such a way that it is not used anywhere else.
2. Add search pill so user can clear search

<img width="838" height="384" alt="Screenshot 2026-03-13 at 2 28 46 PM" src="https://github.com/user-attachments/assets/b915bf10-6889-43bd-8473-a88aa945d97b" />

<img width="818" height="526" alt="Screenshot 2026-03-13 at 3 02 46 PM" src="https://github.com/user-attachments/assets/7e31aa27-4d62-4a27-8365-38ab8c75372e" />


<img width="591" height="334" alt="Screenshot 2026-03-13 at 2 57 22 PM" src="https://github.com/user-attachments/assets/e97a20e3-dbb5-4628-97c1-1ccfffb76a14" />
