### PR TITLE
home page responsiveness

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -66,11 +66,11 @@
 
   <div class="search-bar p-4">
     <form action="https://searchworks.stanford.edu/" method="get" target="_blank">
-      <div class="row justify-content-center align-items-center">
-        <div class="col-2 d-flex justify-content-end">
-          <label for="search" class="fw-bold">Find SDR items in SearchWorks</label>
+      <div class="row justify-content-center align-items-center g-3">
+        <div class="col-12 col-md-4 col-lg-3 text-start text-md-end">
+          <label for="search" class="fw-bold mb-0">Find SDR items in SearchWorks</label>
         </div>
-        <div class="col-6">
+        <div class="col-12 col-md-8 col-lg-6">
           <input type="hidden" name="f[building_facet][]" value="Stanford Digital Repository">
           <div class="input-group">
             <input name="q" type="text" id="search" class="form-control" placeholder="Search..." autocomplete="off">
@@ -82,17 +82,13 @@
   </div>
 
   <div class="row mt-5 gy-2 justify-content-center">
-    <div class="col col-sm-12 w-75">
-      <div class="d-flex align-items-center ">
-        <div class="m-3">
-          <%= image_tag 'home_news.jpg', height: 54, width: 185, alt: 'News' %>
-        </div>
-        <div class="m-3">
-          <p>
-            Sign up for our newsletter to stay<br> informed about SDR and related services.
-          </p>
-        </div>
-        <div class="flex-grow-1 m-3">
+      <div class="col-12 col-md-4 col-lg-4 ms-5 ms-md-0 text-md-end">
+        <%= image_tag 'home_news.jpg', height: 54, width: 185, alt: 'News' %>
+      </div>
+      <div class="col-12 col-md-3 col-lg-3 ms-5 ms-md-0 d-flex">
+          Sign up for our newsletter to stay informed about SDR and related services.
+      </div>
+      <div class="col-12 col-md-5 col-lg-5 ms-5 ms-md-0 d-flex">
           <%= tag.form action: Settings.newsletter_url, method: 'post', data: { turbo: false },
                        id: 'mc-embedded-subscribe-form', name: 'mc-embedded-subscribe-form', class: 'validate', target: '_blank', novalidate: true do %>
             <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
@@ -101,14 +97,12 @@
             </div>
             <label for="mce-EMAIL" class="visually-hidden">Sign up for our newsletter</label>
             <div class="input-group">
-              <input type="email" value="" name="EMAIL" class="form-control" id="mce-EMAIL" autocomplete="email" placeholder="Enter your email address" required>
+              <input type="email" value="" name="EMAIL" class="form-control" id="mce-EMAIL" autocomplete="email" placeholder="Enter email address" required>
               <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-primary">
             </div>
           <% end %>
         </div>
       </div>
-    </div>
-  </div>
 
   <h1 class="h2 text-center mt-5">What Stanford researchers say about SDR</h1>
 


### PR DESCRIPTION
Fixes #2192 

Make home page more responsive.  Small text tweaks to prevent placeholder from potentially being cutoff ("Enter your email address" -> "Enter email address")

Normal:

<img width="933" height="463" alt="Screenshot 2026-03-13 at 4 59 14 PM" src="https://github.com/user-attachments/assets/64e1415e-af41-4ea2-9132-f7f92ec5c9b9" />


Narrow:


<img width="470" height="400" alt="Screenshot 2026-03-13 at 5 01 09 PM" src="https://github.com/user-attachments/assets/2c9da414-eadb-4080-979f-1d673d07fc8c" />
