### PR TITLE
add aria label to article identifier field for accessibility

### DIFF
--- a/app/views/articles/form.html.erb
+++ b/app/views/articles/form.html.erb
@@ -59,7 +59,9 @@
                                                    tooltip: I18n.t('article_form.fields.identifier.tooltip_html'),
                                                    mark_required: true, classes: 'fw-bold') %>
     <div class="d-flex align-items-center">
-      <%= form.text_field :identifier, class: 'form-control w-50', data: { action: 'change->unsaved-changes#changed' } %>
+      <%= form.text_field :identifier, class: 'form-control w-50',
+                                       aria: Elements::Forms::InvalidFeedbackSupport.arias_for(form:, field_name: :identifier),
+                                       data: { action: 'change->unsaved-changes#changed' } %>
       <%= render Elements::Forms::SubmitComponent.new(label: t('article_form.buttons.lookup_identifier'), value: 'lookup', classes: 'ms-2 text-nowrap') %>
     </div>
     <%= render Elements::Forms::InvalidFeedbackComponent.new(form:, field_name: :identifier) %>

--- a/spec/system/create_article_deposit_spec.rb
+++ b/spec/system/create_article_deposit_spec.rb
@@ -62,6 +62,9 @@ RSpec.describe 'Create an article deposit' do
     click_link_or_button(I18n.t('article_form.buttons.lookup_identifier'))
 
     expect(page).to have_css('.invalid-feedback', text: 'This field cannot be blank.')
+    expect(page).to have_css(
+      'input#article_identifier[aria-invalid="true"][aria-describedby="article_identifier_error"]'
+    )
 
     # Validate missing DOI submission
     fill_in 'article_identifier', with: not_found_doi
@@ -78,6 +81,10 @@ RSpec.describe 'Create an article deposit' do
     expect(page).to have_css('.invalid-feedback', text: 'selection required')
     expect(page).to have_css('.invalid-feedback', text: 'must be accepted')
     expect(page).to have_css('.invalid-feedback', text: 'Look up before editing or depositing')
+    expect(page).to have_css(
+      'select#article_article_version_identification[aria-invalid="true"]' \
+      '[aria-describedby="article_article_version_identification_error"]'
+    )
 
     # Lookup
     click_link_or_button(I18n.t('article_form.buttons.lookup_identifier'))


### PR DESCRIPTION
Fixes #2221 - verified it now will read the error when the field is focused