### PR TITLE
Update GitHub page text

### DIFF
--- a/app/views/github_repositories/form.html.erb
+++ b/app/views/github_repositories/form.html.erb
@@ -7,15 +7,15 @@
 <% end %>
 
 <%= render SdrViewComponents::Elements::HeadingComponent.new(level: :h1, text: 'Deposit your GitHub repository') %>
-<p class="mb-5">
-  This form will allow you to set up automatic deposits of GitHub repository releases.
-</p>
 
 <%= form_with(model: @github_repository_form, data: { controller: 'form-invalid-focus' }) do |form| %>
   <%= form.hidden_field(:collection_druid) %>
 
   <%= render Elements::Forms::TextFieldComponent.new(form:, field_name: :repository, label: I18n.t('github_repository_form.fields.github_repository.label'),
                                                      tooltip: I18n.t('github_repository_form.fields.github_repository.tooltip_html'),
+                                                     help_text: sanitize(I18n.t('github_repository_form.fields.github_repository.help_text'),
+                                                                         tags: %w[ul li],
+                                                                         attributes: []),
                                                      mark_required: true, label_classes: 'fw-bold') %>
 
   <div class="d-flex my-5">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -559,6 +559,11 @@ en:
         label: 'Enter the link or owner/name of the GitHub repository you want to deposit'
         tooltip_html: >-
           GitHub repositories must be public. Format is either "https://github.com/[owner]/[repository_name]" or "[owner]/[repository_name]". Only releases created after you have finished filling the form will be archived in the SDR.
+        help_text: >-
+          <ul>
+            <li>This form will allow you to set up automatic deposits of future GitHub repository releases.</li>
+            <li>Only releases created after this form is saved will be deposited.</li>
+          </ul>
         validations:
           blank: "Can't be blank"
           invalid: 'A link or owner/name of a public GitHub repository is required.'


### PR DESCRIPTION
Fixes #2274 

<img width="1254" height="381" alt="Screenshot 2026-03-18 at 3 18 09 PM" src="https://github.com/user-attachments/assets/4e1334d4-dd1d-4266-a307-3a176ea6396b" />
