### PR TITLE
Avoid user version mismatch when sdr version has advanced

### DIFF
--- a/app/services/user_version_change_service.rb
+++ b/app/services/user_version_change_service.rb
@@ -26,9 +26,11 @@ class UserVersionChangeService
     structural.to_h[:contains].tap do |contains_hash|
       contains_hash.each do |file_set_hash|
         file_set_hash.delete(:label)
+        file_set_hash.delete(:version)
         file_set_hash[:structural][:contains].each do |file_hash|
           file_hash.delete(:label)
           file_hash.delete(:access)
+          file_hash.delete(:version)
         end
       end
     end

--- a/spec/services/user_version_change_service_spec.rb
+++ b/spec/services/user_version_change_service_spec.rb
@@ -257,6 +257,15 @@ RSpec.describe UserVersionChangeService do
     end
   end
 
+  context 'when only the version number has changed (e.g., due to a technical correction between user versions)' do
+    let(:original_cocina_object) { dro_with_structural_fixture(version: 1) }
+    let(:new_cocina_object) { dro_with_structural_fixture(version: 3) }
+
+    it 'returns false' do
+      expect(changed?).to be false
+    end
+  end
+
   context 'when original cocina object is nil' do
     let(:original_cocina_object) { nil }
     let(:new_cocina_object) { dro_with_structural_fixture }


### PR DESCRIPTION
Fixes #2317

This is a subtle bug that is triggering when there have been SDR version bumps that didn't create new user versions (e.g., technical corrections by an admin), the SDR version will be ahead of the last user version. For example:
  - User version 2 created at SDR v2 → files have version: 2
  - Admin technical correction opens SDR v3 (no new user version)
  - Depositor makes metadata-only change: work_form.version = 3 → mapped_cocina_object has files with version: 3
  - Comparison: version: 3 ≠ version: 2 → UserVersionChangeService returns true → new public version incorrectly created

Removing the version from the `contains_hash_for` should guard against this bug in the future.