### PR TITLE
Only send one email on participant changes

### DIFF
--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -59,10 +59,11 @@ class DepositCollectionJob < ApplicationJob
                        work_type: collection_form.work_type,
                        work_subtypes: collection_form.work_subtypes,
                        works_contact_email: collection_form.works_contact_email)
-    assign_participants(:managers)
-    assign_participants(:depositors)
-    assign_participants(:reviewers)
+    participants_changed = assign_participants(:managers)
+    participants_changed |= assign_participants(:depositors)
+    participants_changed |= assign_participants(:reviewers)
     assign_contributors
+    Notifier.publish(Notifier::PARTICIPANTS_CHANGED, collection:) if participants_changed
   end
 
   def perform_persist
@@ -74,28 +75,24 @@ class DepositCollectionJob < ApplicationJob
     end
   end
 
-  # @param [Symbol] role :managers or :depositors
+  # @param [Symbol] role :managers, :depositors, or :reviewers
   #
-  # Based on the provided role (:managers or :depositors), first clears the existing participants
+  # Based on the provided role, first clears the existing participants
   # in order to apply any deletes, then adds the participants from the form. If the added user
   # does not exist, it will be created and the name set to the sunetid until they login for the first time.
-  def assign_participants(role) # rubocop:disable Metrics/AbcSize
+  # @return [Boolean] true if any participants were added or removed
+  def assign_participants(role)
     updated_users_for_role = []
-    collection_form.public_send(role.to_sym).each do |participant|
+    added = false
+    collection_form.public_send(role).each do |participant|
       next if participant.sunetid.blank?
 
-      user = User.create_with(name: participant.name)
-                 .find_or_create_by!(email_address: sunetid_to_email_address(participant.sunetid))
-      # if this user was first added when the name lookup failed, we should now backfill their name if we have it
-      if (user.name.blank? || user.name == user.sunetid) && participant.name.present?
-        user.update(name: participant.name)
-      end
-
-      collection.public_send(role).append(user) unless collection.public_send(role).include?(user)
+      user = find_or_create_user(participant)
+      added = true if add_participant_if_missing(role, user)
       updated_users_for_role.append(user)
     end
 
-    remove_deleted_participants(role, updated_users_for_role)
+    added || remove_deleted_participants(role, updated_users_for_role).any?
   end
 
   # Remove any participants that are no longer in the form
@@ -103,6 +100,21 @@ class DepositCollectionJob < ApplicationJob
     collection.public_send(role)
               .reject { |user| participants.include?(user) }
               .map { |user| collection.public_send(role).destroy(user) }
+  end
+
+  def find_or_create_user(participant)
+    user = User.create_with(name: participant.name)
+               .find_or_create_by!(email_address: sunetid_to_email_address(participant.sunetid))
+    # if this user was first added when the name lookup failed, we should now backfill their name if we have it
+    user.update(name: participant.name) if (user.name.blank? || user.name == user.sunetid) && participant.name.present?
+    user
+  end
+
+  def add_participant_if_missing(role, user)
+    return false if collection.public_send(role).include?(user)
+
+    collection.public_send(role).append(user)
+    true
   end
 
   def sunetid_to_email_address(sunetid)

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -11,6 +11,9 @@ class Notifier
   REVIEWER_REMOVED = 'reviewer_removed'
   DEPOSITOR_REMOVED = 'depositor_removed'
 
+  # Fired once per collection save when any participant (depositor/manager/reviewer) was added or removed
+  PARTICIPANTS_CHANGED = 'participants_changed'
+
   REVIEW_REQUESTED = 'review_requested'
   REVIEW_APPROVED = 'review_approved'
   REVIEW_REJECTED = 'review_rejected'

--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -9,10 +9,7 @@ Rails.application.config.after_initialize do # rubocop:disable Metrics/BlockLeng
   Notifier.subscribe(event_name: Notifier::DEPOSITOR_REMOVED) do |payload|
     CollectionsMailer.with(**payload).deposit_access_removed_email.deliver_later
   end
-  Notifier.subscribe(event_name: Notifier::DEPOSITOR_ADDED) do |payload|
-    CollectionParticipantsChangedSubscriptionMailer.call(**payload)
-  end
-  Notifier.subscribe(event_name: Notifier::DEPOSITOR_REMOVED) do |payload|
+  Notifier.subscribe(event_name: Notifier::PARTICIPANTS_CHANGED) do |payload|
     CollectionParticipantsChangedSubscriptionMailer.call(**payload)
   end
   Notifier.subscribe(event_name: Notifier::ACCESSIONING_STARTED) do |payload|
@@ -23,22 +20,9 @@ Rails.application.config.after_initialize do # rubocop:disable Metrics/BlockLeng
   Notifier.subscribe(event_name: Notifier::MANAGER_ADDED) do |payload|
     CollectionsMailer.with(**payload).manage_access_granted_email.deliver_later
   end
-  Notifier.subscribe(event_name: Notifier::MANAGER_ADDED) do |payload|
-    CollectionParticipantsChangedSubscriptionMailer.call(**payload)
-  end
-  Notifier.subscribe(event_name: Notifier::MANAGER_REMOVED) do |payload|
-    CollectionParticipantsChangedSubscriptionMailer.call(**payload)
-  end
-
   # Reviewer change notifications
   Notifier.subscribe(event_name: Notifier::REVIEWER_ADDED) do |payload|
     CollectionsMailer.with(**payload).review_access_granted_email.deliver_later
-  end
-  Notifier.subscribe(event_name: Notifier::REVIEWER_ADDED) do |payload|
-    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
-  end
-  Notifier.subscribe(event_name: Notifier::REVIEWER_REMOVED) do |payload|
-    CollectionsMailer.with(**payload).participants_changed_email.deliver_later
   end
 
   # Subscriptions for ReviewsMailer

--- a/spec/jobs/deposit_collection_job_spec.rb
+++ b/spec/jobs/deposit_collection_job_spec.rb
@@ -253,10 +253,11 @@ RSpec.describe DepositCollectionJob do
       allow(Notifier).to receive(:publish)
     end
 
-    it 'publishes a MANAGER_ADDED notification' do
+    it 'publishes a MANAGER_ADDED notification and a single PARTICIPANTS_CHANGED notification' do
       described_class.perform_now(collection_form:, collection:, current_user:)
       expect(collection.managers).to include(manager)
       expect(Notifier).to have_received(:publish).with(Notifier::MANAGER_ADDED, collection:, user: manager)
+      expect(Notifier).to have_received(:publish).with(Notifier::PARTICIPANTS_CHANGED, collection:).once
     end
   end
 
@@ -280,12 +281,13 @@ RSpec.describe DepositCollectionJob do
       allow(Notifier).to receive(:publish)
     end
 
-    it 'only publishes a MANGER_REMOVED notification' do
+    it 'publishes a MANAGER_REMOVED notification and a single PARTICIPANTS_CHANGED notification' do
       described_class.perform_now(collection_form:, collection:, current_user:)
       expect(collection.managers).to include(first_manager)
       expect(collection.managers).not_to include(second_manager)
       expect(Notifier).to have_received(:publish).with(Notifier::MANAGER_REMOVED, collection:, user: second_manager)
       expect(Notifier).not_to have_received(:publish).with(Notifier::MANAGER_ADDED)
+      expect(Notifier).to have_received(:publish).with(Notifier::PARTICIPANTS_CHANGED, collection:).once
     end
   end
 


### PR DESCRIPTION
Fixes #2318 

What was happening was that `DEPOSITOR_ADDED`, `DEPOSITOR_REMOVED`, `MANAGER_ADDED`, `MANAGER_REMOVED` events fired once per participant change (via after_create/after_destroy on join models), and each triggered `CollectionParticipantsChangedSubscriptionMailer` which sent one email per manager/reviewer. 9 additions + 6 removals = 15 events = 15 emails per manager. The `EVIEWER_ADDED`/`REVIEWER_REMOVED` subscriptions were also incorrectly sending directly to the reviewer being added (not all managers/reviewers).

This adds `PARTICIPANTS_CHANGED` to track if any changes happened on save and limits to a single participant changed email.

Additionally extracted `find_or_create_user(participant)` and `add_participant_if_missing(role, user)` to help reduce complexity and length of `assign_participants(role)`

This has been tested in stage by @amyehodge 