### PR TITLE
rollback deposit state when a github deposit fails

### DIFF
--- a/app/jobs/deposit_github_release_job.rb
+++ b/app/jobs/deposit_github_release_job.rb
@@ -20,7 +20,7 @@ class DepositGithubReleaseJob < ApplicationJob
       return
     end
 
-    update_release_status(status: 'started', status_details: nil)
+    github_release.update!(status: 'started', status_details: nil)
 
     return if check_release_zip_exists!
 
@@ -32,7 +32,10 @@ class DepositGithubReleaseJob < ApplicationJob
 
     github_release.completed!
   rescue StandardError => e
-    update_release_status(status: 'failed', status_details: "error processing release: #{e.message}")
+    github_release.update!(status: 'failed', status_details: "error processing release: #{e.message}")
+
+    # rollback the repository status so it can be tried again
+    github_repository.deposit_clear_fail! if github_repository.can_deposit_clear_fail?
     raise
   end
 
@@ -54,7 +57,7 @@ class DepositGithubReleaseJob < ApplicationJob
     return false if skip_publish_wait
     return false unless github_release.published_at > publish_wait
 
-    update_release_status(status_details: "waiting #{time_ago_in_words(publish_wait)} after publishing")
+    github_release.update!(status_details: "waiting #{time_ago_in_words(publish_wait)} after publishing")
 
     true
   end
@@ -63,15 +66,15 @@ class DepositGithubReleaseJob < ApplicationJob
     Settings.github.publish_wait.seconds.ago
   end
 
-  def check_version_status!
+  def check_version_status! # rubocop:disable Metrics/AbcSize
     if version_status.open? && !version_status.closeable?
-      update_release_status(status_details: 'version is open but not closeable')
+      github_release.update!(status_details: 'version is open but not closeable')
       Honeybadger.notify('Version is open but not closeable')
       return true
     end
 
     if !version_status.open? && !version_status.openable?
-      update_release_status(status_details: 'version is not openable')
+      github_release.update!(status_details: 'version is not openable')
       Honeybadger.notify('Version is not openable')
       return true
     end
@@ -127,7 +130,7 @@ class DepositGithubReleaseJob < ApplicationJob
   def check_release_zip_exists!
     return false if Github::Downloader.new(url: github_release.zip_url).exist?
 
-    update_release_status(status: 'completed', status_details: 'version zip missing')
+    github_release.update!(status: 'completed', status_details: 'version zip missing')
     true
   end
 
@@ -140,8 +143,11 @@ class DepositGithubReleaseJob < ApplicationJob
   def check_github_repository_deposit_state!
     return false if github_repository.deposit_not_in_progress?
 
-    update_release_status(status: 'failed',
-                          status_details: "github repository state is #{github_repository.deposit_state}")
+    github_release.update!(status: 'failed',
+                           status_details: "github repository state is #{github_repository.deposit_state}")
+    # rollback the repository status so it can be tried again
+    github_repository.deposit_clear_fail! if github_repository.can_deposit_clear_fail?
+
     true
   end
 
@@ -162,14 +168,5 @@ class DepositGithubReleaseJob < ApplicationJob
         create_content_file(tempfile:, filename: asset['name'], mime_type: asset['content_type'])
       end
     end
-  end
-
-  def update_release_status(status_details:, status: github_release.status)
-    github_release.update!(status_details:, status:)
-
-    return unless status == 'failed'
-
-    # if the release failed, rollback the repository status so it can be tried again
-    github_repository.deposit_fail! if github_repository.can_deposit_fail?
   end
 end

--- a/app/jobs/deposit_github_release_job.rb
+++ b/app/jobs/deposit_github_release_job.rb
@@ -20,7 +20,7 @@ class DepositGithubReleaseJob < ApplicationJob
       return
     end
 
-    github_release.update!(status: 'started', status_details: nil)
+    update_release_status(status: 'started', status_details: nil)
 
     return if check_release_zip_exists!
 
@@ -32,7 +32,7 @@ class DepositGithubReleaseJob < ApplicationJob
 
     github_release.completed!
   rescue StandardError => e
-    github_release.update!(status: 'failed', status_details: "error processing release: #{e.message}")
+    update_release_status(status: 'failed', status_details: "error processing release: #{e.message}")
     raise
   end
 
@@ -54,7 +54,7 @@ class DepositGithubReleaseJob < ApplicationJob
     return false if skip_publish_wait
     return false unless github_release.published_at > publish_wait
 
-    github_release.update!(status_details: "waiting #{time_ago_in_words(publish_wait)} after publishing")
+    update_release_status(status_details: "waiting #{time_ago_in_words(publish_wait)} after publishing")
 
     true
   end
@@ -63,15 +63,15 @@ class DepositGithubReleaseJob < ApplicationJob
     Settings.github.publish_wait.seconds.ago
   end
 
-  def check_version_status! # rubocop:disable Metrics/AbcSize
+  def check_version_status!
     if version_status.open? && !version_status.closeable?
-      github_release.update!(status_details: 'version is open but not closeable')
+      update_release_status(status_details: 'version is open but not closeable')
       Honeybadger.notify('Version is open but not closeable')
       return true
     end
 
     if !version_status.open? && !version_status.openable?
-      github_release.update!(status_details: 'version is not openable')
+      update_release_status(status_details: 'version is not openable')
       Honeybadger.notify('Version is not openable')
       return true
     end
@@ -127,7 +127,7 @@ class DepositGithubReleaseJob < ApplicationJob
   def check_release_zip_exists!
     return false if Github::Downloader.new(url: github_release.zip_url).exist?
 
-    github_release.update!(status: 'completed', status_details: 'version zip missing')
+    update_release_status(status: 'completed', status_details: 'version zip missing')
     true
   end
 
@@ -140,8 +140,8 @@ class DepositGithubReleaseJob < ApplicationJob
   def check_github_repository_deposit_state!
     return false if github_repository.deposit_not_in_progress?
 
-    github_release.update!(status: 'failed',
-                           status_details: "github repository state is #{github_repository.deposit_state}")
+    update_release_status(status: 'failed',
+                          status_details: "github repository state is #{github_repository.deposit_state}")
     true
   end
 
@@ -162,5 +162,14 @@ class DepositGithubReleaseJob < ApplicationJob
         create_content_file(tempfile:, filename: asset['name'], mime_type: asset['content_type'])
       end
     end
+  end
+
+  def update_release_status(status_details:, status: github_release.status)
+    github_release.update!(status_details:, status:)
+
+    return unless status == 'failed'
+
+    # if the release failed, rollback the repository status so it can be tried again
+    github_repository.deposit_fail! if github_repository.can_deposit_fail?
   end
 end

--- a/app/models/concerns/deposit_state_machine.rb
+++ b/app/models/concerns/deposit_state_machine.rb
@@ -4,6 +4,7 @@
 module DepositStateMachine
   extend ActiveSupport::Concern
 
+  # rubocop:disable Metrics/BlockLength
   included do
     # In general, the version status should be used for the status of an object.
     # However, deposit_state is used for very specific purposes.
@@ -14,6 +15,12 @@ module DepositStateMachine
     state_machine :deposit_state, initial: :deposit_not_in_progress do
       event :deposit_persist do
         transition deposit_not_in_progress: :deposit_registering_or_updating
+      end
+
+      # On deposit failure, clear in-progress states so a retry can be attempted.
+      event :deposit_fail do
+        transition deposit_registering_or_updating: :deposit_not_in_progress
+        transition accessioning: :deposit_not_in_progress
       end
 
       # As part of the deposit job, accessioning may or may not be started.
@@ -31,7 +38,7 @@ module DepositStateMachine
         transition accessioning: :deposit_not_in_progress
       end
 
-      before_transition deposit_registering_or_updating: any do |object|
+      before_transition on: %i[deposit_persist_complete accession] do |object|
         Notifier.publish(Notifier::DEPOSIT_PERSIST_COMPLETE, object:)
       end
 
@@ -39,9 +46,10 @@ module DepositStateMachine
         Notifier.publish(Notifier::ACCESSIONING_STARTED, object:, current_user: Current.user)
       end
 
-      before_transition accessioning: :deposit_not_in_progress do |object|
+      before_transition on: :accession_complete do |object|
         Notifier.publish(Notifier::ACCESSIONING_COMPLETE, object:)
       end
     end
+    # rubocop:enable Metrics/BlockLength
   end
 end

--- a/app/models/concerns/deposit_state_machine.rb
+++ b/app/models/concerns/deposit_state_machine.rb
@@ -18,7 +18,7 @@ module DepositStateMachine
       end
 
       # On deposit failure, clear in-progress states so a retry can be attempted.
-      event :deposit_fail do
+      event :deposit_clear_fail do
         transition deposit_registering_or_updating: :deposit_not_in_progress
         transition accessioning: :deposit_not_in_progress
       end

--- a/spec/jobs/deposit_github_release_job_spec.rb
+++ b/spec/jobs/deposit_github_release_job_spec.rb
@@ -107,11 +107,27 @@ RSpec.describe DepositGithubReleaseJob do
       github_repository.deposit_persist!
     end
 
-    it 'does not process the release' do
+    it 'does not process the release and rolls back repository deposit state' do
       expect { described_class.perform_now(github_release:) }
         .to change { github_release.reload.status }
         .to('failed').and change(github_release,
                                  :status_details).to('github repository state is deposit_registering_or_updating')
+        .and change { github_repository.reload.deposit_state }.to('deposit_not_in_progress')
+    end
+  end
+
+  context 'when github repository deposit state is accessioning' do
+    before do
+      github_repository.deposit_persist!
+      github_repository.accession!
+    end
+
+    it 'does not process the release and rolls back repository deposit state' do
+      expect { described_class.perform_now(github_release:) }
+        .to change { github_release.reload.status }
+        .to('failed').and change(github_release,
+                                 :status_details).to('github repository state is accessioning')
+        .and change { github_repository.reload.deposit_state }.to('deposit_not_in_progress')
     end
   end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe Work do
     end
   end
 
+  describe '.deposit_clear_fail!' do
+    let(:work) { create(:work, deposit_state: 'accessioning') }
+
+    it 'resets state back to not in progress and does not send a notification' do
+      expect do
+        work.deposit_clear_fail!
+      end.to change(work, :deposit_state).from('accessioning').to('deposit_not_in_progress')
+      expect(Notifier).not_to have_received(:publish).with(Notifier::ACCESSIONING_COMPLETE, object: work)
+    end
+  end
+
   describe '.update_settings_from_form' do
     let(:work) { create(:work) }
     let(:work_form) { instance_double(WorkForm) }

--- a/spec/requests/contact_us_spec.rb
+++ b/spec/requests/contact_us_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'Contact us' do
       it 'renders the form with an error and does not send email' do
         expect { post contacts_path, params: contact_params }.not_to change(ActionMailer::Base.deliveries, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include('reCAPTCHA challenge failed.')
       end
     end


### PR DESCRIPTION
Follow on from #2324 

If something similar happens in the future (starting accessioning or other things fail in the job), this rolls back the deposit state so it can be cleanly retried without manual intervention.