### PR TITLE
Fix FAST search for queries with spaces.

### DIFF
--- a/app/services/keyword_resolver.rb
+++ b/app/services/keyword_resolver.rb
@@ -61,7 +61,7 @@ class KeywordResolver
 
   def resolve(query) # rubocop:disable Metrics/AbcSize
     response = connection.get do |req|
-      req.params['query'] = ERB::Util.url_encode(query)
+      req.params['query'] = ERB::Util.url_encode(query).gsub('%20', '+')
       req.params['queryIndex'] = 'suggestall'
       req.params['queryReturn'] = 'idroot,suggestall,tag'
       req.params['suggest'] = 'autoSubject'
@@ -70,7 +70,6 @@ class KeywordResolver
       req.params['rows'] = Settings.autocomplete_lookup.num_records * 2
       req.params['sort'] = 'usage desc'
     end
-
     return Success(parse(response.body)) if response.success?
 
     Honeybadger.notify('FAST API Error',

--- a/spec/support/stub_fast_connection.rb
+++ b/spec/support/stub_fast_connection.rb
@@ -4,7 +4,7 @@ RSpec.shared_context('with FAST connection') do
   before do
     stub_request(:get, Settings.autocomplete_lookup.url)
       .with(headers: lookup_headers, query: {
-              query:,
+              query: ERB::Util.url_encode(query).gsub('%20', '+'),
               rows: 20,
               sort: 'usage desc',
               queryIndex: 'suggestall',

--- a/spec/system/edit_work_spec.rb
+++ b/spec/system/edit_work_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Edit a work' do
 
   include_context 'with FAST connection'
 
-  let(:query) { 'First%20Keyword' }
+  let(:query) { 'First Keyword' }
   let(:druid) { druid_fixture }
   let(:user) { create(:user) }
   let(:cocina_object) do


### PR DESCRIPTION
closes #2345

Before:
<img width="894" height="360" alt="image" src="https://github.com/user-attachments/assets/c3bd7b02-75d4-45a7-b500-3579e5547859" />

After:
<img width="850" height="376" alt="image" src="https://github.com/user-attachments/assets/f9018546-5b85-4959-9c09-6cdc2b54654b" />
