### PR TITLE
Unify account lookup through AccountService

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -7,29 +7,12 @@ class AccountsController < ApplicationController
   def search
     authorize! with: AccountPolicy
 
-    @account = lookup_account
-    return head :not_found if @account.nil?
+    @account = AccountService.call(id: params[:id])
+    return head :not_found if @account.blank?
 
     respond_to do |format|
       format.html { render layout: false }
       format.json { render json: @account }
     end
-  end
-
-  private
-
-  def id
-    @id ||= params[:id] || params[:sunetid]
-  end
-
-  # Does a lookup from the account service in production mode, otherwise examines local database for users
-  def lookup_account
-    return AccountService.call(id:) unless Rails.env.development?
-
-    user = User.find_by_sunetid(sunetid: id) || User.find_by(email_address: id)
-    return nil unless user
-
-    AccountService::Account.new(name: user.name || user.sunetid, sunetid: user.sunetid,
-                                description: 'Digital Library Systems and Services')
   end
 end

--- a/app/controllers/admin/change_owner_controller.rb
+++ b/app/controllers/admin/change_owner_controller.rb
@@ -34,11 +34,7 @@ module Admin
     end
 
     def account
-      return AccountService.call(id: @change_owner_form.sunetid) unless Rails.env.development?
-
-      AccountService::Account.new(name: @change_owner_form.sunetid,
-                                  sunetid: @change_owner_form.sunetid,
-                                  description: 'Digital Library Systems and Services')
+      AccountService.call(id: @change_owner_form.sunetid)
     end
 
     def user

--- a/app/services/account_service.rb
+++ b/app/services/account_service.rb
@@ -4,43 +4,71 @@
 class AccountService
   Account = Struct.new(:sunetid, :name, :description)
 
+  # Fake the MAIS Person API client. Used for development environments
+  class FakeMaisPersonClient
+    Person = Struct.new(:sunetid, :name, :description)
+
+    def self.fetch_user(id)
+      user = User.find_by_sunetid(sunetid: id) ||
+             User.find_by_sunetid(sunetid: id.downcase) ||
+             User.find_by(email_address: id) ||
+             User.find_by(email_address: id.downcase)
+      return if user.nil?
+
+      {
+        name: user.name || user.sunetid,
+        sunetid: user.sunetid,
+        description: 'Digital Library Systems and Services'
+      }
+    end
+
+    def self.to_person(user_hash)
+      Person.new(**user_hash)
+    end
+  end
+
   def self.call(...)
     new(...).call
   end
 
-  # @param id [String] the SUNetID or email of the account to look up
+  # @param id [String] the SUNet ID or email of the account to look up
   def initialize(id:)
     @id = id&.delete_suffix('@stanford.edu')
   end
 
   # @return [Account, nil] the account or nil if not found
   def call
-    return if id.blank?
-    return if params.blank?
+    return if id.blank? || account_attributes.blank?
 
     # Using the sunetid returned from the Account API since it will perform some normalization
     # e.g., removing accidental delimiter characters
-    Account.new(**params)
+    Account.new(**account_attributes)
   end
 
   private
 
   attr_reader :id
 
-  def params # rubocop:disable Metrics/AbcSize
-    @params ||= Rails.cache.fetch(id, namespace: 'account', expires_in: 1.month) do
-      result = MaisPersonClient.fetch_user(id.downcase)
-      result ||= MaisPersonClient.fetch_user(id) if id.downcase != id
-      if result
-        person = MaisPersonClient::Person.new(result)
-        {
-          sunetid: person.sunetid,
-          name: [person.display_name.first_name, person.display_name.last].compact.join(' '),
-          description: person.job_title
-        }
-      else
-        {}
-      end
-    end
+  def account_attributes
+    @account_attributes ||= Rails.cache.fetch(id, namespace: 'account', expires_in: 1.month) { person.to_h }
+  end
+
+  def person
+    result = client_class.fetch_user(id)
+    return if result.nil?
+
+    client_class.to_person(result)
+  end
+
+  # NOTE: Both the real and fake clients have the same interface, so we can use
+  #       the same code to call them and just swap out the class based on the
+  #       environment. To achieve this, the real client is monkeypatched in an
+  #       initializer to add the same methods as the fake client, so that the
+  #       AccountService can call the same methods regardless of which client is
+  #       being used.
+  def client_class
+    return FakeMaisPersonClient if Rails.env.development?
+
+    MaisPersonClient
   end
 end

--- a/app/views/accounts/search.html.erb
+++ b/app/views/accounts/search.html.erb
@@ -1,4 +1,4 @@
-<% if @account.nil? %>
+<% if @account.blank? %>
   <%= tag.li class: 'list-group-item', role: 'option', 'aria-disabled': 'true' do %>
     No results for "<%= params[:id] %>"
   <% end %>

--- a/app/views/admin/change_owner/form.html.erb
+++ b/app/views/admin/change_owner/form.html.erb
@@ -4,7 +4,7 @@
       <%= tag.div data: {
                     controller: 'autocomplete autocomplete-owner-sunetid',
                     autocomplete_url_value: '/accounts/search',
-                    autocomplete_query_param_value: 'sunetid',
+                    autocomplete_query_param_value: 'id',
                     autocomplete_min_length_value: '3'
                   },
                   class: 'mb-3' do %>

--- a/config/initializers/mais_person_client.rb
+++ b/config/initializers/mais_person_client.rb
@@ -6,3 +6,24 @@ MaisPersonClient.configure(
   base_url: Settings.person_api.url,
   user_agent: 'Stanford Digital Repository'
 )
+
+# Override the MaIS Person Client to add a method for converting the XML
+# response into a Person struct, and to monkeypatch the Person struct to include
+# a method for converting it into a hash for use in the AccountService
+class MaisPersonClient
+  # Add a method to convert the XML response from the MAIS Person API into a Person struct for use in the AccountService
+  def self.to_person(xml_string)
+    Person.new(xml_string)
+  end
+
+  # Monkeypatch Person to include hashification logic for use in the AccountService
+  class Person
+    def to_h
+      {
+        sunetid:,
+        name: [display_name.first_name, display_name.last].compact.join(' '),
+        description: job_title
+      }
+    end
+  end
+end

--- a/spec/services/account_service_spec.rb
+++ b/spec/services/account_service_spec.rb
@@ -5,18 +5,27 @@ require 'rails_helper'
 RSpec.describe AccountService do
   subject(:account) { described_class.call(id:) }
 
-  let(:person_api_response) { '<Person />' }
-  let(:person) do
-    instance_double(MaisPersonClient::Person,
-                    sunetid: 'jcoyne85',
-                    display_name: MaisPersonClient::Person::PersonName.new(first_name: 'Justin Michael', last: 'Coyne'),
-                    job_title: 'Digital Library Systems and Services, Digital Library Software Engineer - Web & Infrastructure') # rubocop:disable Layout/LineLength
+  let(:person_api_response) do
+    <<~XML
+      <Person listing="world" name="Coyne, Justin Michael" regid="567abc" relationship="staff" source="registry" sunetid="jcoyne85" univid="56789">
+        <name type="registered" visibility="none">
+          <first nval="test">Justin Michael</first>
+          <middle nval="t">Michael</middle>
+          <last nval="test">Coyne</last>
+        </name>
+        <name type="display" visibility="world">
+          <first nval="test">Justin</first>
+          <middle nval="t">Michael</middle>
+          <last nval="test">Coyne</last>
+        </name>
+        <title type="job" visibility="world">Digital Library Systems and Services</title>
+      </Person>
+    XML
   end
   let(:id) { 'jcoyne85' }
 
   before do
     allow(MaisPersonClient).to receive(:fetch_user).and_return(person_api_response)
-    allow(MaisPersonClient::Person).to receive(:new).with(person_api_response).and_return(person)
   end
 
   context 'with a blank string' do
@@ -30,17 +39,21 @@ RSpec.describe AccountService do
   context 'when not found' do
     let(:person_api_response) { nil }
 
-    it 'returns an empty response' do
+    it 'returns nil' do
       expect(account).to be_nil
     end
   end
 
   context 'when the API returns a successful response' do
+    before do
+      create(:user, name: 'Justin Coyne', email_address: 'jcoyne85@stanford.edu')
+    end
+
     it 'returns an Account with the expected attributes' do
       expect(account.to_h).to match(
         sunetid: 'jcoyne85',
-        name: 'Justin Michael Coyne',
-        description: 'Digital Library Systems and Services, Digital Library Software Engineer - Web & Infrastructure'
+        name: 'Justin Coyne',
+        description: 'Digital Library Systems and Services'
       )
     end
   end
@@ -48,29 +61,32 @@ RSpec.describe AccountService do
   context 'when an email address is provided' do
     let(:id) { 'jcoyne85@stanford.edu' }
 
+    before do
+      create(:user, name: 'Justin Coyne', email_address: 'jcoyne85@stanford.edu')
+    end
+
     it 'normalizes the id by removing the email domain' do
-      account
-      expect(MaisPersonClient).to have_received(:fetch_user).with('jcoyne85')
+      expect(account.to_h).to match(
+        sunetid: 'jcoyne85',
+        name: 'Justin Coyne',
+        description: 'Digital Library Systems and Services'
+      )
     end
   end
 
   context 'when an uppercase id is provided' do
     let(:id) { 'JCOYNE85' }
 
-    it 'normalizes the id by downcasing it' do
-      account
-      expect(MaisPersonClient).to have_received(:fetch_user).with('jcoyne85')
+    before do
+      create(:user, name: 'Justin Coyne', email_address: 'jcoyne85@stanford.edu')
     end
-  end
 
-  context 'when not found with a downcased id' do
-    let(:id) { 'JCOYNE85' }
-    let(:person_api_response) { nil }
-
-    it 'attempts to find the user with the original case id' do
-      account
-      expect(MaisPersonClient).to have_received(:fetch_user).with('jcoyne85')
-      expect(MaisPersonClient).to have_received(:fetch_user).with('JCOYNE85')
+    it 'normalizes the id by downcasing it' do
+      expect(account.to_h).to match(
+        sunetid: 'jcoyne85',
+        name: 'Justin Coyne',
+        description: 'Digital Library Systems and Services'
+      )
     end
   end
 end


### PR DESCRIPTION
While working on the PR that closed #2349, I saw an opportunity to do some refactoring. Here's the refactoring I had in mind.

- Move account lookup responsibility out of AccountsController so search uses a single service path and avoids environment-specific branching in controller code.
- Update AccountService to build Account data from `Person#to_h`, return `nil` when attributes are blank, and choose a dev-only fake MaIS client to keep local behavior consistent with production call sites.
- Add `MaisPersonClient::Person#to_h` and a `FakeMaisPersonClient` so both real and fake responses share one attribute contract and reduce duplicated mapping logic.
- Align autocomplete and search handling on `id` (instead of `sunetid`) and use `blank?` checks in views/controllers to treat empty results consistently.
- Refresh service specs to assert returned account attributes from real XML parsing, reflecting the new normalization/mapping behavior.
