### PR TITLE
Remove no break spaces from participants entry

### DIFF
--- a/app/javascript/controllers/participants_controller.js
+++ b/app/javascript/controllers/participants_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
     if (this.inputTarget.value === '') return
 
     this.invalidFeedbackContainerTarget.innerHTML = ''
+    // Split on comma, semicolon, pipe, or whitespace (including any no-break spaces), and remove leading/trailing empty strings
     const ids = this.inputTarget.value.split(/[,;|\s]+/).filter(Boolean)
     await Promise.all(ids.map(id => this.lookupId(id)))
       .then((errorIds) => {

--- a/app/javascript/controllers/participants_controller.js
+++ b/app/javascript/controllers/participants_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
     if (this.inputTarget.value === '') return
 
     this.invalidFeedbackContainerTarget.innerHTML = ''
-    const ids = this.inputTarget.value.split(/[,;| ]+|\n/)
+    const ids = this.inputTarget.value.split(/[,;|\s]+/).filter(Boolean)
     await Promise.all(ids.map(id => this.lookupId(id)))
       .then((errorIds) => {
         this.inputTarget.value = ''

--- a/spec/system/edit_collection_spec.rb
+++ b/spec/system/edit_collection_spec.rb
@@ -54,6 +54,9 @@ RSpec.describe 'Edit a collection' do
       .with(id: 'stepking')
       .and_return(AccountService::Account.new(name: 'Stephen King', sunetid: 'stepking'))
     allow(AccountService).to receive(:call)
+      .with(id: 'alborland')
+      .and_return(AccountService::Account.new(name: 'Al Borland', sunetid: 'alborland'))
+    allow(AccountService).to receive(:call)
       .with(id: 'joehill')
       .and_return(AccountService::Account.new(name: 'Joe Hill', sunetid: 'joehill'))
 
@@ -151,6 +154,12 @@ RSpec.describe 'Edit a collection' do
     fill_in('managers-textarea', with: '<stepking@stanford.edu>')
     click_link_or_button('Add Managers')
     expect(page).to have_css('.participant-label', text: 'Stephen King (stepking)')
+
+    # A trailing no-break space should be treated like other whitespace and
+    # not become part of the SUNet ID.
+    fill_in('managers-textarea', with: "alborland\u00A0")
+    click_link_or_button('Add Managers')
+    expect(page).to have_css('.participant-label', text: 'Al Borland (alborland)')
 
     # Fill in the depositor form
     fill_in('depositors-textarea', with: 'joehill')


### PR DESCRIPTION
Fixes #2356. Splits on any kind of whitespace (including no-break spaces) and removes them. 

Tested on stage