### PR TITLE
approval with deposit for reviewer

### DIFF
--- a/app/components/works/edit/submit_component.rb
+++ b/app/components/works/edit/submit_component.rb
@@ -25,7 +25,9 @@ module Works
       end
 
       def label
-        if review?
+        if approve_and_deposit?
+          'Approve and deposit'
+        elsif review?
           'Submit for review'
         else
           deposit_label
@@ -42,6 +44,10 @@ module Works
 
       def review_permissions?
         @review_permissions ||= helpers.allowed_to?(:review?, collection)
+      end
+
+      def approve_and_deposit?
+        work&.pending_review? && review_permissions?
       end
 
       def deposit_permissions?

--- a/app/components/works/show/pending_review_component.rb
+++ b/app/components/works/show/pending_review_component.rb
@@ -11,8 +11,9 @@ module Works
         super()
       end
 
+      # only render if the work is pending review and the current user is the depositor
       def render?
-        work_presenter.pending_review?
+        work_presenter.pending_review? && work_presenter.user == Current.user
       end
     end
   end

--- a/app/jobs/deposit_work_job.rb
+++ b/app/jobs/deposit_work_job.rb
@@ -162,7 +162,8 @@ class DepositWorkJob < ApplicationJob # rubocop:disable Metrics/ClassLength
   end
 
   def authorized_reviewer?
-    work.collection.reviewers.exists?(Current.user.id) || work.collection.managers.exists?(Current.user.id)
+    work.user_id == Current.user.id || work.collection.reviewers.exists?(Current.user.id) ||
+      work.collection.managers.exists?(Current.user.id)
   end
 
   def update_last_deposited_at!

--- a/app/jobs/deposit_work_job.rb
+++ b/app/jobs/deposit_work_job.rb
@@ -147,6 +147,7 @@ class DepositWorkJob < ApplicationJob # rubocop:disable Metrics/ClassLength
   def accession_or_persist_complete(druid:) # rubocop:disable Metrics/AbcSize
     if accession?
       validate_datacite
+      work.approve! if work.pending_review? && authorized_reviewer?
       work.accession!
       Sdr::Repository.accession(druid:, new_user_version: new_user_version?,
                                 version_description: work_form.whats_changing)
@@ -158,6 +159,10 @@ class DepositWorkJob < ApplicationJob # rubocop:disable Metrics/ClassLength
     else
       work.deposit_persist_complete!
     end
+  end
+
+  def authorized_reviewer?
+    work.collection.reviewers.exists?(Current.user.id) || work.collection.managers.exists?(Current.user.id)
   end
 
   def update_last_deposited_at!

--- a/spec/components/works/edit/submit_component_spec.rb
+++ b/spec/components/works/edit/submit_component_spec.rb
@@ -55,6 +55,21 @@ RSpec.describe Works::Edit::SubmitComponent, type: :component do
     end
   end
 
+  context 'when user is reviewer and work is pending review' do
+    let(:work) { create(:work, :registering_or_updating, user:, collection:, review_state: 'pending_review') }
+
+    before do
+      allow(vc_test_controller).to receive(:current_user).and_return(reviewer)
+      allow(Current).to receive(:groups).and_return([])
+    end
+
+    it 'renders approve and deposit' do
+      render_inline(described_class.new(form_id:, work:, collection:))
+
+      expect(page).to have_button('Approve and deposit')
+    end
+  end
+
   context 'when user has deposit share permissions' do
     let(:permission) { Share::VIEW_EDIT_DEPOSIT_PERMISSION }
     let(:review_enabled) { false }

--- a/spec/components/works/show/pending_review_component_spec.rb
+++ b/spec/components/works/show/pending_review_component_spec.rb
@@ -3,18 +3,39 @@
 require 'rails_helper'
 
 RSpec.describe Works::Show::PendingReviewComponent, type: :component do
-  let(:work) { instance_double(Work, pending_review?: pending_review) }
+  let(:depositor) { build(:user) }
+  let(:viewer) { depositor }
+  let(:work) { instance_double(Work, pending_review?: pending_review, user: depositor) }
   let(:work_presenter) do
     WorkPresenter.new(work_form: WorkForm.new, work:, version_status: VersionStatus::NilStatus)
   end
 
-  context 'with work pending review' do
+  before do
+    Current.user = viewer
+  end
+
+  after do
+    Current.reset
+  end
+
+  context 'with work pending review and depositor viewing' do
     let(:pending_review) { true }
+
+    it 'renders the alert' do
+      render_inline(described_class.new(work_presenter:))
+
+      expect(page).to have_css('.alert', text: 'Work successfully submitted for review')
+    end
+  end
+
+  context 'with work pending review and non-depositor viewing' do
+    let(:pending_review) { true }
+    let(:viewer) { build(:user) }
 
     it 'does not render the alert' do
       render_inline(described_class.new(work_presenter:))
 
-      expect(page).to have_css('.alert', text: 'Work successfully submitted for review')
+      expect(page).to have_no_css('.alert')
     end
   end
 

--- a/spec/jobs/deposit_work_job_spec.rb
+++ b/spec/jobs/deposit_work_job_spec.rb
@@ -482,6 +482,67 @@ RSpec.describe DepositWorkJob do
     end
   end
 
+  context 'when review is pending and a reviewer deposits' do
+    let(:druid) { druid_fixture }
+    let(:cocina_object) { dro_with_metadata_fixture }
+    let(:work_form) { WorkForm.new(druid:, content_id: content.id, lock: lock_fixture) }
+    let(:work) do
+      create(:work, :registering_or_updating, druid:, collection:, review_state: 'pending_review')
+    end
+    let(:version_status) { build(:draft_version_status) }
+    let(:collection) { create(:collection, druid: collection_druid_fixture, reviewers: [current_user]) }
+
+    before do
+      allow(Sdr::Repository).to receive(:status).and_return(version_status)
+      allow(Cocina::WorkMapper).to receive(:call).and_return(cocina_object)
+      allow(RoundtripSupport).to receive(:changed?).and_return(false)
+      allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
+      allow(Sdr::Repository).to receive(:find_latest_user_version).with(druid:).and_return(cocina_object)
+      allow(Sdr::Repository).to receive(:update)
+    end
+
+    it 'approves the work and deposits' do
+      expect(work.pending_review?).to be true
+
+      described_class.perform_now(work_form:, work:, deposit: true, request_review: false, current_user:, ahoy_visit:)
+
+      expect(work.review_not_in_progress?).to be true
+      expect(Sdr::Repository).to have_received(:accession)
+      expect(Sdr::Repository).to have_received(:update)
+    end
+  end
+
+  context 'when review is pending and a non-reviewer deposits' do
+    let(:druid) { druid_fixture }
+    let(:cocina_object) { dro_with_metadata_fixture }
+    let(:work_form) { WorkForm.new(druid:, content_id: content.id, lock: lock_fixture) }
+    let(:collection) { create(:collection, druid: collection_druid_fixture) }
+    let(:work) do
+      create(:work, :registering_or_updating, druid:, collection:, review_state: 'pending_review')
+    end
+    let(:version_status) { build(:draft_version_status) }
+
+    before do
+      allow(Sdr::Repository).to receive(:status).and_return(version_status)
+      allow(Cocina::WorkMapper).to receive(:call).and_return(cocina_object)
+      allow(RoundtripSupport).to receive(:changed?).and_return(false)
+      allow(Sdr::Repository).to receive(:find).with(druid:).and_return(cocina_object)
+      allow(Sdr::Repository).to receive(:find_latest_user_version).with(druid:).and_return(cocina_object)
+      allow(Sdr::Repository).to receive(:update)
+    end
+
+    it 'returns without approving the work' do
+      expect(work.pending_review?).to be true
+
+      expect do
+        described_class.perform_now(work_form:, work:, deposit: true, request_review: false, current_user:, ahoy_visit:)
+      end.not_to raise_error
+
+      expect(work.reload.pending_review?).to be true
+      expect(Sdr::Repository).to have_received(:accession)
+    end
+  end
+
   context 'when a stale lock' do
     let(:work) { create(:work, :registering_or_updating, druid:) }
     let(:work_form) do


### PR DESCRIPTION
~~HOLD pending PO approval/testing~~

Fixes #2357 

Does a few things:

1. Do not show this message when an item requires review and the review is looking at it.  This message only makes sense for the depositor

<img width="1138" height="255" alt="Screenshot 2026-05-22 at 2 32 19 PM" src="https://github.com/user-attachments/assets/cdeadcfb-3c06-43df-9cfd-5baa2f5f8c8a" />

2. Change the label for the "Deposit" button to "Approve and Deposit" when a reviewer is editing a deposit that is also under review.

<img width="1081" height="474" alt="Screenshot 2026-05-22 at 2 32 14 PM" src="https://github.com/user-attachments/assets/133098f5-60d6-490a-90a1-2a0a3a67332f" />

3. Mark the deposit as approved as well as deposited when a reviewer clicks the "Approve and Deposit" button above.  This will also take away the review panel that shows above the deposit for the reviewer (because it is no longer under review and has been approved).

4. Fixes the current issue where a deposit under review that is edited and then immediately approved gets stuck (because our current workflow does not account for this, and instead tries to modify an object that isn't open).

