### PR TITLE
Ignore label in roundtripping

### DIFF
--- a/app/services/roundtrip_support.rb
+++ b/app/services/roundtrip_support.rb
@@ -14,7 +14,9 @@ class RoundtripSupport
                   else
                     {}
                   end
-    norm_cocina_object = norm_cocina_object.new(cocinaVersion: Cocina::Models::VERSION, **other_attrs)
+    # Label is not set when mapping to Cocina, so ignore it (e.g., when it is still present on
+    # objects retrieved from dor-services-app) when roundtripping.
+    norm_cocina_object = norm_cocina_object.new(cocinaVersion: Cocina::Models::VERSION, label: '', **other_attrs)
 
     Cocina::Models.with_metadata(norm_cocina_object, lock)
   end

--- a/spec/services/roundtrip_support_spec.rb
+++ b/spec/services/roundtrip_support_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe RoundtripSupport do
         expect(described_class.changed?(cocina_object:)).to be false
       end
     end
+
+    context 'when the original cocina object has a label but the mapped cocina object does not' do
+      let(:original_cocina_object) { cocina_object.new(label: 'a pre-existing label') }
+
+      it 'returns false' do
+        expect(described_class.changed?(cocina_object:, original_cocina_object:)).to be false
+      end
+    end
   end
 
   describe '#normalize_cocina_object' do


### PR DESCRIPTION
Until we remove the label from all Cocina, there can be a roundtripping problem. This ignores the label when roundtripping. 