### PR TITLE
Change managers depositing email to only send one email per invocation.

### DIFF
--- a/app/mailers/works_mailer.rb
+++ b/app/mailers/works_mailer.rb
@@ -16,10 +16,7 @@ class WorksMailer < ApplicationMailer
   end
 
   def managers_depositing_email
-    (@collection.managers - Array(params[:current_user])).each do |user|
-      @user = user
-      mail(to: @user.email_address, subject: "Item deposit completed in the #{@collection.title} collection")
-    end
+    mail(to: @user.email_address, subject: "Item deposit completed in the #{@collection.title} collection")
   end
 
   def ownership_changed_email

--- a/app/subscription_handlers/work_accessioning_started_subscription_mailer.rb
+++ b/app/subscription_handlers/work_accessioning_started_subscription_mailer.rb
@@ -16,7 +16,9 @@ class WorkAccessioningStartedSubscriptionMailer
   def call
     return unless object.is_a?(Work)
 
-    WorksMailer.with(work: object, current_user:).managers_depositing_email.deliver_later
+    (object.collection.managers - Array(current_user)).each do |user|
+      WorksMailer.with(work: object, user:).managers_depositing_email.deliver_later
+    end
   end
 
   private

--- a/spec/mailers/previews/works_mailer_preview.rb
+++ b/spec/mailers/previews/works_mailer_preview.rb
@@ -12,7 +12,7 @@ class WorksMailerPreview < ActionMailer::Preview
   end
 
   def managers_depositing_email
-    WorksMailer.with(work: Work.first).managers_depositing_email
+    WorksMailer.with(work: Work.first, user: User.first).managers_depositing_email
   end
 
   def ownership_changed_email

--- a/spec/mailers/works_mailer_spec.rb
+++ b/spec/mailers/works_mailer_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe WorksMailer do
   end
 
   describe '.managers_depositing_email' do
-    let(:mail) { described_class.with(work:, current_user: user).managers_depositing_email }
+    let(:mail) { described_class.with(work:, user: manager).managers_depositing_email }
     let(:manager) { create(:user, first_name: 'Carter') }
     let(:managers) { [user, manager] }
 

--- a/spec/subscription_handlers/work_accessioning_started_subscription_mailer_spec.rb
+++ b/spec/subscription_handlers/work_accessioning_started_subscription_mailer_spec.rb
@@ -8,12 +8,15 @@ RSpec.describe WorkAccessioningStartedSubscriptionMailer, :active_job_test_adapt
   let(:current_user) { create(:user) }
 
   context 'when work' do
-    let(:work) { create(:work) }
+    let(:manager) { create(:user) }
+    let(:collection) { create(:collection, managers: [manager, current_user]) }
+    let(:work) { create(:work, collection:) }
 
-    it 'sends the deposited email' do
+    it 'sends the managers depositing email to each manager other than the current user' do
       described_class.call(object: work, current_user:)
 
-      assert_enqueued_email_with WorksMailer.with(work:, current_user:), :managers_depositing_email
+      assert_enqueued_email_with WorksMailer.with(work:, user: manager), :managers_depositing_email
+      assert_enqueued_emails 1
     end
   end
 


### PR DESCRIPTION
Rails only allows a mailer to send one email per invocation. This moves the looping out of the mailer.