### PR TITLE
Normalize description form when roundtrip validating.

### DIFF
--- a/app/roundtrippers/work_roundtripper.rb
+++ b/app/roundtrippers/work_roundtripper.rb
@@ -31,12 +31,12 @@ class WorkRoundtripper
 
   # @return [Boolean] true if the work form can be converted to a cocina object and back without loss
   def call
-    if roundtripped_cocina_object == normalized_original_cocina_object
+    if normalized_roundtripped_cocina_object == normalized_original_cocina_object
       true
     else
       if notify
         RoundtripSupport.notify_error(original_cocina_object: normalized_original_cocina_object,
-                                      roundtripped_cocina_object:)
+                                      roundtripped_cocina_object: normalized_roundtripped_cocina_object)
       end
       false
     end
@@ -50,6 +50,11 @@ class WorkRoundtripper
     Cocina::WorkMapper.call(work_form:,
                             content:,
                             source_id: normalized_original_cocina_object.identification&.sourceId)
+  end
+
+  def normalized_roundtripped_cocina_object
+    @normalized_roundtripped_cocina_object ||=
+      RoundtripSupport.normalize_cocina_object(cocina_object: roundtripped_cocina_object)
   end
 
   def normalized_original_cocina_object

--- a/app/services/roundtrip_support.rb
+++ b/app/services/roundtrip_support.rb
@@ -9,8 +9,11 @@ class RoundtripSupport
     lock = cocina_object&.lock
     norm_cocina_object = Cocina::Models.without_metadata(cocina_object)
     other_attrs = if cocina_object.dro?
-                    { structural: normalize_structural_attrs(structural_attrs: cocina_object.structural.to_h,
-                                                             version: cocina_object.version) }
+                    {
+                      structural: normalize_structural_attrs(structural_attrs: cocina_object.structural.to_h,
+                                                             version: cocina_object.version),
+                      description: normalize_description_attrs(description_attrs: cocina_object.description.to_h)
+                    }
                   else
                     {}
                   end
@@ -29,11 +32,23 @@ class RoundtripSupport
   end
   private_class_method :normalize_structural_attrs
 
+  def self.normalize_description_attrs(description_attrs:)
+    # Form ordering doesn't matter and may be re-ordered by Argo description updates.
+    # This provides deterministic ordering.
+    description_attrs[:form] = Array(description_attrs[:form]).sort_by do |h|
+      h.to_a.sort_by do |k, v|
+        [k.to_s, v.to_s]
+      end.inspect
+    end
+    description_attrs
+  end
+  private_class_method :normalize_description_attrs
+
   # @param [Cocina::Models::DRO,Cocina::Models::Collection] cocina_object
   # @return [Boolean] true if the provided cocina object is the same as a cocina object retrieved from SDR.
   def self.changed?(cocina_object:, original_cocina_object: nil)
     original_cocina_object ||= Sdr::Repository.find(druid: cocina_object.externalIdentifier)
-    cocina_object != normalize_cocina_object(cocina_object: original_cocina_object)
+    normalize_cocina_object(cocina_object:) != normalize_cocina_object(cocina_object: original_cocina_object)
   end
 
   def self.notify_error(original_cocina_object:, roundtripped_cocina_object:) # rubocop:disable Metrics/AbcSize

--- a/spec/roundtrippers/work_roundtripper_spec.rb
+++ b/spec/roundtrippers/work_roundtripper_spec.rb
@@ -10,7 +10,12 @@ RSpec.describe WorkRoundtripper, type: :mapping do
   let(:notify) { true }
 
   context 'when roundtrippable' do
-    let(:cocina_object) { dro_with_structural_and_metadata_fixture }
+    let(:cocina_object) do
+      dro_with_structural_and_metadata_fixture.new(
+        # Randomly shuffle the form array to ensure that the order of the form elements does not affect the roundtrip.
+        description: dro_fixture.description.new(form: form_fixture.shuffle)
+      )
+    end
 
     it 'returns true' do
       expect(validator.call).to be true

--- a/spec/services/roundtrip_support_spec.rb
+++ b/spec/services/roundtrip_support_spec.rb
@@ -31,10 +31,48 @@ RSpec.describe RoundtripSupport do
   describe '#normalize_cocina_object' do
     context 'when the cocina object is a DRO' do
       let(:cocina_object) { dro_with_structural_and_metadata_fixture(version: 1).new(cocinaVersion: '0.0.0') }
+      let(:expected_cocina_object) do
+        dro_with_structural_and_metadata_fixture.new(
+          # This is the deterministic form ordering.
+          description: dro_fixture.description.new(form: expected_form)
+        )
+      end
+      let(:expected_form) do
+        [{ value: 'Photographs',
+           type: 'genre',
+           uri: 'http://id.loc.gov/authorities/genreForms/gf2017027249',
+           source: { code: 'lcgft' } },
+         { value: 'Data sets',
+           type: 'genre',
+           uri: 'http://id.loc.gov/authorities/genreForms/gf2018026119',
+           source: { code: 'lcgft' } },
+         { value: 'dataset',
+           type: 'genre',
+           source: { code: 'local' } },
+         { value: 'Dataset',
+           type: 'resource type',
+           uri: 'http://id.loc.gov/vocabulary/resourceTypes/dat',
+           source: { uri: 'http://id.loc.gov/vocabulary/resourceTypes/' } },
+         { value: 'Image',
+           type: 'resource type',
+           source: { value: 'DataCite resource types' } },
+         { value: 'still image',
+           type: 'resource type',
+           source: { value: 'MODS resource types' } },
+         { structuredValue:
+           [{ value: 'Image',
+              type: 'type' },
+            { value: 'Data',
+              type: 'subtype' },
+            { value: 'Photograph',
+              type: 'subtype' }],
+           type: 'resource type',
+           source: { value: 'Stanford self-deposit resource types' } }]
+      end
 
       it 'returns a normalized cocina object' do
         expect(described_class.normalize_cocina_object(cocina_object:))
-          .to equal_cocina dro_with_structural_and_metadata_fixture
+          .to equal_cocina expected_cocina_object
       end
     end
 


### PR DESCRIPTION
Argo bulk description can re-order description forms causing roundtripping errors.

refs #2404