### PR TITLE
Rake task for calling WorkModelSynchronizer on all non-draft works

### DIFF
--- a/lib/tasks/resync.rake
+++ b/lib/tasks/resync.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :resync do
-  desc 'Synchronize all with their cocina objects'
+  desc 'Synchronize all works with their cocina objects'
   task works: :environment do
     Work.where.not(druid: nil).find_each do |work|
       cocina_object = Sdr::Repository.find(druid: work.druid)

--- a/lib/tasks/resync.rake
+++ b/lib/tasks/resync.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :resync do
+  desc 'Synchronize all with their cocina objects'
+  task works: :environment do
+    Work.where.not(druid: nil).find_each do |work|
+      cocina_object = Sdr::Repository.find(druid: work.druid)
+      WorkModelSynchronizer.call(work:, cocina_object:, raise: false)
+      puts "Synchronized #{work.druid}"
+    rescue StandardError => e
+      puts "Error synchronizing #{work.druid}: #{e.message}"
+    end
+  end
+end


### PR DESCRIPTION
Basic script used to resynch work data with cocina win necessary.